### PR TITLE
Add roster index velidations

### DIFF
--- a/contracts/Anonify.sol
+++ b/contracts/Anonify.sol
@@ -8,25 +8,25 @@ import "./utils/BytesUtils.sol";
 // Consider: Avoid inheritting
 contract Anonify is ReportHandle {
     address private _owner;
-    uint256 private _mrenclaveVer;
+    uint32 private _mrenclaveVer;
 
     // An counter of registered roster index
-    uint256 private _rosterIdxCounter;
+    uint32 private _rosterIdxCounter;
     // Mapping of a sender and roster index
-    mapping(address => uint256) private _senderToRosterIdx;
+    mapping(address => uint32) private _senderToRosterIdx;
 
     event StoreCiphertext(bytes ciphertext);
     event StoreHandshake(bytes handshake);
-    event UpdateMrenclaveVer(uint256 newVersion);
+    event UpdateMrenclaveVer(uint32 newVersion);
 
     constructor(
         bytes memory _report,
         bytes memory _reportSig,
         bytes memory _handshake,
-        uint256 mrenclaveVer
+        uint32 mrenclaveVer
     ) ReportHandle(_report, _reportSig) public {
         // The offset of roster index is 4.
-        uint256 rosterIdx = BytesUtils.toUint256(_handshake, 4);
+        uint32 rosterIdx = BytesUtils.toUint32(_handshake, 4);
         require(rosterIdx == 0, "First roster_idx must be zero");
 
         _owner = msg.sender;
@@ -46,10 +46,10 @@ contract Anonify is ReportHandle {
         bytes memory _report,
         bytes memory _reportSig,
         bytes memory _handshake,
-        uint256 _version
+        uint32 _version
     ) public {
         require(_mrenclaveVer == _version, "Must be same version");
-        uint256 rosterIdx = BytesUtils.toUint256(_handshake, 4);
+        uint32 rosterIdx = BytesUtils.toUint32(_handshake, 4);
         require(rosterIdx == _rosterIdxCounter + 1, "Joining the group must be ordered accordingly by roster index");
         require(_senderToRosterIdx[msg.sender] == 0, "The msg.sender can join only once");
 
@@ -63,9 +63,9 @@ contract Anonify is ReportHandle {
         bytes memory _report,
         bytes memory _reportSig,
         bytes memory _handshake,
-        uint256 _newVersion
+        uint32 _newVersion
     ) public onlyOwner {
-        require(_mrenclaveVer != _newVersion, "Must be new version");        
+        require(_mrenclaveVer != _newVersion, "Must be new version");
         updateMrenclaveInner(_report, _reportSig);
         handshake_wo_sig(_handshake);
         _mrenclaveVer = _newVersion;
@@ -87,7 +87,7 @@ contract Anonify is ReportHandle {
         bytes memory _handshake,
         bytes memory _enclaveSig
     ) public {
-        uint256 rosterIdx = BytesUtils.toUint256(_handshake, 4);
+        uint32 rosterIdx = BytesUtils.toUint32(_handshake, 4);
         require(_senderToRosterIdx[msg.sender] == rosterIdx, "The roster index must be same as the registered one");
         address verifyingKey = Secp256k1.recover(sha256(_handshake), _enclaveSig);
         require(verifyingKeyMapping[verifyingKey] == verifyingKey, "Invalid enclave signature.");

--- a/contracts/utils/BytesUtils.sol
+++ b/contracts/utils/BytesUtils.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.0;
 
+// ref: https://github.com/GNSPS/solidity-bytes-utils
 library BytesUtils {
     function toAddress(bytes memory _bytes, uint _start) internal  pure returns (address) {
         require(_bytes.length >= (_start + 20));
@@ -21,5 +22,16 @@ library BytesUtils {
         }
 
         return tempBytes32;
+    }
+
+    function toUint256(bytes memory _bytes, uint256 _start) internal pure returns (uint256) {
+        require(_bytes.length >= (_start + 32), "Read out of bounds");
+        uint256 tempUint;
+
+        assembly {
+            tempUint := mload(add(add(_bytes, 0x20), _start))
+        }
+
+        return tempUint;
     }
 }

--- a/contracts/utils/BytesUtils.sol
+++ b/contracts/utils/BytesUtils.sol
@@ -24,12 +24,12 @@ library BytesUtils {
         return tempBytes32;
     }
 
-    function toUint256(bytes memory _bytes, uint256 _start) internal pure returns (uint256) {
-        require(_bytes.length >= (_start + 32), "Read out of bounds");
-        uint256 tempUint;
+    function toUint32(bytes memory _bytes, uint256 _start) internal pure returns (uint32) {
+        require(_bytes.length >= (_start + 4), "Read out of bounds");
+        uint32 tempUint;
 
         assembly {
-            tempUint := mload(add(add(_bytes, 0x20), _start))
+            tempUint := mload(add(add(_bytes, 0x4), _start))
         }
 
         return tempUint;


### PR DESCRIPTION
resolved: #91 

## Motivation
* roster indexは環境変数により指定し、他のTEEと被る値を設定するとhandshake process時に上書きされたTEEでエラーが発生してしまう
* このエラーは上書き以降のpath secretが異なるために生じるものであり、それ以降の暗号文が復号できなくなる

##  変更点
* コントラクトでhandshake payloadに含まれるroster idxを用いてバリデーションを追加

