### PR TITLE
Fix join group api

### DIFF
--- a/example/erc20/api/src/lib.rs
+++ b/example/erc20/api/src/lib.rs
@@ -29,11 +29,6 @@ pub mod join_group {
     pub mod post {
         use super::super::*;
 
-        #[derive(Clone, Deserialize, Serialize, Debug)]
-        pub struct Request {
-            pub contract_addr: String,
-        }
-
         #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
         pub struct Response(pub H256);
     }
@@ -42,11 +37,6 @@ pub mod join_group {
 pub mod update_mrenclave {
     pub mod post {
         use super::super::*;
-
-        #[derive(Clone, Deserialize, Serialize, Debug)]
-        pub struct Request {
-            pub contract_addr: String,
-        }
 
         #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
         pub struct Response(pub H256);

--- a/example/erc20/server/src/handlers.rs
+++ b/example/erc20/server/src/handlers.rs
@@ -53,7 +53,6 @@ where
 
 pub async fn handle_join_group<D, S, W>(
     server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::join_group::post::Request>,
 ) -> Result<HttpResponse>
 where
     D: Deployer,
@@ -67,12 +66,7 @@ where
         .map_err(|e| ServerError::from(e))?;
     let (tx_hash, export_path_secret) = server
         .dispatcher
-        .join_group(
-            sender_address,
-            DEFAULT_GAS,
-            &req.contract_addr,
-            &server.abi_path,
-        )
+        .join_group(sender_address, DEFAULT_GAS)
         .await
         .map_err(|e| ServerError::from(e))?;
     server
@@ -85,7 +79,6 @@ where
 
 pub async fn handle_update_mrenclave<D, S, W>(
     server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::update_mrenclave::post::Request>,
 ) -> Result<HttpResponse>
 where
     D: Deployer,
@@ -99,12 +92,7 @@ where
         .map_err(|e| ServerError::from(e))?;
     let (tx_hash, export_path_secret) = server
         .dispatcher
-        .update_mrenclave(
-            sender_address,
-            DEFAULT_GAS,
-            &req.contract_addr,
-            &server.abi_path,
-        )
+        .update_mrenclave(sender_address, DEFAULT_GAS)
         .await
         .map_err(|e| ServerError::from(e))?;
     server

--- a/example/erc20/server/src/tests.rs
+++ b/example/erc20/server/src/tests.rs
@@ -133,9 +133,6 @@ async fn test_join_group_then_handshake() {
 
     let req = test::TestRequest::post()
         .uri("/api/v1/join_group")
-        .set_json(&erc20_api::join_group::post::Request {
-            contract_addr: contract_addr.0,
-        })
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -99,15 +99,11 @@ where
         Ok((contract_addr, export_path_secret))
     }
 
-    pub async fn join_group<P: AsRef<Path> + Copy>(
-        &self,
-        signer: Address,
-        gas: u64,
-    ) -> Result<(H256, ExportPathSecret)> {
+    pub async fn join_group(&self, signer: Address, gas: u64) -> Result<(H256, ExportPathSecret)> {
         self.send_report_handshake(signer, gas, "joinGroup").await
     }
 
-    pub async fn update_mrenclave<P: AsRef<Path> + Copy>(
+    pub async fn update_mrenclave(
         &self,
         signer: Address,
         gas: u64,

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -103,34 +103,25 @@ where
         &self,
         signer: Address,
         gas: u64,
-        contract_addr: &str,
-        abi_path: P,
     ) -> Result<(H256, ExportPathSecret)> {
-        self.send_report_handshake(signer, gas, contract_addr, abi_path, "joinGroup")
-            .await
+        self.send_report_handshake(signer, gas, "joinGroup").await
     }
 
     pub async fn update_mrenclave<P: AsRef<Path> + Copy>(
         &self,
         signer: Address,
         gas: u64,
-        contract_addr: &str,
-        abi_path: P,
     ) -> Result<(H256, ExportPathSecret)> {
-        self.send_report_handshake(signer, gas, contract_addr, abi_path, "updateMrenclave")
+        self.send_report_handshake(signer, gas, "updateMrenclave")
             .await
     }
 
-    async fn send_report_handshake<P: AsRef<Path> + Copy>(
+    async fn send_report_handshake(
         &self,
         signer: Address,
         gas: u64,
-        contract_addr: &str,
-        abi_path: P,
         method: &str,
     ) -> Result<(H256, ExportPathSecret)> {
-        self.set_contract_addr(contract_addr, abi_path)?;
-
         let inner = self.inner.read();
         let eid = inner.deployer.get_enclave_id();
         let input = host_input::JoinGroup::new(signer, gas);

--- a/modules/anonify-eth-driver/src/eth/event_watcher.rs
+++ b/modules/anonify-eth-driver/src/eth/event_watcher.rs
@@ -39,8 +39,9 @@ impl Watcher for EventWatcher {
             .get_event(self.cache.clone(), self.contract.address())
             .await?
             .into_enclave_log()?
+            // verification must be executed only before calling `insert_enclave`
             .insert_enclave(eid)?
-            .save_cache(self.contract.address());
+            .save_cache(self.contract.address()); // cache must be saved only after calling `insert_enclave`.
 
         Ok(enclave_updated_state.updated_states())
     }


### PR DESCRIPTION
* join group apiのリクエストに`contract_addr`を渡さないと空文字がdispatcherの`contract_info`に更新されてしまうので、join group apiでは`contract_addr`の指定は行わないように修正