### PR TITLE
Implement AccessPolicy

### DIFF
--- a/example/erc20/api/src/lib.rs
+++ b/example/erc20/api/src/lib.rs
@@ -4,7 +4,7 @@ use serde_big_array::big_array;
 use rand::Rng;
 use ed25519_dalek::{Keypair, Signature, PublicKey, SignatureError, SIGNATURE_LENGTH, PUBLIC_KEY_LENGTH};
 use frame_common::{
-    crypto::{AccessRight, UserAddress},
+    crypto::{Ed25519ChallengeResponse, AccountId},
     traits::State,
 };
 
@@ -68,11 +68,11 @@ pub mod init_state {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
 
@@ -102,7 +102,7 @@ pub mod transfer {
             pub sig: [u8; SIGNATURE_LENGTH],
             pub pubkey: [u8; PUBLIC_KEY_LENGTH],
             pub challenge: [u8; 32],
-            pub target: UserAddress,
+            pub target: AccountId,
             pub amount: u64,
         }
 
@@ -110,7 +110,7 @@ pub mod transfer {
             pub fn new<R: Rng>(
                 keypair: &Keypair,
                 amount: u64,
-                target: UserAddress,
+                target: AccountId,
                 rng: &mut R,
             ) -> Self {
                 let challenge: [u8; 32] = rng.gen();
@@ -126,11 +126,11 @@ pub mod transfer {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
 
@@ -160,7 +160,7 @@ pub mod approve {
             pub sig: [u8; SIGNATURE_LENGTH],
             pub pubkey: [u8; PUBLIC_KEY_LENGTH],
             pub challenge: [u8; 32],
-            pub target: UserAddress,
+            pub target: AccountId,
             pub amount: u64,
         }
 
@@ -168,7 +168,7 @@ pub mod approve {
             pub fn new<R: Rng>(
                 keypair: &Keypair,
                 amount: u64,
-                target: UserAddress,
+                target: AccountId,
                 rng: &mut R,
             ) -> Self {
                 let challenge: [u8; 32] = rng.gen();
@@ -184,11 +184,11 @@ pub mod approve {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
 
@@ -218,8 +218,8 @@ pub mod transfer_from {
             pub sig: [u8; SIGNATURE_LENGTH],
             pub pubkey: [u8; PUBLIC_KEY_LENGTH],
             pub challenge: [u8; 32],
-            pub owner: UserAddress,
-            pub target: UserAddress,
+            pub owner: AccountId,
+            pub target: AccountId,
             pub amount: u64,
         }
 
@@ -227,8 +227,8 @@ pub mod transfer_from {
             pub fn new<R: Rng>(
                 keypair: &Keypair,
                 amount: u64,
-                owner: UserAddress,
-                target: UserAddress,
+                owner: AccountId,
+                target: AccountId,
                 rng: &mut R,
             ) -> Self {
                 let challenge: [u8; 32] = rng.gen();
@@ -245,11 +245,11 @@ pub mod transfer_from {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
 
@@ -279,7 +279,7 @@ pub mod mint {
             pub sig: [u8; SIGNATURE_LENGTH],
             pub pubkey: [u8; PUBLIC_KEY_LENGTH],
             pub challenge: [u8; 32],
-            pub target: UserAddress,
+            pub target: AccountId,
             pub amount: u64,
         }
 
@@ -287,7 +287,7 @@ pub mod mint {
             pub fn new<R: Rng>(
                 keypair: &Keypair,
                 amount: u64,
-                target: UserAddress,
+                target: AccountId,
                 rng: &mut R,
             ) -> Self {
                 let challenge: [u8; 32] = rng.gen();
@@ -303,11 +303,11 @@ pub mod mint {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
 
@@ -358,11 +358,11 @@ pub mod burn {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
 
@@ -401,13 +401,13 @@ pub mod allowance {
             pub sig: [u8; SIGNATURE_LENGTH],
             pub pubkey: [u8; PUBLIC_KEY_LENGTH],
             pub challenge: [u8; 32],
-            pub spender: UserAddress,
+            pub spender: AccountId,
         }
 
         impl Request {
             pub fn new<R: Rng>(
                 keypair: &Keypair,
-                spender: UserAddress,
+                spender: AccountId,
                 rng: &mut R
             ) -> Self {
                 let challenge: [u8; 32] = rng.gen();
@@ -422,11 +422,11 @@ pub mod allowance {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
 
@@ -474,11 +474,11 @@ pub mod state {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
 
@@ -543,11 +543,11 @@ pub mod register_notification {
                 }
             }
 
-            pub fn into_access_right(&self) -> Result<AccessRight, SignatureError> {
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
                 let sig = Signature::from_bytes(&self.sig)?;
                 let pubkey = PublicKey::from_bytes(&self.pubkey)?;
 
-                Ok(AccessRight::new(sig, pubkey, self.challenge))
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
             }
         }
     }

--- a/example/erc20/enclave/src/ecalls.rs
+++ b/example/erc20/enclave/src/ecalls.rs
@@ -4,6 +4,7 @@ use std::{
 };
 use frame_common::{
     traits::{EcallInput, EcallOutput},
+    crypto::Ed25519ChallengeResponse,
 };
 use config::constants::*;
 use anonify_enclave::{
@@ -21,14 +22,14 @@ register_ecall!(
     MAX_MEM_SIZE,
     Runtime<EnclaveContext>,
     EnclaveContext,
-    (ENCRYPT_INSTRUCTION_CMD, Instruction),
+    (ENCRYPT_INSTRUCTION_CMD, Instruction<Ed25519ChallengeResponse>),
     // Insert a ciphertext in event logs from blockchain nodes into enclave's memory database.
     (INSERT_CIPHERTEXT_CMD, InsertCiphertext),
     // Insert handshake received from blockchain nodes into enclave.
     (INSERT_HANDSHAKE_CMD, InsertHandshake),
     // Get current state of the user represented the given public key from enclave memory database.
-    (GET_STATE_CMD, GetState),
+    (GET_STATE_CMD, GetState<Ed25519ChallengeResponse>),
     (CALL_JOIN_GROUP_CMD, CallJoinGroup),
     (CALL_HANDSHAKE_CMD, CallHandshake),
-    (REGISTER_NOTIFICATION_CMD, RegisterNotification),
+    (REGISTER_NOTIFICATION_CMD, RegisterNotification<Ed25519ChallengeResponse>),
 );

--- a/example/erc20/server/src/handlers.rs
+++ b/example/erc20/server/src/handlers.rs
@@ -76,7 +76,7 @@ pub fn handle_init_state<D, S, W, DB>(
     let total_supply = U64::from_raw(req.total_supply);
     let init_state = construct{ total_supply };
 
-    let receipt = server.dispatcher.send_instruction::<_, CallName>(
+    let receipt = server.dispatcher.send_instruction::<_, CallName, _>(
         access_right,
         init_state,
         "construct",
@@ -103,7 +103,7 @@ pub fn handle_transfer<D, S, W, DB>(
     let recipient = req.target;
     let transfer_state = transfer{ amount, recipient };
 
-    let receipt = server.dispatcher.send_instruction::<_, CallName>(
+    let receipt = server.dispatcher.send_instruction::<_, CallName, _>(
         access_right,
         transfer_state,
         "transfer",
@@ -130,7 +130,7 @@ pub fn handle_approve<D, S, W, DB>(
     let spender = req.target;
     let approve_state = approve { amount, spender };
 
-    let receipt = server.dispatcher.send_instruction::<_, CallName>(
+    let receipt = server.dispatcher.send_instruction::<_, CallName, _>(
         access_right,
         approve_state,
         "approve",
@@ -157,7 +157,7 @@ pub fn handle_mint<D, S, W, DB>(
     let recipient = req.target;
     let minting_state = mint{ amount, recipient };
 
-    let receipt = server.dispatcher.send_instruction::<_, CallName>(
+    let receipt = server.dispatcher.send_instruction::<_, CallName, _>(
         access_right,
         minting_state,
         "mint",
@@ -183,7 +183,7 @@ pub fn handle_burn<D, S, W, DB>(
     let amount = U64::from_raw(req.amount);
     let burn_state = burn{ amount };
 
-    let receipt = server.dispatcher.send_instruction::<_, CallName>(
+    let receipt = server.dispatcher.send_instruction::<_, CallName, _>(
         access_right,
         burn_state,
         "burn",
@@ -211,7 +211,7 @@ pub fn handle_transfer_from<D, S, W, DB>(
     let recipient = req.target;
     let transferred_from_state = transfer_from { owner, recipient, amount };
 
-    let receipt = server.dispatcher.send_instruction::<_, CallName>(
+    let receipt = server.dispatcher.send_instruction::<_, CallName, _>(
         access_right,
         transferred_from_state,
         "transfer_from",
@@ -254,7 +254,7 @@ pub fn handle_allowance<D, S, W, DB>(
     server.dispatcher.block_on_event::<U64>()?;
 
     let access_right = req.into_access_right()?;
-    let owner_approved = get_state::<Approved, MemName>(access_right, server.eid, "Approved")?;
+    let owner_approved = get_state::<Approved, MemName, _>(access_right, server.eid, "Approved")?;
     let approved_amount = owner_approved.allowance(&req.spender).unwrap();
     // TODO: stop using unwrap when switching from failure to anyhow.
 
@@ -275,7 +275,7 @@ pub fn handle_balance_of<D, S, W, DB>(
     server.dispatcher.block_on_event::<U64>()?;
 
     let access_right = req.into_access_right()?;
-    let state = get_state::<U64, MemName>(access_right, server.eid, "Balance")?;
+    let state = get_state::<U64, MemName, _>(access_right, server.eid, "Balance")?;
 
     Ok(HttpResponse::Ok().json(erc20_api::state::get::Response(state.as_raw())))
 }

--- a/example/erc20/state-transition/src/lib.rs
+++ b/example/erc20/state-transition/src/lib.rs
@@ -15,28 +15,28 @@ impl_memory! {
     (0, "Balance", U64),
     (1, "Approved", Approved),
     (2, "TotalSupply", U64),
-    (3, "Owner", UserAddress)
+    (3, "Owner", AccountId)
 }
 
 impl_runtime! {
     #[fn_id=0]
     pub fn construct(
         self,
-        sender: UserAddress,
+        sender: AccountId,
         total_supply: U64
     ) {
-        let owner_address = update!(*OWNER_ADDRESS, "Owner", sender);
+        let owner_account_id = update!(*OWNER_ACCOUNT_ID, "Owner", sender);
         let sender_balance = update!(sender, "Balance", total_supply);
-        let total_supply = update!(*OWNER_ADDRESS, "TotalSupply", total_supply);
+        let total_supply = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply);
 
-        insert![owner_address, sender_balance, total_supply]
+        insert![owner_account_id, sender_balance, total_supply]
     }
 
     #[fn_id=1]
     pub fn transfer(
         self,
-        sender: UserAddress,
-        recipient: UserAddress,
+        sender: AccountId,
+        recipient: AccountId,
         amount: U64
     ) {
         let sender_balance = self.get_map::<U64>(sender, "Balance")?;
@@ -53,8 +53,8 @@ impl_runtime! {
     #[fn_id=2]
     pub fn approve(
         self,
-        owner: UserAddress,
-        spender: UserAddress,
+        owner: AccountId,
+        spender: AccountId,
         amount: U64
     ) {
         let owner_balance = self.get_map::<U64>(owner, "Balance")?;
@@ -73,9 +73,9 @@ impl_runtime! {
     #[fn_id=3]
     pub fn transfer_from(
         self,
-        sender: UserAddress,
-        owner: UserAddress,
-        recipient: UserAddress,
+        sender: AccountId,
+        owner: AccountId,
+        recipient: AccountId,
         amount: U64
     ) {
         let owner_balance = self.get_map::<U64>(owner, "Balance")?;
@@ -106,18 +106,18 @@ impl_runtime! {
     #[fn_id=4]
     pub fn mint(
         self,
-        executer: UserAddress,
-        recipient: UserAddress,
+        executer: AccountId,
+        recipient: AccountId,
         amount: U64
     ) {
-        let owner_address = self.get_map::<UserAddress>(*OWNER_ADDRESS, "Owner")?;
-        ensure!(executer == owner_address, "only owner can mint");
+        let owner_account_id = self.get_map::<AccountId>(*OWNER_ACCOUNT_ID, "Owner")?;
+        ensure!(executer == owner_account_id, "only owner can mint");
 
         let recipient_balance = self.get_map::<U64>(recipient, "Balance")?;
         let recipient_balance_update = update!(recipient, "Balance", recipient_balance + amount);
 
-        let total_supply = self.get_map::<U64>(*OWNER_ADDRESS, "TotalSupply")?;
-        let total_supply_update = update!(*OWNER_ADDRESS, "TotalSupply", total_supply + amount);
+        let total_supply = self.get_map::<U64>(*OWNER_ACCOUNT_ID, "TotalSupply")?;
+        let total_supply_update = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply + amount);
 
         insert![recipient_balance_update, total_supply_update]
     }
@@ -125,15 +125,15 @@ impl_runtime! {
     #[fn_id=5]
     pub fn burn(
         self,
-        sender: UserAddress,
+        sender: AccountId,
         amount: U64
     ) {
         let balance = self.get_map::<U64>(sender, "Balance")?;
         ensure!(balance >= amount, "not enough balance to burn");
         let balance_update = update!(sender, "Balance", balance - amount);
 
-        let total_supply = self.get_map::<U64>(*OWNER_ADDRESS, "TotalSupply")?;
-        let total_supply_update = update!(*OWNER_ADDRESS, "TotalSupply", total_supply - amount);
+        let total_supply = self.get_map::<U64>(*OWNER_ACCOUNT_ID, "TotalSupply")?;
+        let total_supply_update = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply - amount);
 
         insert![balance_update, total_supply_update]
     }

--- a/example/invoice-flow/enclave/src/ecalls.rs
+++ b/example/invoice-flow/enclave/src/ecalls.rs
@@ -2,7 +2,10 @@ use std::{
     vec::Vec,
     ptr,
 };
-use frame_common::traits::{EcallInput, EcallOutput};
+use frame_common::{
+    traits::{EcallInput, EcallOutput},
+    crypto::Ed25519ChallengeResponse,
+};
 use anonify_enclave::{
     context::EnclaveContext,
     workflow::*,
@@ -19,14 +22,14 @@ register_ecall!(
     MAX_MEM_SIZE,
     Runtime<EnclaveContext>,
     EnclaveContext,
-    (ENCRYPT_INSTRUCTION_CMD, Instruction),
+    (ENCRYPT_INSTRUCTION_CMD, Instruction<Ed25519ChallengeResponse>),
     // Insert a ciphertext in event logs from blockchain nodes into enclave's memory database.
     (INSERT_CIPHERTEXT_CMD, InsertCiphertext),
     // Insert handshake received from blockchain nodes into enclave.
     (INSERT_HANDSHAKE_CMD, InsertHandshake),
     // Get current state of the user represented the given public key from enclave memory database.
-    (GET_STATE_CMD, GetState),
+    (GET_STATE_CMD, GetState<Ed25519ChallengeResponse>),
     (CALL_JOIN_GROUP_CMD, CallJoinGroup),
     (CALL_HANDSHAKE_CMD, CallHandshake),
-    (REGISTER_NOTIFICATION_CMD, RegisterNotification),
+    (REGISTER_NOTIFICATION_CMD, RegisterNotification<Ed25519ChallengeResponse>),
 );

--- a/example/invoice-flow/state-transition/src/lib.rs
+++ b/example/invoice-flow/state-transition/src/lib.rs
@@ -19,8 +19,8 @@ impl_runtime! {
     #[fn_id=0]
     pub fn send_invoice(
         self,
-        _sender: UserAddress,
-        recipient: UserAddress,
+        _sender: AccountId,
+        recipient: AccountId,
         invoice: Bytes
     ) {
         let invoice_update = update!(recipient, "Invoice", invoice);

--- a/frame/common/src/crypto.rs
+++ b/frame/common/src/crypto.rs
@@ -32,7 +32,7 @@ lazy_static! {
         Ed25519ChallengeResponse::new(sig, keypair.public, COMMON_CHALLENGE)
     };
 
-    pub static ref OWNER_ACCOUNT_ID: AccountID = {
+    pub static ref OWNER_ACCOUNT_ID: AccountId = {
         COMMON_ACCESS_RIGHT.account_id()
     };
 }
@@ -41,25 +41,25 @@ lazy_static! {
 /// A signature verification must return true to generate a user account_id.
 #[derive(Encode, Decode, Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(crate = "crate::serde")]
-pub struct AccountID([u8; ACCOUNT_ID_SIZE]);
+pub struct AccountId([u8; ACCOUNT_ID_SIZE]);
 
 #[cfg(feature = "std")]
-impl From<AccountID> for web3::types::Address {
-    fn from(account_id: AccountID) -> Self {
+impl From<AccountId> for web3::types::Address {
+    fn from(account_id: AccountId) -> Self {
         let bytes = account_id.as_bytes();
         web3::types::Address::from_slice(bytes)
     }
 }
 
 #[cfg(feature = "std")]
-impl From<&AccountID> for web3::types::Address {
-    fn from(account_id: &AccountID) -> Self {
+impl From<&AccountId> for web3::types::Address {
+    fn from(account_id: &AccountId) -> Self {
         let bytes = account_id.as_bytes();
         web3::types::Address::from_slice(bytes)
     }
 }
 
-impl From<&str> for AccountID {
+impl From<&str> for AccountId {
     fn from(s: &str) -> Self {
         let mut res = [0u8; ACCOUNT_ID_SIZE];
         res.copy_from_slice(&s.as_bytes()[..ACCOUNT_ID_SIZE]);
@@ -68,7 +68,7 @@ impl From<&str> for AccountID {
     }
 }
 
-impl From<String> for AccountID {
+impl From<String> for AccountId {
     fn from(s: String) -> Self {
         let mut res = [0u8; ACCOUNT_ID_SIZE];
         res.copy_from_slice(&s.as_bytes()[..ACCOUNT_ID_SIZE]);
@@ -77,7 +77,7 @@ impl From<String> for AccountID {
     }
 }
 
-impl TryFrom<Vec<u8>> for AccountID {
+impl TryFrom<Vec<u8>> for AccountId {
     type Error = Error;
 
     fn try_from(s: Vec<u8>) -> Result<Self, Self::Error> {
@@ -91,7 +91,7 @@ impl TryFrom<Vec<u8>> for AccountID {
     }
 }
 
-impl AccountID {
+impl AccountId {
     /// Get a user account_id only if the verification of signature returns true.
     pub fn from_sig(msg: &[u8], sig: &Signature, pubkey: &PublicKey) -> Result<Self, Error> {
         pubkey.verify(msg, &sig)
@@ -111,11 +111,11 @@ impl AccountID {
 
     pub fn from_pubkey(pubkey: &PublicKey) -> Self {
         let hash = Sha256::from_pubkey(pubkey);
-        let addr = &hash.as_array()[12..];
+        let account_id = &hash.as_array()[12..];
         let mut res = [0u8; ACCOUNT_ID_SIZE];
-        res.copy_from_slice(addr);
+        res.copy_from_slice(account_id);
 
-        AccountID(res)
+        AccountId(res)
     }
 
     pub fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
@@ -126,7 +126,7 @@ impl AccountID {
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
         let mut res = [0u8; ACCOUNT_ID_SIZE];
         reader.read_exact(&mut res)?;
-        Ok(AccountID(res))
+        Ok(AccountId(res))
     }
 
     #[cfg(feature = "std")]
@@ -142,7 +142,7 @@ impl AccountID {
         let mut arr = [0u8; ACCOUNT_ID_SIZE];
         arr.copy_from_slice(&decoded_vec[..]);
 
-        AccountID::from_array(arr)
+        AccountId::from_array(arr)
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -150,7 +150,7 @@ impl AccountID {
     }
 
     pub fn from_array(array: [u8; ACCOUNT_ID_SIZE]) -> Self {
-        AccountID(array)
+        AccountId(array)
     }
 
     pub fn into_array(self) -> [u8; ACCOUNT_ID_SIZE] {
@@ -216,7 +216,7 @@ pub struct Ed25519ChallengeResponse {
 }
 
 impl AccessPolicy for Ed25519ChallengeResponse {
-    fn verify(&self) -> Result<()> {
+    fn verify(&self) -> Result<(), Error> {
         self.verify_sig()
     }
 
@@ -317,13 +317,13 @@ impl Ed25519ChallengeResponse {
         Ok(())
     }
 
-    pub fn account_id(&self) -> AccountID {
-        AccountID::from_pubkey(&self.pubkey())
+    pub fn account_id(&self) -> AccountId {
+        AccountId::from_pubkey(&self.pubkey())
     }
 
-    pub fn verified_account_id(&self) -> Result<AccountID, Error> {
+    pub fn verified_account_id(&self) -> Result<AccountId, Error> {
         self.verify_sig()?;
-        Ok(AccountID::from_pubkey(&self.pubkey()))
+        Ok(AccountId::from_pubkey(&self.pubkey()))
     }
 
     pub fn sig(&self) -> &Signature {

--- a/frame/common/src/crypto.rs
+++ b/frame/common/src/crypto.rs
@@ -21,7 +21,7 @@ pub const COMMON_SECRET: [u8; SECRET_KEY_LENGTH] = [182, 93, 72, 157, 114, 225, 
 pub const COMMON_CHALLENGE: [u8; CHALLENGE_SIZE] = [39, 79, 228, 49, 240, 219, 135, 53, 169, 47, 65, 111, 236, 125, 2, 195, 214, 154, 18, 77, 254, 135, 35, 77, 36, 45, 164, 254, 64, 8, 169, 238];
 
 lazy_static! {
-    pub static ref COMMON_ACCESS_RIGHT: Ed25519ChallengeResponse = {
+    pub static ref COMMON_ACCESS_POLICY: Ed25519ChallengeResponse = {
         let secret = SecretKey::from_bytes(&COMMON_SECRET).unwrap();
         let pubkey = PublicKey::from(&secret);
         let keypair = Keypair { secret, public: pubkey };
@@ -33,7 +33,7 @@ lazy_static! {
     };
 
     pub static ref OWNER_ACCOUNT_ID: AccountId = {
-        COMMON_ACCESS_RIGHT.account_id()
+        COMMON_ACCESS_POLICY.account_id()
     };
 }
 

--- a/frame/common/src/crypto.rs
+++ b/frame/common/src/crypto.rs
@@ -6,7 +6,7 @@ use crate::localstd::{
 };
 use crate::serde::{Serialize, Deserialize};
 use crate::local_anyhow::{anyhow, Error};
-use crate::traits::{IntoVec, Hash256};
+use crate::traits::{IntoVec, Hash256, AccessPolicy};
 use ed25519_dalek::{Keypair, SecretKey, PublicKey, Signature, SECRET_KEY_LENGTH, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
 use codec::{Encode, Decode, Input, self};
 #[cfg(feature = "std")]
@@ -16,12 +16,12 @@ use rand_core::{RngCore, CryptoRng};
 #[cfg(feature = "std")]
 use rand_os::OsRng;
 
-const ADDRESS_SIZE: usize = 20;
+const ACCOUNT_ID_SIZE: usize = 20;
 pub const COMMON_SECRET: [u8; SECRET_KEY_LENGTH] = [182, 93, 72, 157, 114, 225, 213, 95, 237, 176, 179, 23, 11, 100, 177, 16, 129, 8, 41, 4, 158, 209, 227, 21, 89, 47, 118, 0, 232, 162, 217, 203];
 pub const COMMON_CHALLENGE: [u8; CHALLENGE_SIZE] = [39, 79, 228, 49, 240, 219, 135, 53, 169, 47, 65, 111, 236, 125, 2, 195, 214, 154, 18, 77, 254, 135, 35, 77, 36, 45, 164, 254, 64, 8, 169, 238];
 
 lazy_static! {
-    pub static ref COMMON_ACCESS_RIGHT: AccessRight = {
+    pub static ref COMMON_ACCESS_RIGHT: Ed25519ChallengeResponse = {
         let secret = SecretKey::from_bytes(&COMMON_SECRET).unwrap();
         let pubkey = PublicKey::from(&secret);
         let keypair = Keypair { secret, public: pubkey };
@@ -29,70 +29,70 @@ lazy_static! {
         let sig = keypair.sign(&COMMON_CHALLENGE);
 
         assert!(keypair.verify(&COMMON_CHALLENGE, &sig).is_ok());
-        AccessRight::new(sig, keypair.public, COMMON_CHALLENGE)
+        Ed25519ChallengeResponse::new(sig, keypair.public, COMMON_CHALLENGE)
     };
 
-    pub static ref OWNER_ADDRESS: UserAddress = {
-        COMMON_ACCESS_RIGHT.user_address()
+    pub static ref OWNER_ACCOUNT_ID: AccountID = {
+        COMMON_ACCESS_RIGHT.account_id()
     };
 }
 
-/// User address represents last 20 bytes of digest of user's public key.
-/// A signature verification must return true to generate a user address.
+/// User account_id represents last 20 bytes of digest of user's public key.
+/// A signature verification must return true to generate a user account_id.
 #[derive(Encode, Decode, Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(crate = "crate::serde")]
-pub struct UserAddress([u8; ADDRESS_SIZE]);
+pub struct AccountID([u8; ACCOUNT_ID_SIZE]);
 
 #[cfg(feature = "std")]
-impl From<UserAddress> for web3::types::Address {
-    fn from(address: UserAddress) -> Self {
-        let bytes = address.as_bytes();
+impl From<AccountID> for web3::types::Address {
+    fn from(account_id: AccountID) -> Self {
+        let bytes = account_id.as_bytes();
         web3::types::Address::from_slice(bytes)
     }
 }
 
 #[cfg(feature = "std")]
-impl From<&UserAddress> for web3::types::Address {
-    fn from(address: &UserAddress) -> Self {
-        let bytes = address.as_bytes();
+impl From<&AccountID> for web3::types::Address {
+    fn from(account_id: &AccountID) -> Self {
+        let bytes = account_id.as_bytes();
         web3::types::Address::from_slice(bytes)
     }
 }
 
-impl From<&str> for UserAddress {
+impl From<&str> for AccountID {
     fn from(s: &str) -> Self {
-        let mut res = [0u8; ADDRESS_SIZE];
-        res.copy_from_slice(&s.as_bytes()[..ADDRESS_SIZE]);
+        let mut res = [0u8; ACCOUNT_ID_SIZE];
+        res.copy_from_slice(&s.as_bytes()[..ACCOUNT_ID_SIZE]);
 
         Self::from_array(res)
     }
 }
 
-impl From<String> for UserAddress {
+impl From<String> for AccountID {
     fn from(s: String) -> Self {
-        let mut res = [0u8; ADDRESS_SIZE];
-        res.copy_from_slice(&s.as_bytes()[..ADDRESS_SIZE]);
+        let mut res = [0u8; ACCOUNT_ID_SIZE];
+        res.copy_from_slice(&s.as_bytes()[..ACCOUNT_ID_SIZE]);
 
         Self::from_array(res)
     }
 }
 
-impl TryFrom<Vec<u8>> for UserAddress {
+impl TryFrom<Vec<u8>> for AccountID {
     type Error = Error;
 
     fn try_from(s: Vec<u8>) -> Result<Self, Self::Error> {
-        if s.len() < ADDRESS_SIZE {
-            return Err(anyhow!("source length must be {}", ADDRESS_SIZE));
+        if s.len() < ACCOUNT_ID_SIZE {
+            return Err(anyhow!("source length must be {}", ACCOUNT_ID_SIZE));
         }
 
-        let mut res = [0u8; ADDRESS_SIZE];
-        res.copy_from_slice(&s.as_slice()[..ADDRESS_SIZE]);
+        let mut res = [0u8; ACCOUNT_ID_SIZE];
+        res.copy_from_slice(&s.as_slice()[..ACCOUNT_ID_SIZE]);
         Ok(Self::from_array(res))
     }
 }
 
-impl UserAddress {
-    /// Get a user address only if the verification of signature returns true.
+impl AccountID {
+    /// Get a user account_id only if the verification of signature returns true.
     pub fn from_sig(msg: &[u8], sig: &Signature, pubkey: &PublicKey) -> Result<Self, Error> {
         pubkey.verify(msg, &sig)
             .map_err(|e| anyhow!("{}", e))?;
@@ -100,22 +100,22 @@ impl UserAddress {
         Ok(Self::from_pubkey(&pubkey))
     }
 
-    pub fn try_from_access_right(access_right: &AccessRight) -> Result<Self, Error> {
-        access_right.verify_sig()?;
-        Ok(Self::from_pubkey(access_right.pubkey()))
+    pub fn try_from_access_policy<AP: AccessPolicy>(access_policy: &AP) -> Result<Self, Error> {
+        access_policy.verify()?;
+        Ok(access_policy.into_account_id())
     }
 
-    pub fn from_access_right(access_right: &AccessRight) -> Self {
-        Self::from_pubkey(access_right.pubkey())
+    pub fn from_access_policy<AP: AccessPolicy>(access_policy: &AP) -> Self {
+        access_policy.into_account_id()
     }
 
     pub fn from_pubkey(pubkey: &PublicKey) -> Self {
         let hash = Sha256::from_pubkey(pubkey);
         let addr = &hash.as_array()[12..];
-        let mut res = [0u8; ADDRESS_SIZE];
+        let mut res = [0u8; ACCOUNT_ID_SIZE];
         res.copy_from_slice(addr);
 
-        UserAddress(res)
+        AccountID(res)
     }
 
     pub fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
@@ -124,9 +124,9 @@ impl UserAddress {
     }
 
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
-        let mut res = [0u8; ADDRESS_SIZE];
+        let mut res = [0u8; ACCOUNT_ID_SIZE];
         reader.read_exact(&mut res)?;
-        Ok(UserAddress(res))
+        Ok(AccountID(res))
     }
 
     #[cfg(feature = "std")]
@@ -137,23 +137,23 @@ impl UserAddress {
     #[cfg(feature = "std")]
     pub fn base64_decode(encoded_str: &str) -> Self {
         let decoded_vec = base64::decode(encoded_str).expect("Failed to decode base64.");
-        assert_eq!(decoded_vec.len(), ADDRESS_SIZE);
+        assert_eq!(decoded_vec.len(), ACCOUNT_ID_SIZE);
 
-        let mut arr = [0u8; ADDRESS_SIZE];
+        let mut arr = [0u8; ACCOUNT_ID_SIZE];
         arr.copy_from_slice(&decoded_vec[..]);
 
-        UserAddress::from_array(arr)
+        AccountID::from_array(arr)
     }
 
     pub fn as_bytes(&self) -> &[u8] {
         &self.0[..]
     }
 
-    pub fn from_array(array: [u8; ADDRESS_SIZE]) -> Self {
-        UserAddress(array)
+    pub fn from_array(array: [u8; ACCOUNT_ID_SIZE]) -> Self {
+        AccountID(array)
     }
 
-    pub fn into_array(self) -> [u8; ADDRESS_SIZE] {
+    pub fn into_array(self) -> [u8; ACCOUNT_ID_SIZE] {
         self.0
     }
 }
@@ -207,15 +207,25 @@ impl Sha256 {
 
 const CHALLENGE_SIZE: usize = 32;
 
-/// Access right of Read/Write to anonify's enclave mem db.
+/// A challenge and response authentication parameter to read and write to anonify's enclave mem db.
 #[derive(Debug, Clone)]
-pub struct AccessRight {
+pub struct Ed25519ChallengeResponse {
     sig: Signature,
     pubkey: PublicKey,
     challenge: [u8; CHALLENGE_SIZE],
 }
 
-impl Encode for AccessRight {
+impl AccessPolicy for Ed25519ChallengeResponse {
+    fn verify(&self) -> Result<()> {
+        self.verify_sig()
+    }
+
+    fn into_account_id(&self) -> AccountId {
+        AccountId::from_pubkey(&self.pubkey())
+    }
+}
+
+impl Encode for Ed25519ChallengeResponse {
     fn encode(&self) -> Vec<u8> {
         let mut acc = vec![];
         acc.extend_from_slice(&self.sig.to_bytes());
@@ -226,7 +236,7 @@ impl Encode for AccessRight {
     }
 }
 
-impl Decode for AccessRight {
+impl Decode for Ed25519ChallengeResponse {
     fn decode<I: Input>(value: &mut I) -> Result<Self, codec::Error> {
         let mut sig_buf = [0u8; SIGNATURE_LENGTH];
         let mut pubkey_buf = [0u8; PUBLIC_KEY_LENGTH];
@@ -237,11 +247,11 @@ impl Decode for AccessRight {
         value.read(&mut chal_buf)?;
 
         let sig = Signature::from_bytes(&sig_buf)
-            .expect("Failed to decode sig of AccessRight");
+            .expect("Failed to decode sig of Ed25519ChallengeResponse");
         let pubkey = PublicKey::from_bytes(&pubkey_buf)
-            .expect("Failed to decode pubkey of AccessRight");
+            .expect("Failed to decode pubkey of Ed25519ChallengeResponse");
 
-        Ok(AccessRight{
+        Ok(Ed25519ChallengeResponse{
             sig,
             pubkey,
             challenge: chal_buf,
@@ -249,7 +259,7 @@ impl Decode for AccessRight {
     }
 }
 
-impl AccessRight {
+impl Ed25519ChallengeResponse {
     #[cfg(feature = "std")]
     fn inner_new_from_rng<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let keypair = Keypair::generate(rng);
@@ -293,7 +303,7 @@ impl AccessRight {
     ) -> Self {
         assert!(pubkey.verify(&challenge, &sig).is_ok());
 
-        AccessRight {
+        Ed25519ChallengeResponse {
             sig,
             pubkey,
             challenge,
@@ -307,13 +317,13 @@ impl AccessRight {
         Ok(())
     }
 
-    pub fn user_address(&self) -> UserAddress {
-        UserAddress::from_pubkey(&self.pubkey())
+    pub fn account_id(&self) -> AccountID {
+        AccountID::from_pubkey(&self.pubkey())
     }
 
-    pub fn verified_user_address(&self) -> Result<UserAddress, Error> {
+    pub fn verified_account_id(&self) -> Result<AccountID, Error> {
         self.verify_sig()?;
-        Ok(UserAddress::from_pubkey(&self.pubkey()))
+        Ok(AccountID::from_pubkey(&self.pubkey()))
     }
 
     pub fn sig(&self) -> &Signature {

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -1,7 +1,7 @@
 use crate::traits::State;
 use crate::localstd::vec::Vec;
 use crate::local_anyhow::{Result, anyhow};
-use crate::crypto::UserAddress;
+use crate::crypto::AccountId;
 use codec::{Encode, Decode};
 
 pub trait RawState: Encode + Decode + Clone + Default {}
@@ -38,27 +38,27 @@ impl StateType {
     }
 }
 
-impl From<UserAddress> for StateType {
-    fn from(address: UserAddress) -> Self {
-        Self(address.encode_s().into())
+impl From<AccountId> for StateType {
+    fn from(account_id: AccountId) -> Self {
+        Self(account_id.encode_s().into())
     }
 }
 
 #[derive(Debug, Clone, Default, Encode, Decode)]
 pub struct UpdatedState<S: State> {
-    pub address: UserAddress,
+    pub account_id: AccountId,
     pub mem_id: MemId,
     pub state: S,
 }
 
 impl<S: State> UpdatedState<S> {
     pub fn new(
-        address: impl Into<UserAddress>,
+        account_id: impl Into<AccountId>,
         mem_id: MemId,
         state: impl Into<S>,
     ) -> Result<Self> {
         Ok(UpdatedState {
-            address: address.into(),
+            account_id: account_id.into(),
             mem_id,
             state: state.into(),
         })
@@ -69,7 +69,7 @@ impl<S: State> UpdatedState<S> {
             .map_err(|e| anyhow!("{:?}", e))?;
 
         Ok(UpdatedState {
-            address: update.address,
+            account_id: update.account_id,
             mem_id: update.mem_id,
             state,
         })

--- a/frame/common/src/traits.rs
+++ b/frame/common/src/traits.rs
@@ -5,7 +5,7 @@ use crate::localstd::{
 };
 use crate::state_types::MemId;
 use crate::local_anyhow::{Result, anyhow};
-use crate::crypto::AccountID;
+use crate::crypto::AccountId;
 use codec::{Encode, Decode};
 use ed25519_dalek::PublicKey;
 use tiny_keccak::Keccak;

--- a/frame/common/src/traits.rs
+++ b/frame/common/src/traits.rs
@@ -5,9 +5,17 @@ use crate::localstd::{
 };
 use crate::state_types::MemId;
 use crate::local_anyhow::{Result, anyhow};
+use crate::crypto::AccountID;
 use codec::{Encode, Decode};
 use ed25519_dalek::PublicKey;
 use tiny_keccak::Keccak;
+
+/// A trait to verify policy to access resources in the enclave
+pub trait AccessPolicy: Encode + Decode + Clone + Debug {
+    fn verify(&self) -> Result<()>;
+
+    fn into_account_id(&self) -> AccountId;
+}
 
 pub trait EcallInput {}
 pub trait EcallOutput {}

--- a/frame/runtime/src/impls.rs
+++ b/frame/runtime/src/impls.rs
@@ -62,7 +62,7 @@ macro_rules! __impl_inner_runtime {
             #[fn_id=$fn_id:expr]
             pub fn $fn_name:ident(
                 $runtime:ident,
-                $sender:ident : $address:ty
+                $sender:ident : $account_id:ty
                 $(, $param_name:ident : $param:ty )*
             ) {
                 $( $impl:tt )*
@@ -110,11 +110,11 @@ macro_rules! __impl_inner_runtime {
                 }
             }
 
-            fn execute(self, runtime: Self::R, my_addr: UserAddress) -> Result<Vec<UpdatedState<Self::S>>> {
+            fn execute(self, runtime: Self::R, my_account_id: AccountId) -> Result<Vec<UpdatedState<Self::S>>> {
                 match self {
                     $( CallKind::$fn_name($fn_name) => {
                         runtime.$fn_name(
-                            my_addr,
+                            my_account_id,
                             $( $fn_name.$param_name, )*
                         )
                     }, )*
@@ -139,8 +139,8 @@ macro_rules! __impl_inner_runtime {
                 }
             }
 
-            fn execute(self, kind: Self::C, my_addr: UserAddress) -> Result<Vec<UpdatedState<Self::S>>> {
-                kind.execute(self, my_addr)
+            fn execute(self, kind: Self::C, my_account_id: AccountId) -> Result<Vec<UpdatedState<Self::S>>> {
+                kind.execute(self, my_account_id)
             }
         }
 
@@ -148,7 +148,7 @@ macro_rules! __impl_inner_runtime {
         impl<G: ContextOps<S=StateType>> Runtime<G> {
             pub fn get_map<S: State>(
                 &self,
-                key: UserAddress,
+                key: AccountId,
                 name: &str
             ) -> Result<S> {
                 let mem_id = MemName::as_id(name);
@@ -168,7 +168,7 @@ macro_rules! __impl_inner_runtime {
             $(
                 pub fn $fn_name (
                     $runtime,
-                    $sender: $address
+                    $sender: $account_id
                     $(, $param_name : $param )*
                 ) -> Result<Vec<UpdatedState<StateType>>> {
                     $( $impl )*
@@ -180,8 +180,8 @@ macro_rules! __impl_inner_runtime {
 
 #[macro_export]
 macro_rules! update {
-    ($addr:expr, $mem_name:expr, $value:expr) => {
-        UpdatedState::new($addr, MemName::as_id($mem_name), $value)?
+    ($account_id:expr, $mem_name:expr, $value:expr) => {
+        UpdatedState::new($account_id, MemName::as_id($mem_name), $value)?
     };
 
     ($mem_name:expr, $value:expr) => {

--- a/frame/runtime/src/prelude.rs
+++ b/frame/runtime/src/prelude.rs
@@ -2,7 +2,7 @@ pub use crate::{impl_memory, __impl_inner_memory, impl_runtime, __impl_inner_run
 pub use frame_common::{
     traits::*,
     state_types::*,
-    crypto::{UserAddress, OWNER_ADDRESS},
+    crypto::{AccountId, OWNER_ACCOUNT_ID},
 };
 pub use codec::{Encode, Decode};
 pub use crate::local_anyhow::{ensure, Result, anyhow};

--- a/frame/runtime/src/primitives.rs
+++ b/frame/runtime/src/primitives.rs
@@ -7,7 +7,7 @@ use crate::localstd::{
 };
 use crate::local_anyhow::{Result, Error, anyhow};
 use frame_common::{
-    crypto::UserAddress,
+    crypto::AccountId,
     traits::State,
     state_types::StateType,
 };
@@ -145,10 +145,10 @@ impl From<Bytes> for StateType {
 }
 
 #[derive(Encode, Decode, Clone, Debug, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct Approved(BTreeMap<UserAddress, U64>);
+pub struct Approved(BTreeMap<AccountId, U64>);
 
 impl Approved {
-    pub fn new(inner: BTreeMap<UserAddress, U64>) -> Self {
+    pub fn new(inner: BTreeMap<AccountId, U64>) -> Self {
         Approved(inner)
     }
 
@@ -158,40 +158,40 @@ impl Approved {
         sum
     }
 
-    pub fn approve(&mut self, user_address: UserAddress, amount: U64) {
-        match self.allowance(&user_address) {
+    pub fn approve(&mut self, account_id: AccountId, amount: U64) {
+        match self.allowance(&account_id) {
             Some(&existing_amount) => {
-                self.0.insert(user_address, existing_amount + amount);
+                self.0.insert(account_id, existing_amount + amount);
             }
             None => {
-                self.0.insert(user_address, amount);
+                self.0.insert(account_id, amount);
             }
         }
     }
 
-    pub fn consume(&mut self, user_address: UserAddress, amount: U64) -> Result<(), Error> {
-        match self.allowance(&user_address) {
+    pub fn consume(&mut self, account_id: AccountId, amount: U64) -> Result<(), Error> {
+        match self.allowance(&account_id) {
             Some(&existing_amount) => {
                 if existing_amount < amount {
                     return Err(anyhow!(
                     "{:?} doesn't have enough balance to consume {:?}.",
-                     user_address,
+                     account_id,
                      amount,
                      ).into());
                 }
-                self.0.insert(user_address, existing_amount - amount);
+                self.0.insert(account_id, existing_amount - amount);
                 Ok(())
             }
-            None => return Err(anyhow!("{:?} doesn't have any balance.", user_address).into())
+            None => return Err(anyhow!("{:?} doesn't have any balance.", account_id).into())
         }
     }
 
-    pub fn allowance(&self, user_address: &UserAddress) -> Option<&U64> {
-        self.0.get(user_address)
+    pub fn allowance(&self, account_id: &AccountId) -> Option<&U64> {
+        self.0.get(account_id)
     }
 
     pub fn size(&self) -> usize {
-        self.0.len() * (UserAddress::default().size() + U64::default().size())
+        self.0.len() * (AccountId::default().size() + U64::default().size())
     }
 }
 

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -7,7 +7,7 @@ use crate::localstd::{
     string::String,
 };
 use frame_common::{
-    crypto::{UserAddress, Ciphertext},
+    crypto::{AccountId, Ciphertext},
     traits::*,
     state_types::{UpdatedState, MemId},
 };
@@ -20,7 +20,7 @@ pub trait RuntimeExecutor<G: ContextOps>: Sized {
     type S: State;
 
     fn new(db: G) -> Self;
-    fn execute(self, kind: Self::C, my_addr: UserAddress) -> Result<Vec<UpdatedState<Self::S>>>;
+    fn execute(self, kind: Self::C, my_account_id: AccountId) -> Result<Vec<UpdatedState<Self::S>>>;
 }
 
 /// Execute state transition functions from call kind
@@ -29,7 +29,7 @@ pub trait CallKindExecutor<G: ContextOps>: Sized + Encode + Decode + Debug + Clo
     type S: State;
 
     fn new(id: u32, state: &mut [u8]) -> Result<Self>;
-    fn execute(self, runtime: Self::R, my_addr: UserAddress) -> Result<Vec<UpdatedState<Self::S>>>;
+    fn execute(self, runtime: Self::R, my_account_id: AccountId) -> Result<Vec<UpdatedState<Self::S>>>;
 }
 
 impl<T: StateOps + GroupKeyGetter + NotificationOps + Signer + QuoteGetter> ContextOps for T {}
@@ -44,9 +44,9 @@ pub trait StateOps {
     /// Assumed this is called in user-defined state transition functions.
     fn get_state<U>(&self, key: U, mem_id: MemId) -> Self::S
     where
-        U: Into<UserAddress>;
+        U: Into<AccountId>;
 
-    /// Returns a updated state of registered address in notification.
+    /// Returns a updated state of registered account_id in notification.
     fn update_state(
         &self,
         state_iter: impl Iterator<Item=UpdatedState<Self::S>> + Clone
@@ -62,9 +62,9 @@ pub trait GroupKeyGetter {
 }
 
 pub trait NotificationOps {
-    fn set_notification(&self, address: UserAddress) -> bool;
+    fn set_notification(&self, account_id: AccountId) -> bool;
 
-    fn is_notified(&self, address: &UserAddress) -> bool;
+    fn is_notified(&self, account_id: &AccountId) -> bool;
 }
 
 pub trait Signer {

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -5,7 +5,7 @@ use std::{
 use sgx_types::*;
 use std::prelude::v1::*;
 use frame_common::{
-    crypto::UserAddress,
+    crypto::AccountId,
     traits::*,
     state_types::{MemId, UpdatedState, StateType},
 };
@@ -29,20 +29,20 @@ impl StateOps for EnclaveContext {
 
     fn get_state<U>(&self, key: U, mem_id: MemId) -> Self::S
     where
-        U: Into<UserAddress>,
+        U: Into<AccountId>,
     {
         self.db
             .get(key.into(), mem_id)
     }
 
-    /// Returns a updated state of registerd address in notification.
+    /// Returns a updated state of registerd account_id in notification.
     // TODO: Enables to return multiple updated states.
     fn update_state(
         &self,
         mut state_iter: impl Iterator<Item=UpdatedState<Self::S>> + Clone
     ) -> Option<UpdatedState<Self::S>> {
         state_iter.clone().for_each(|s| self.db.insert_by_updated_state(s));
-        state_iter.find(|s| self.is_notified(&s.address))
+        state_iter.find(|s| self.is_notified(&s.account_id))
     }
 }
 
@@ -59,12 +59,12 @@ impl GroupKeyGetter for EnclaveContext {
 }
 
 impl NotificationOps for EnclaveContext {
-    fn set_notification(&self, address: UserAddress) -> bool {
-        self.notifier.register(address)
+    fn set_notification(&self, account_id: AccountId) -> bool {
+        self.notifier.register(account_id)
     }
 
-    fn is_notified(&self, address: &UserAddress) -> bool {
-        self.notifier.contains(&address)
+    fn is_notified(&self, account_id: &AccountId) -> bool {
+        self.notifier.contains(&account_id)
     }
 }
 

--- a/modules/anonify-enclave/src/crypto.rs
+++ b/modules/anonify-enclave/src/crypto.rs
@@ -80,10 +80,10 @@ impl EnclaveIdentityKey {
 
     fn verifying_key_into_array(&self) -> [u8; HASHED_PUBKEY_SIZE] {
         let pubkey = &self.verifying_key().serialize();
-        let address = &pubkey.keccak256()[12..];
-        assert_eq!(address.len(), HASHED_PUBKEY_SIZE);
+        let account_id = &pubkey.keccak256()[12..];
+        assert_eq!(account_id.len(), HASHED_PUBKEY_SIZE);
         let mut res = [0u8; HASHED_PUBKEY_SIZE];
-        res.copy_from_slice(address);
+        res.copy_from_slice(account_id);
         res
     }
 

--- a/modules/anonify-enclave/src/notify.rs
+++ b/modules/anonify-enclave/src/notify.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{SgxRwLock, Arc},
 };
 use frame_common::{
-    crypto::UserAddress,
+    crypto::AccountId,
     traits::State,
     state_types::{UpdatedState, StateType},
 };
@@ -13,23 +13,23 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct Notifier {
-    addresses: Arc<SgxRwLock<HashSet<UserAddress>>>,
+    account_ids: Arc<SgxRwLock<HashSet<AccountId>>>,
 }
 
 impl Notifier {
     pub fn new() -> Self {
-        let addresses = HashSet::new();
+        let account_ids = HashSet::new();
         Notifier {
-            addresses: Arc::new(SgxRwLock::new(addresses)),
+            account_ids: Arc::new(SgxRwLock::new(account_ids)),
         }
     }
 
-    pub fn register(&self, address: UserAddress) -> bool {
-        let mut tmp = self.addresses.write().unwrap();
-        tmp.insert(address)
+    pub fn register(&self, account_id: AccountId) -> bool {
+        let mut tmp = self.account_ids.write().unwrap();
+        tmp.insert(account_id)
     }
 
-    pub fn contains(&self, address: &UserAddress) -> bool {
-        self.addresses.read().unwrap().contains(&address)
+    pub fn contains(&self, account_id: &AccountId) -> bool {
+        self.account_ids.read().unwrap().contains(&account_id)
     }
 }

--- a/modules/anonify-enclave/src/workflow.rs
+++ b/modules/anonify-enclave/src/workflow.rs
@@ -46,8 +46,8 @@ impl<AP: AccessPolicy> EnclaveEngine for Instruction<AP> {
         R: RuntimeExecutor<C, S=StateType>,
         C: ContextOps<S=StateType> + Clone,
     {
-        let state = ecall_input.state.as_mut_bytes();
         let account_id = ecall_input.access_policy().into_account_id();
+        let state = ecall_input.state.as_mut_bytes();
 
         let instruction_output = create_instruction_output::<R, C>(
             ecall_input.call_id,

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -126,7 +126,7 @@ impl<D, S, W, DB> Dispatcher<D, S, W, DB>
             AP: AccessPolicy,
     {
         let inner = self.inner.read();
-        let input = host_input::Instruction::<ST, C>::new(
+        let input = host_input::Instruction::<ST, C, AP>::new(
             state, call_name.to_string(), access_policy, signer, gas,
         );
         let eid = inner.deployer.get_enclave_id();

--- a/modules/anonify-eth-driver/src/eth/client.rs
+++ b/modules/anonify-eth-driver/src/eth/client.rs
@@ -6,7 +6,6 @@ use sgx_types::sgx_enclave_id_t;
 use anonify_io_types::*;
 use frame_common::{
     traits::*,
-    crypto::AccessRight,
     state_types::UpdatedState,
 };
 use web3::types::Address;

--- a/modules/anonify-eth-driver/src/traits.rs
+++ b/modules/anonify-eth-driver/src/traits.rs
@@ -7,7 +7,6 @@ use std::{
 use sgx_types::sgx_enclave_id_t;
 use frame_common::{
     traits::*,
-    crypto::AccessRight,
     state_types::UpdatedState,
 };
 use anonify_io_types::*;

--- a/modules/anonify-eth-driver/src/utils.rs
+++ b/modules/anonify-eth-driver/src/utils.rs
@@ -73,7 +73,7 @@ impl<'a, ST: State, C: CallNameConverter> StateInfo<'a, ST, C> {
         self.state.encode_s()
     }
 
-    pub fn crate_input<AP: AccessPolicy>(self, access_policy: AP) -> input::Instruction {
+    pub fn crate_input<AP: AccessPolicy>(self, access_policy: AP) -> input::Instruction<AP> {
         let call_id = self.call_name_to_id();
         let state = StateType::new(self.state.encode_s());
 

--- a/modules/anonify-eth-driver/src/utils.rs
+++ b/modules/anonify-eth-driver/src/utils.rs
@@ -10,7 +10,6 @@ use ethabi::Contract as ContractABI;
 use anonify_io_types::*;
 use frame_common::{
     traits::*,
-    crypto::AccessRight,
     state_types::StateType,
 };
 use anyhow::anyhow;
@@ -74,11 +73,11 @@ impl<'a, ST: State, C: CallNameConverter> StateInfo<'a, ST, C> {
         self.state.encode_s()
     }
 
-    pub fn crate_input(self, access_right: AccessRight) -> input::Instruction {
+    pub fn crate_input<AP: AccessPolicy>(self, access_policy: AP) -> input::Instruction {
         let call_id = self.call_name_to_id();
         let state = StateType::new(self.state.encode_s());
 
-        input::Instruction::new(access_right, state, call_id)
+        input::Instruction::new(access_policy, state, call_id)
     }
 }
 

--- a/modules/anonify-eth-driver/src/workflow.rs
+++ b/modules/anonify-eth-driver/src/workflow.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use frame_host::engine::*;
 use frame_common::{
-    crypto::{AccessRight, Ciphertext},
+    crypto::Ciphertext,
     traits::*,
     state_types::MemId,
 };
@@ -95,25 +95,25 @@ impl HostEngine for InsertHandshakeWorkflow {
 pub mod host_input {
     use super::*;
 
-    pub struct Instruction<S: State, C: CallNameConverter> {
+    pub struct Instruction<S: State, C: CallNameConverter, AP: AccessPolicy> {
         state: S,
         call_name: String,
-        access_right: AccessRight,
+        access_policy: AP,
         signer: Address,
         gas: u64,
         phantom: PhantomData<C>
     }
 
-    impl<S: State, C: CallNameConverter> Instruction<S, C> {
+    impl<S: State, C: CallNameConverter, AP: AccessPolicy> Instruction<S, C, AP> {
         pub fn new(
             state: S,
             call_name: String,
-            access_right: AccessRight,
+            access_policy: AP,
             signer: Address,
             gas: u64,
         ) -> Self {
             Instruction {
-                state, call_name, access_right, signer, gas,
+                state, call_name, access_policy, signer, gas,
                 phantom: PhantomData,
             }
         }
@@ -125,7 +125,7 @@ pub mod host_input {
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
             let state_info = StateInfo::<_, C>::new(self.state, &self.call_name);
-            let ecall_input = state_info.crate_input(self.access_right);
+            let ecall_input = state_info.crate_input(self.access_policy);
             let host_output = host_output::Instruction::new(self.signer, self.gas);
 
             Ok((ecall_input, host_output))
@@ -176,13 +176,13 @@ pub mod host_input {
         }
     }
 
-    pub struct RegisterNotification {
-        access_right: AccessRight,
+    pub struct RegisterNotification<AP: AccessPolicy> {
+        access_policy: AP,
     }
 
-    impl RegisterNotification {
-        pub fn new(access_right: AccessRight) -> Self {
-            RegisterNotification { access_right }
+    impl<AP: AccessPolicy> RegisterNotification<AP> {
+        pub fn new(access_policy: AP) -> Self {
+            RegisterNotification { access_policy }
         }
     }
 
@@ -191,20 +191,20 @@ pub mod host_input {
         type HostOutput = host_output::RegisterNotification;
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
-            let ecall_input = Self::EcallInput::new(self.access_right);
+            let ecall_input = Self::EcallInput::new(self.access_policy);
 
             Ok((ecall_input, Self::HostOutput::default()))
         }
     }
 
-    pub struct GetState {
-        access_right: AccessRight,
+    pub struct GetState<AP: AccessPolicy> {
+        access_policy: AP,
         mem_id: MemId,
     }
 
-    impl GetState {
-        pub fn new(access_right: AccessRight, mem_id: MemId) -> Self {
-            GetState { access_right, mem_id }
+    impl<AP: AccessPolicy> GetState<AP> {
+        pub fn new(access_policy: AP, mem_id: MemId) -> Self {
+            GetState { access_policy, mem_id }
         }
     }
 
@@ -213,7 +213,7 @@ pub mod host_input {
         type HostOutput = host_output::GetState;
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
-            let ecall_input = Self::EcallInput::new(self.access_right, self.mem_id);
+            let ecall_input = Self::EcallInput::new(self.access_policy, self.mem_id);
 
             Ok((ecall_input, Self::HostOutput::new()))
         }

--- a/modules/anonify-io-types/src/types.rs
+++ b/modules/anonify-io-types/src/types.rs
@@ -6,33 +6,34 @@ use crate::localstd::{
 use codec::{Encode, Decode, Input, self};
 use frame_common::{
     EcallInput, EcallOutput, State,
-    crypto::{AccessRight, Sha256, Ciphertext},
+    crypto::{Sha256, Ciphertext},
     state_types::{StateType, MemId, UpdatedState},
+    traits::AccessPolicy,
 };
 
 pub mod input {
     use super::*;
 
     #[derive(Encode, Decode, Debug, Clone)]
-    pub struct Instruction {
-        pub access_right: AccessRight,
+    pub struct Instruction<AP: AccessPolicy> {
+        pub access_policy: AP,
         pub state: StateType,
         pub call_id: u32,
     }
 
-    impl EcallInput for Instruction {}
+    impl<AP: AccessPolicy> EcallInput for Instruction<AP> {}
 
-    impl Instruction {
-        pub fn new(access_right: AccessRight, state: StateType, call_id: u32) -> Self {
+    impl<AP: AccessPolicy> Instruction<AP> {
+        pub fn new(access_policy: AP, state: StateType, call_id: u32) -> Self {
             Instruction {
-                access_right,
+                access_policy,
                 state,
                 call_id,
             }
         }
 
-        pub fn access_right(&self) -> &AccessRight {
-            &self.access_right
+        pub fn access_policy(&self) -> &AP {
+            &self.access_policy
         }
     }
 
@@ -81,20 +82,20 @@ pub mod input {
     }
 
     #[derive(Encode, Decode, Debug, Clone)]
-    pub struct GetState {
-        access_right: AccessRight,
+    pub struct GetState<AP: AccessPolicy> {
+        access_policy: AP,
         mem_id: MemId,
     }
 
-    impl EcallInput for GetState {}
+    impl<AP: AccessPolicy> EcallInput for GetState<AP> {}
 
-    impl GetState {
-        pub fn new(access_right: AccessRight, mem_id: MemId) -> Self {
-            GetState { access_right, mem_id }
+    impl<AP: AccessPolicy> GetState<AP> {
+        pub fn new(access_policy: AP, mem_id: MemId) -> Self {
+            GetState { access_policy, mem_id }
         }
 
-        pub fn access_right(&self) -> &AccessRight {
-            &self.access_right
+        pub fn access_policy(&self) -> &AP {
+            &self.access_policy
         }
 
         pub fn mem_id(&self) -> MemId {
@@ -103,19 +104,19 @@ pub mod input {
     }
 
     #[derive(Encode, Decode, Debug, Clone)]
-    pub struct RegisterNotification {
-        access_right: AccessRight,
+    pub struct RegisterNotification<AP: AccessPolicy> {
+        access_policy: AP,
     }
 
-    impl EcallInput for RegisterNotification {}
+    impl<AP: AccessPolicy> EcallInput for RegisterNotification<AP> {}
 
-    impl RegisterNotification {
-        pub fn new(access_right: AccessRight) -> Self {
-            RegisterNotification { access_right }
+    impl<AP: AccessPolicy> RegisterNotification<AP> {
+        pub fn new(access_policy: AP) -> Self {
+            RegisterNotification { access_policy }
         }
 
-        pub fn access_right(&self) -> &AccessRight {
-            &self.access_right
+        pub fn access_policy(&self) -> &AP {
+            &self.access_policy
         }
     }
 }

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -5,8 +5,8 @@ use std::{
 };
 use sgx_types::*;
 use frame_common::{
-    crypto::{AccessRight, UserAddress, COMMON_ACCESS_RIGHT},
-    traits::State,
+    crypto::{Ed25519ChallengeResponse, AccountId, COMMON_ACCESS_POLICY},
+    traits::*,
 };
 use frame_runtime::primitives::{U64, Approved};
 use erc20_state_transition::{
@@ -29,7 +29,7 @@ fn test_integration_eth_construct() {
     env::set_var("MAX_ROSTER_IDX", "2");
     let enclave = EnclaveDir::new().init_enclave(true).unwrap();
     let eid = enclave.geteid();
-    let my_access_right = AccessRight::new_from_rng().unwrap();
+    let my_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
 
     let gas = 5_000_000;
     let event_db = Arc::new(EventDB::new());
@@ -39,8 +39,8 @@ fn test_integration_eth_construct() {
     let deployer_addr = dispatcher.get_account(0).unwrap();
     let contract_addr = dispatcher.deploy(deployer_addr.clone(), gas).unwrap();
     dispatcher.set_contract_addr(&contract_addr, ANONYMOUS_ASSET_ABI_PATH).unwrap();
-    println!("Deployer address: {:?}", deployer_addr);
-    println!("deployed contract address: {}", contract_addr);
+    println!("Deployer account_id: {:?}", deployer_addr);
+    println!("deployed contract account_id: {}", contract_addr);
 
     // Get handshake from contract
     dispatcher.block_on_event::<U64>().unwrap();
@@ -48,8 +48,8 @@ fn test_integration_eth_construct() {
     // Init state
     let total_supply = U64::from_raw(100);
     let init_state = construct{ total_supply };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName ,_>(
+        my_access_policy.clone(),
         init_state,
         "construct",
         deployer_addr.clone(),
@@ -64,10 +64,10 @@ fn test_integration_eth_construct() {
 
 
     // Get state from enclave
-    let owner_address = get_state::<UserAddress, MemName>(COMMON_ACCESS_RIGHT.clone(), eid, "Owner").unwrap();
-    let my_balance = get_state::<U64, MemName>(my_access_right.clone(), eid, "Balance").unwrap();
-    let actual_total_supply = get_state::<U64, MemName>(COMMON_ACCESS_RIGHT.clone(), eid, "TotalSupply").unwrap();
-    assert_eq!(owner_address, my_access_right.user_address());
+    let owner_account_id = get_state::<AccountId, MemName, _>(COMMON_ACCESS_POLICY.clone(), eid, "Owner").unwrap();
+    let my_balance = get_state::<U64, MemName, _>(my_access_policy.clone(), eid, "Balance").unwrap();
+    let actual_total_supply = get_state::<U64, MemName, _>(COMMON_ACCESS_POLICY.clone(), eid, "TotalSupply").unwrap();
+    assert_eq!(owner_account_id, my_access_policy.into_account_id());
     assert_eq!(my_balance, total_supply);
     assert_eq!(actual_total_supply, total_supply);
 }
@@ -78,9 +78,9 @@ fn test_auto_notification() {
     env::set_var("MAX_ROSTER_IDX", "2");
     let enclave = EnclaveDir::new().init_enclave(true).unwrap();
     let eid = enclave.geteid();
-    let my_access_right = AccessRight::new_from_rng().unwrap();
-    let other_access_right = AccessRight::new_from_rng().unwrap();
-    let third_access_right = AccessRight::new_from_rng().unwrap();
+    let my_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let other_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let third_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
 
     let gas = 5_000_000;
     let event_db = Arc::new(EventDB::new());
@@ -90,8 +90,8 @@ fn test_auto_notification() {
     let deployer_addr = dispatcher.get_account(0).unwrap();
     let contract_addr = dispatcher.deploy(deployer_addr.clone(), gas).unwrap();
     dispatcher.set_contract_addr(&contract_addr, ANONYMOUS_ASSET_ABI_PATH).unwrap();
-    println!("Deployer address: {:?}", deployer_addr);
-    println!("deployed contract address: {}", contract_addr);
+    println!("Deployer account_id: {:?}", deployer_addr);
+    println!("deployed contract account_id: {}", contract_addr);
 
     // Get handshake from contract
     dispatcher.block_on_event::<U64>().unwrap();
@@ -99,8 +99,8 @@ fn test_auto_notification() {
     // Init state
     let total_supply = U64::from_raw(100);
     let init_state = construct{ total_supply };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         init_state,
         "construct",
         deployer_addr.clone(),
@@ -114,16 +114,16 @@ fn test_auto_notification() {
         .block_on_event::<U64>().unwrap().unwrap();
 
     assert_eq!(updated_state.len(), 1);
-    assert_eq!(updated_state[0].address, my_access_right.user_address());
+    assert_eq!(updated_state[0].account_id, my_access_policy.into_account_id());
     assert_eq!(updated_state[0].mem_id.as_raw(), 0);
     assert_eq!(updated_state[0].state, total_supply);
 
     // Send a transaction to contract
     let amount = U64::from_raw(30);
-    let recipient = other_access_right.user_address();
+    let recipient = other_access_policy.into_account_id();
     let transfer_state = transfer{ amount, recipient };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         transfer_state,
         "transfer",
         deployer_addr,
@@ -135,7 +135,7 @@ fn test_auto_notification() {
     let updated_state = dispatcher.block_on_event::<U64>().unwrap().unwrap();
 
     assert_eq!(updated_state.len(), 1);
-    assert_eq!(updated_state[0].address, my_access_right.user_address());
+    assert_eq!(updated_state[0].account_id, my_access_policy.into_account_id());
     assert_eq!(updated_state[0].mem_id.as_raw(), 0);
     assert_eq!(updated_state[0].state, U64::from_raw(70));
 }
@@ -146,9 +146,9 @@ fn test_integration_eth_transfer() {
     env::set_var("MAX_ROSTER_IDX", "2");
     let enclave = EnclaveDir::new().init_enclave(true).unwrap();
     let eid = enclave.geteid();
-    let my_access_right = AccessRight::new_from_rng().unwrap();
-    let other_access_right = AccessRight::new_from_rng().unwrap();
-    let third_access_right = AccessRight::new_from_rng().unwrap();
+    let my_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let other_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let third_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
 
     let gas = 5_000_000;
     let event_db = Arc::new(EventDB::new());
@@ -158,8 +158,8 @@ fn test_integration_eth_transfer() {
     let deployer_addr = dispatcher.get_account(0).unwrap();
     let contract_addr = dispatcher.deploy(deployer_addr.clone(), gas).unwrap();
     dispatcher.set_contract_addr(&contract_addr, ANONYMOUS_ASSET_ABI_PATH).unwrap();
-    println!("Deployer address: {:?}", deployer_addr);
-    println!("deployed contract address: {}", contract_addr);
+    println!("Deployer account_id: {:?}", deployer_addr);
+    println!("deployed contract account_id: {}", contract_addr);
 
     // Get handshake from contract
     dispatcher.block_on_event::<U64>().unwrap();
@@ -167,8 +167,8 @@ fn test_integration_eth_transfer() {
     // Init state
     let total_supply = U64::from_raw(100);
     let init_state = construct{ total_supply };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         init_state,
         "construct",
         deployer_addr.clone(),
@@ -183,9 +183,9 @@ fn test_integration_eth_transfer() {
 
 
     // Get state from enclave
-    let my_state = get_state::<U64, MemName>(my_access_right.clone(), eid, "Balance").unwrap();
-    let other_state = get_state::<U64, MemName>(other_access_right.clone(), eid, "Balance").unwrap();
-    let third_state = get_state::<U64, MemName>(third_access_right.clone(), eid, "Balance").unwrap();
+    let my_state = get_state::<U64, MemName, _>(my_access_policy.clone(), eid, "Balance").unwrap();
+    let other_state = get_state::<U64, MemName, _>(other_access_policy.clone(), eid, "Balance").unwrap();
+    let third_state = get_state::<U64, MemName, _>(third_access_policy.clone(), eid, "Balance").unwrap();
     assert_eq!(my_state, total_supply);
     assert_eq!(other_state, U64::zero());
     assert_eq!(third_state, U64::zero());
@@ -193,10 +193,10 @@ fn test_integration_eth_transfer() {
 
     // Send a transaction to contract
     let amount = U64::from_raw(30);
-    let recipient = other_access_right.user_address();
+    let recipient = other_access_policy.into_account_id();
     let transfer_state = transfer{ amount, recipient };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         transfer_state,
         "transfer",
         deployer_addr,
@@ -209,9 +209,9 @@ fn test_integration_eth_transfer() {
 
 
     // Check the updated states
-    let my_updated_state = get_state::<U64, MemName>(my_access_right, eid, "Balance").unwrap();
-    let other_updated_state = get_state::<U64, MemName>(other_access_right, eid, "Balance").unwrap();
-    let third_updated_state = get_state::<U64, MemName>(third_access_right, eid, "Balance").unwrap();
+    let my_updated_state = get_state::<U64, MemName, _>(my_access_policy, eid, "Balance").unwrap();
+    let other_updated_state = get_state::<U64, MemName, _>(other_access_policy, eid, "Balance").unwrap();
+    let third_updated_state = get_state::<U64, MemName, _>(third_access_policy, eid, "Balance").unwrap();
 
     assert_eq!(my_updated_state, U64::from_raw(70));
     assert_eq!(other_updated_state, amount);
@@ -224,9 +224,9 @@ fn test_key_rotation() {
     env::set_var("MAX_ROSTER_IDX", "2");
     let enclave = EnclaveDir::new().init_enclave(true).unwrap();
     let eid = enclave.geteid();
-    let my_access_right = AccessRight::new_from_rng().unwrap();
-    let other_access_right = AccessRight::new_from_rng().unwrap();
-    let third_access_right = AccessRight::new_from_rng().unwrap();
+    let my_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let other_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let third_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
 
     let gas = 5_000_000;
     let event_db = Arc::new(EventDB::new());
@@ -236,8 +236,8 @@ fn test_key_rotation() {
     let deployer_addr = dispatcher.get_account(0).unwrap();
     let contract_addr = dispatcher.deploy(deployer_addr.clone(), gas).unwrap();
     dispatcher.set_contract_addr(&contract_addr, ANONYMOUS_ASSET_ABI_PATH).unwrap();
-    println!("Deployer address: {:?}", deployer_addr);
-    println!("deployed contract address: {}", contract_addr);
+    println!("Deployer account_id: {:?}", deployer_addr);
+    println!("deployed contract account_id: {}", contract_addr);
 
     // Get handshake from contract
     dispatcher.block_on_event::<U64>().unwrap();
@@ -252,8 +252,8 @@ fn test_key_rotation() {
     // init state
     let total_supply = U64::from_raw(100);
     let init_state = construct{ total_supply };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         init_state,
         "construct",
         deployer_addr.clone(),
@@ -265,9 +265,9 @@ fn test_key_rotation() {
     dispatcher.block_on_event::<U64>().unwrap();
 
     // Get state from enclave
-    let my_state = get_state::<U64, MemName>(my_access_right, eid, "Balance").unwrap();
-    let other_state = get_state::<U64, MemName>(other_access_right, eid, "Balance").unwrap();
-    let third_state = get_state::<U64, MemName>(third_access_right, eid, "Balance").unwrap();
+    let my_state = get_state::<U64, MemName, _>(my_access_policy, eid, "Balance").unwrap();
+    let other_state = get_state::<U64, MemName, _>(other_access_policy, eid, "Balance").unwrap();
+    let third_state = get_state::<U64, MemName, _>(third_access_policy, eid, "Balance").unwrap();
     assert_eq!(my_state, total_supply);
     assert_eq!(other_state, U64::zero());
     assert_eq!(third_state, U64::zero());
@@ -279,8 +279,8 @@ fn test_integration_eth_approve() {
     env::set_var("MAX_ROSTER_IDX", "2");
     let enclave = EnclaveDir::new().init_enclave(true).unwrap();
     let eid = enclave.geteid();
-    let my_access_right = AccessRight::new_from_rng().unwrap();
-    let other_access_right = AccessRight::new_from_rng().unwrap();
+    let my_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let other_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
 
     let gas = 5_000_000;
     let event_db = Arc::new(EventDB::new());
@@ -290,8 +290,8 @@ fn test_integration_eth_approve() {
     let deployer_addr = dispatcher.get_account(0).unwrap();
     let contract_addr = dispatcher.deploy(deployer_addr.clone(), gas).unwrap();
     dispatcher.set_contract_addr(&contract_addr, ANONYMOUS_ASSET_ABI_PATH).unwrap();
-    println!("Deployer address: {:?}", deployer_addr);
-    println!("deployed contract address: {}", contract_addr);
+    println!("Deployer account_id: {:?}", deployer_addr);
+    println!("deployed contract account_id: {}", contract_addr);
 
     // Get handshake from contract
     dispatcher.block_on_event::<U64>().unwrap();
@@ -299,8 +299,8 @@ fn test_integration_eth_approve() {
     // Init state
     let total_supply = U64::from_raw(100);
     let init_state = construct { total_supply };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         init_state,
         "construct",
         deployer_addr.clone(),
@@ -314,17 +314,17 @@ fn test_integration_eth_approve() {
     dispatcher.block_on_event::<U64>().unwrap();
 
     // Get state from enclave
-    let my_state = get_state::<Approved, MemName>(my_access_right.clone(), eid, "Approved").unwrap();
-    let other_state = get_state::<Approved, MemName>(other_access_right.clone(), eid, "Approved").unwrap();
+    let my_state = get_state::<Approved, MemName, _>(my_access_policy.clone(), eid, "Approved").unwrap();
+    let other_state = get_state::<Approved, MemName, _>(other_access_policy.clone(), eid, "Approved").unwrap();
     assert_eq!(my_state, Approved::default());
     assert_eq!(other_state, Approved::default());
 
     // Send a transaction to contract
     let amount = U64::from_raw(30);
-    let spender = other_access_right.user_address();
+    let spender = other_access_policy.into_account_id();
     let approve_state = approve { amount, spender };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         approve_state,
         "approve",
         deployer_addr,
@@ -338,8 +338,8 @@ fn test_integration_eth_approve() {
 
 
     // Check the updated states
-    let my_state = get_state::<Approved, MemName>(my_access_right, eid, "Approved").unwrap();
-    let other_state = get_state::<Approved, MemName>(other_access_right, eid, "Approved").unwrap();
+    let my_state = get_state::<Approved, MemName, _>(my_access_policy, eid, "Approved").unwrap();
+    let other_state = get_state::<Approved, MemName, _>(other_access_policy, eid, "Approved").unwrap();
     let want_my_state = Approved::new({
         let mut bt = BTreeMap::new();
         bt.insert(spender, amount);
@@ -355,9 +355,9 @@ fn test_integration_eth_transfer_from() {
     env::set_var("MAX_ROSTER_IDX", "2");
     let enclave = EnclaveDir::new().init_enclave(true).unwrap();
     let eid = enclave.geteid();
-    let my_access_right = AccessRight::new_from_rng().unwrap();
-    let other_access_right = AccessRight::new_from_rng().unwrap();
-    let third_access_right = AccessRight::new_from_rng().unwrap();
+    let my_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let other_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let third_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
 
     let gas = 5_000_000;
     let event_db = Arc::new(EventDB::new());
@@ -367,8 +367,8 @@ fn test_integration_eth_transfer_from() {
     let deployer_addr = dispatcher.get_account(0).unwrap();
     let contract_addr = dispatcher.deploy(deployer_addr.clone(), gas).unwrap();
     dispatcher.set_contract_addr(&contract_addr, ANONYMOUS_ASSET_ABI_PATH).unwrap();
-    println!("Deployer address: {:?}", deployer_addr);
-    println!("deployed contract address: {}", contract_addr);
+    println!("Deployer account_id: {:?}", deployer_addr);
+    println!("deployed contract account_id: {}", contract_addr);
 
     // Get handshake from contract
     dispatcher.block_on_event::<U64>().unwrap();
@@ -376,8 +376,8 @@ fn test_integration_eth_transfer_from() {
     // Init state
     let total_supply = U64::from_raw(100);
     let init_state = construct { total_supply };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         init_state,
         "construct",
         deployer_addr.clone(),
@@ -391,26 +391,26 @@ fn test_integration_eth_transfer_from() {
     dispatcher.block_on_event::<U64>().unwrap();
 
     // Get initial state from enclave
-    let my_state_balance = get_state::<U64, MemName>(my_access_right.clone(), eid, "Balance").unwrap();
-    let other_state_balance = get_state::<U64, MemName>(other_access_right.clone(), eid, "Balance").unwrap();
-    let third_state_balance = get_state::<U64, MemName>(third_access_right.clone(), eid, "Balance").unwrap();
+    let my_state_balance = get_state::<U64, MemName, _>(my_access_policy.clone(), eid, "Balance").unwrap();
+    let other_state_balance = get_state::<U64, MemName, _>(other_access_policy.clone(), eid, "Balance").unwrap();
+    let third_state_balance = get_state::<U64, MemName, _>(third_access_policy.clone(), eid, "Balance").unwrap();
     assert_eq!(my_state_balance, U64::from_raw(100));
     assert_eq!(other_state_balance, U64::zero());
     assert_eq!(third_state_balance, U64::zero());
 
-    let my_state_approved = get_state::<Approved, MemName>(my_access_right.clone(), eid, "Approved").unwrap();
-    let other_state_approved = get_state::<Approved, MemName>(other_access_right.clone(), eid, "Approved").unwrap();
-    let third_state_approved = get_state::<Approved, MemName>(third_access_right.clone(), eid, "Approved").unwrap();
+    let my_state_approved = get_state::<Approved, MemName, _>(my_access_policy.clone(), eid, "Approved").unwrap();
+    let other_state_approved = get_state::<Approved, MemName, _>(other_access_policy.clone(), eid, "Approved").unwrap();
+    let third_state_approved = get_state::<Approved, MemName, _>(third_access_policy.clone(), eid, "Approved").unwrap();
     assert_eq!(my_state_approved, Approved::default());
     assert_eq!(other_state_approved, Approved::default());
     assert_eq!(third_state_approved, Approved::default());
 
     // Send a transaction to contract
     let amount = U64::from_raw(30);
-    let spender = other_access_right.user_address();
+    let spender = other_access_policy.into_account_id();
     let approve_state = approve { amount, spender };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         approve_state,
         "approve",
         deployer_addr.clone(),
@@ -423,16 +423,16 @@ fn test_integration_eth_transfer_from() {
     dispatcher.block_on_event::<U64>().unwrap();
 
     // Check the updated states
-    let my_state_balance = get_state::<U64, MemName>(my_access_right.clone(), eid, "Balance").unwrap();
-    let other_state_balance = get_state::<U64, MemName>(other_access_right.clone(), eid, "Balance").unwrap();
-    let third_state_balance = get_state::<U64, MemName>(third_access_right.clone(), eid, "Balance").unwrap();
+    let my_state_balance = get_state::<U64, MemName, _>(my_access_policy.clone(), eid, "Balance").unwrap();
+    let other_state_balance = get_state::<U64, MemName, _>(other_access_policy.clone(), eid, "Balance").unwrap();
+    let third_state_balance = get_state::<U64, MemName, _>(third_access_policy.clone(), eid, "Balance").unwrap();
     assert_eq!(my_state_balance, U64::from_raw(100));
     assert_eq!(other_state_balance, U64::zero());
     assert_eq!(third_state_balance, U64::zero());
 
-    let my_state_approved = get_state::<Approved, MemName>(my_access_right.clone(), eid, "Approved").unwrap();
-    let other_state_approved = get_state::<Approved, MemName>(other_access_right.clone(), eid, "Approved").unwrap();
-    let third_state_approved = get_state::<Approved, MemName>(third_access_right.clone(), eid, "Approved").unwrap();
+    let my_state_approved = get_state::<Approved, MemName, _>(my_access_policy.clone(), eid, "Approved").unwrap();
+    let other_state_approved = get_state::<Approved, MemName, _>(other_access_policy.clone(), eid, "Approved").unwrap();
+    let third_state_approved = get_state::<Approved, MemName, _>(third_access_policy.clone(), eid, "Approved").unwrap();
     let want_my_state = Approved::new({
         let mut bt = BTreeMap::new();
         bt.insert(spender, amount);
@@ -444,11 +444,11 @@ fn test_integration_eth_transfer_from() {
 
     // Send a transaction to contract
     let amount = U64::from_raw(20);
-    let owner = my_access_right.user_address();
-    let recipient = third_access_right.user_address();
+    let owner = my_access_policy.into_account_id();
+    let recipient = third_access_policy.into_account_id();
     let transferred_from_state = transfer_from { owner, recipient, amount };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        other_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        other_access_policy.clone(),
         transferred_from_state,
         "transfer_from",
         deployer_addr,
@@ -461,16 +461,16 @@ fn test_integration_eth_transfer_from() {
     dispatcher.block_on_event::<U64>().unwrap();
 
     // Check the final states
-    let my_state_balance = get_state::<U64, MemName>(my_access_right.clone(), eid, "Balance").unwrap();
-    let other_state_balance = get_state::<U64, MemName>(other_access_right.clone(), eid, "Balance").unwrap();
-    let third_state_balance = get_state::<U64, MemName>(third_access_right.clone(), eid, "Balance").unwrap();
+    let my_state_balance = get_state::<U64, MemName, _>(my_access_policy.clone(), eid, "Balance").unwrap();
+    let other_state_balance = get_state::<U64, MemName, _>(other_access_policy.clone(), eid, "Balance").unwrap();
+    let third_state_balance = get_state::<U64, MemName, _>(third_access_policy.clone(), eid, "Balance").unwrap();
     assert_eq!(my_state_balance, U64::from_raw(80));
     assert_eq!(other_state_balance, U64::zero());
     assert_eq!(third_state_balance, U64::from_raw(20));
 
-    let my_state_approved = get_state::<Approved, MemName>(my_access_right, eid, "Approved").unwrap();
-    let other_state_approved = get_state::<Approved, MemName>(other_access_right, eid, "Approved").unwrap();
-    let third_state_approved = get_state::<Approved, MemName>(third_access_right, eid, "Approved").unwrap();
+    let my_state_approved = get_state::<Approved, MemName, _>(my_access_policy, eid, "Approved").unwrap();
+    let other_state_approved = get_state::<Approved, MemName, _>(other_access_policy, eid, "Approved").unwrap();
+    let third_state_approved = get_state::<Approved, MemName, _>(third_access_policy, eid, "Approved").unwrap();
     let want_my_state = Approved::new({
         let mut bt = BTreeMap::new();
         bt.insert(spender, U64::from_raw(10));
@@ -487,8 +487,8 @@ fn test_integration_eth_mint() {
     env::set_var("MAX_ROSTER_IDX", "2");
     let enclave = EnclaveDir::new().init_enclave(true).unwrap();
     let eid = enclave.geteid();
-    let my_access_right = AccessRight::new_from_rng().unwrap();
-    let other_access_right = AccessRight::new_from_rng().unwrap();
+    let my_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let other_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
 
     let gas = 5_000_000;
     let event_db = Arc::new(EventDB::new());
@@ -498,8 +498,8 @@ fn test_integration_eth_mint() {
     let deployer_addr = dispatcher.get_account(0).unwrap();
     let contract_addr = dispatcher.deploy(deployer_addr.clone(), gas).unwrap();
     dispatcher.set_contract_addr(&contract_addr, ANONYMOUS_ASSET_ABI_PATH).unwrap();
-    println!("Deployer address: {:?}", deployer_addr);
-    println!("deployed contract address: {}", contract_addr);
+    println!("Deployer account_id: {:?}", deployer_addr);
+    println!("deployed contract account_id: {}", contract_addr);
 
     // Get handshake from contract
     dispatcher.block_on_event::<U64>().unwrap();
@@ -507,8 +507,8 @@ fn test_integration_eth_mint() {
     // Init state
     let total_supply = U64::from_raw(100);
     let init_state = construct{ total_supply };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         init_state,
         "construct",
         deployer_addr.clone(),
@@ -524,10 +524,10 @@ fn test_integration_eth_mint() {
 
     // transit state
     let amount = U64::from_raw(50);
-    let recipient = other_access_right.user_address();
+    let recipient = other_access_policy.into_account_id();
     let minting_state = mint{ amount, recipient };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         minting_state,
         "mint",
         deployer_addr,
@@ -542,9 +542,9 @@ fn test_integration_eth_mint() {
 
 
     // Check the final states
-    let actual_total_supply = get_state::<U64, MemName>(COMMON_ACCESS_RIGHT.clone(), eid, "TotalSupply").unwrap();
-    let owner_balance = get_state::<U64, MemName>(my_access_right, eid, "Balance").unwrap();
-    let other_balance = get_state::<U64, MemName>(other_access_right, eid, "Balance").unwrap();
+    let actual_total_supply = get_state::<U64, MemName, _>(COMMON_ACCESS_POLICY.clone(), eid, "TotalSupply").unwrap();
+    let owner_balance = get_state::<U64, MemName, _>(my_access_policy, eid, "Balance").unwrap();
+    let other_balance = get_state::<U64, MemName, _>(other_access_policy, eid, "Balance").unwrap();
     assert_eq!(actual_total_supply, U64::from_raw(150));
     assert_eq!(owner_balance, U64::from_raw(100));
     assert_eq!(other_balance, amount);
@@ -556,8 +556,8 @@ fn test_integration_eth_burn() {
     env::set_var("MAX_ROSTER_IDX", "2");
     let enclave = EnclaveDir::new().init_enclave(true).unwrap();
     let eid = enclave.geteid();
-    let my_access_right = AccessRight::new_from_rng().unwrap();
-    let other_access_right = AccessRight::new_from_rng().unwrap();
+    let my_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
+    let other_access_policy = Ed25519ChallengeResponse::new_from_rng().unwrap();
 
     let gas = 5_000_000;
     let event_db = Arc::new(EventDB::new());
@@ -567,8 +567,8 @@ fn test_integration_eth_burn() {
     let deployer_addr = dispatcher.get_account(0).unwrap();
     let contract_addr = dispatcher.deploy(deployer_addr.clone(), gas).unwrap();
     dispatcher.set_contract_addr(&contract_addr, ANONYMOUS_ASSET_ABI_PATH).unwrap();
-    println!("Deployer address: {:?}", deployer_addr);
-    println!("deployed contract address: {}", contract_addr);
+    println!("Deployer account_id: {:?}", deployer_addr);
+    println!("deployed contract account_id: {}", contract_addr);
 
     // Get handshake from contract
     dispatcher.block_on_event::<U64>().unwrap();
@@ -576,8 +576,8 @@ fn test_integration_eth_burn() {
     // Init state
     let total_supply = U64::from_raw(100);
     let init_state = construct{ total_supply };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         init_state,
         "construct",
         deployer_addr.clone(),
@@ -593,10 +593,10 @@ fn test_integration_eth_burn() {
 
     // Send a transaction to contract
     let amount = U64::from_raw(30);
-    let recipient = other_access_right.user_address();
+    let recipient = other_access_policy.into_account_id();
     let transfer_state = transfer{ amount, recipient };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        my_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        my_access_policy.clone(),
         transfer_state,
         "transfer",
         deployer_addr.clone(),
@@ -612,8 +612,8 @@ fn test_integration_eth_burn() {
     // Send a transaction to contract
     let amount = U64::from_raw(20);
     let burn_state = burn{ amount };
-    let receipt = dispatcher.send_instruction::<_, CallName>(
-        other_access_right.clone(),
+    let receipt = dispatcher.send_instruction::<_, CallName, _>(
+        other_access_policy.clone(),
         burn_state,
         "burn",
         deployer_addr,
@@ -627,9 +627,9 @@ fn test_integration_eth_burn() {
 
 
     // Check the final states
-    let actual_total_supply = get_state::<U64, MemName>(COMMON_ACCESS_RIGHT.clone(), eid, "TotalSupply").unwrap();
-    let owner_balance = get_state::<U64, MemName>(my_access_right, eid, "Balance").unwrap();
-    let other_balance = get_state::<U64, MemName>(other_access_right, eid, "Balance").unwrap();
+    let actual_total_supply = get_state::<U64, MemName, _>(COMMON_ACCESS_POLICY.clone(), eid, "TotalSupply").unwrap();
+    let owner_balance = get_state::<U64, MemName, _>(my_access_policy, eid, "Balance").unwrap();
+    let other_balance = get_state::<U64, MemName, _>(other_access_policy, eid, "Balance").unwrap();
     assert_eq!(actual_total_supply, U64::from_raw(80)); // 100 - 20(burn)
     assert_eq!(owner_balance, U64::from_raw(70)); // 100 - 30(transfer)
     assert_eq!(other_balance, U64::from_raw(10)); // 30 - 20(burn)

--- a/wallet/src/keyfile.rs
+++ b/wallet/src/keyfile.rs
@@ -70,40 +70,11 @@ impl KeyFile {
     }
 
     fn keypair_to_encoded_addr(key_pair: &Keypair) -> String {
-        use frame_common::crypto::UserAddress;
+        use frame_common::crypto::AccountId;
 
-        let user_address = UserAddress::from_pubkey(&key_pair.public);
+        let user_address = AccountId::from_pubkey(&key_pair.public);
         user_address.base64_encode()
     }
-
-    // pub fn create_master<R: Rng>(
-    //     account_name: &str,
-    //     version: u32,
-    //     password: &[u8],
-    //     iters: u32,
-    //     rng: &mut R,
-    //     seed: &[u8],
-    // ) -> Result<Self> {
-    //     let xsk_master = ExtendedSpendingKey::master(seed);
-
-    //     let encrypted_key = KeyCiphertext::encrypt(&xsk_master, password, iters, rng)?;
-    //     let ss58_master_addr = (&xsk_master).try_into()?;
-
-    //     Ok(KeyFile {
-    //         file_name: None,
-    //         account_name: account_name.to_string(),
-    //         ss58_address: ss58_master_addr,
-    //         version,
-    //         encrypted_key,
-    //     })
-    // }
-
-    // pub fn get_child_xsk(&self, password: &[u8], index: ChildIndex) -> Result<ExtendedSpendingKey> {
-    //     let xsk = self.encrypted_key.decrypt(password)?;
-    //     let xsk_child = xsk.derive_child(index)?;
-
-    //     Ok(xsk_child)
-    // }
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
* 元の`AccessRight` structを`Ed25519ChallengeResponse` に変更
* 命名：`address`を`account_id`に統一変更
* `AccessPolicy` traitを実装し、検証部分を抽象化