### PR TITLE
add test to recover path_secret even if key-vault server is down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,10 +581,9 @@ dependencies = [
 [[package]]
 name = "base64"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+source = "git+https://github.com/mesalock-linux/rust-base64-sgx#368a1db999e3005bb1bf2278dbe31f0906441f8c"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -598,9 +597,10 @@ dependencies = [
 [[package]]
 name = "base64"
 version = "0.10.1"
-source = "git+https://github.com/mesalock-linux/rust-base64-sgx#368a1db999e3005bb1bf2278dbe31f0906441f8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
- "sgx_tstd",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -667,23 +667,23 @@ dependencies = [
 [[package]]
 name = "block-buffer"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
 dependencies = [
- "block-padding 0.1.5",
- "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-padding 0.1.4",
+ "byte-tools 0.3.1 (git+https://github.com/mesalock-linux/rustcrypto-utils-sgx)",
+ "byteorder 1.3.4 (git+https://github.com/mesalock-linux/byteorder-sgx)",
  "generic-array 0.12.3",
 ]
 
 [[package]]
 name = "block-buffer"
 version = "0.7.3"
-source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.4",
- "byte-tools 0.3.1 (git+https://github.com/mesalock-linux/rustcrypto-utils-sgx)",
- "byteorder 1.3.4 (git+https://github.com/mesalock-linux/byteorder-sgx)",
+ "block-padding 0.1.5",
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3",
 ]
 
@@ -773,19 +773,13 @@ checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 [[package]]
 name = "byte-tools"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
 
 [[package]]
 name = "byte-tools"
 version = "0.3.1"
-source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
-
-[[package]]
-name = "byteorder"
-version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -794,6 +788,12 @@ source = "git+https://github.com/mesalock-linux/byteorder-sgx#325f392dcd294109eb
 dependencies = [
  "sgx_tstd",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
@@ -1150,20 +1150,20 @@ dependencies = [
 [[package]]
 name = "crypto-mac"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.3.0",
+ "generic-array 0.12.3",
+ "subtle 2.2.2",
 ]
 
 [[package]]
 name = "crypto-mac"
 version = "0.8.0"
-source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.12.3",
- "subtle 2.2.2",
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
 ]
 
 [[package]]
@@ -1233,19 +1233,19 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
 dependencies = [
  "generic-array 0.12.3",
+ "sgx_tstd",
 ]
 
 [[package]]
 name = "digest"
 version = "0.8.1"
-source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.3",
- "sgx_tstd",
 ]
 
 [[package]]
@@ -1712,8 +1712,8 @@ dependencies = [
  "hex",
  "libsecp256k1 0.3.5",
  "libsecp256k1 0.4.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (git+https://github.com/mesalock-linux/log-sgx?rev=sgx_1.1.3)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "rand 0.6.5",
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?rev=v0.7.3_sgx1.1.3)",
@@ -2056,20 +2056,20 @@ dependencies = [
 [[package]]
 name = "hmac"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+source = "git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx#e8e1410b9c82d2e59da42fa8b0d8ed38e80a203c"
 dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-mac 0.8.0 (git+https://github.com/mesalock-linux/rustcrypto-traits-sgx)",
+ "digest 0.8.1 (git+https://github.com/mesalock-linux/rustcrypto-traits-sgx)",
 ]
 
 [[package]]
 name = "hmac"
 version = "0.7.1"
-source = "git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx#e8e1410b9c82d2e59da42fa8b0d8ed38e80a203c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
- "crypto-mac 0.8.0 (git+https://github.com/mesalock-linux/rustcrypto-traits-sgx)",
- "digest 0.8.1 (git+https://github.com/mesalock-linux/rustcrypto-traits-sgx)",
+ "crypto-mac 0.7.0",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2085,21 +2085,21 @@ dependencies = [
 [[package]]
 name = "hmac-drbg"
 version = "0.1.2"
+source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
+dependencies = [
+ "generic-array 0.12.3",
+ "hmac 0.7.1 (git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx)",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe727d41d2eec0a6574d887914347e5ff96a3b87177817e2a9820c5c87fecc2"
 dependencies = [
  "digest 0.6.2",
  "generic-array 0.8.3",
  "hmac 0.4.2",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.1.2"
-source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
-dependencies = [
- "generic-array 0.12.3",
- "hmac 0.7.1 (git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx)",
 ]
 
 [[package]]
@@ -2138,23 +2138,23 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
-dependencies = [
- "bytes 0.5.6",
- "fnv 1.0.7",
- "itoa 0.4.6",
-]
-
-[[package]]
-name = "http"
-version = "0.2.1"
 source = "git+https://github.com/mesalock-linux/http-sgx?rev=sgx_1.1.3#62544a1833f98f1810a44877c5f1efe45f5327c0"
 dependencies = [
  "bytes 0.5.4",
  "fnv 1.0.6",
  "itoa 0.4.5",
  "sgx_tstd",
+]
+
+[[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv 1.0.7",
+ "itoa 0.4.6",
 ]
 
 [[package]]
@@ -2660,19 +2660,19 @@ dependencies = [
 [[package]]
 name = "log"
 version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+source = "git+https://github.com/mesalock-linux/log-sgx?rev=sgx_1.1.3#5a057d237cf96e9137de08387eb70105d5705648"
 dependencies = [
  "cfg-if 0.1.10",
+ "sgx_tstd",
 ]
 
 [[package]]
 name = "log"
 version = "0.4.11"
-source = "git+https://github.com/mesalock-linux/log-sgx?rev=sgx_1.1.3#5a057d237cf96e9137de08387eb70105d5705648"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
- "sgx_tstd",
 ]
 
 [[package]]
@@ -2938,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "once_cell"
 version = "1.4.0"
-source = "git+https://github.com/mesalock-linux/once_cell-sgx?rev=sgx_1.1.3#cefcaa03fed4d85276b3235d875f1b45d399cc3c"
+source = "git+https://github.com/mesalock-linux/once_cell-sgx#cefcaa03fed4d85276b3235d875f1b45d399cc3c"
 dependencies = [
  "sgx_tstd",
 ]
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "once_cell"
 version = "1.4.0"
-source = "git+https://github.com/mesalock-linux/once_cell-sgx#cefcaa03fed4d85276b3235d875f1b45d399cc3c"
+source = "git+https://github.com/mesalock-linux/once_cell-sgx?rev=sgx_1.1.3#cefcaa03fed4d85276b3235d875f1b45d399cc3c"
 dependencies = [
  "sgx_tstd",
 ]
@@ -3403,19 +3403,6 @@ dependencies = [
 [[package]]
 name = "rand"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.15",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
 source = "git+https://github.com/mesalock-linux/rand-sgx?tag=v0.7.3_sgx1.1.3#55697c5a4007d13e8d5f37be7216be1b18fb8ebf"
 dependencies = [
  "getrandom 0.1.14",
@@ -3433,6 +3420,19 @@ dependencies = [
  "rand_chacha 0.2.1 (git+https://github.com/mesalock-linux/rand-sgx?rev=v0.7.3_sgx1.1.3)",
  "rand_core 0.5.1 (git+https://github.com/mesalock-linux/rand-sgx?rev=v0.7.3_sgx1.1.3)",
  "sgx_tstd",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.15",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -3493,15 +3493,6 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 [[package]]
 name = "rand_core"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.15",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
 source = "git+https://github.com/mesalock-linux/rand-sgx?tag=v0.7.3_sgx1.1.3#55697c5a4007d13e8d5f37be7216be1b18fb8ebf"
 dependencies = [
  "getrandom 0.1.14",
@@ -3515,6 +3506,15 @@ source = "git+https://github.com/mesalock-linux/rand-sgx?rev=v0.7.3_sgx1.1.3#556
 dependencies = [
  "getrandom 0.1.14",
  "sgx_tstd",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.15",
 ]
 
 [[package]]
@@ -3831,19 +3831,6 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
-dependencies = [
- "base64 0.13.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.16.15",
- "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.21.3",
-]
-
-[[package]]
-name = "rustls"
-version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
@@ -3852,6 +3839,19 @@ dependencies = [
  "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx)",
  "sgx_tstd",
  "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+dependencies = [
+ "base64 0.13.0",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.16.15",
+ "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.3",
 ]
 
 [[package]]
@@ -3904,20 +3904,20 @@ dependencies = [
 [[package]]
 name = "sct"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+source = "git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx#c4d859cca232e6c9d88ca12048df3bc26e1ed4ad"
 dependencies = [
- "ring 0.16.15",
+ "ring 0.16.19",
+ "sgx_tstd",
  "untrusted",
 ]
 
 [[package]]
 name = "sct"
 version = "0.6.0"
-source = "git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx#c4d859cca232e6c9d88ca12048df3bc26e1ed4ad"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
- "ring 0.16.19",
- "sgx_tstd",
+ "ring 0.16.15",
  "untrusted",
 ]
 
@@ -3985,6 +3985,7 @@ dependencies = [
  "secret-backup-api",
  "serde_json 1.0.59",
  "sgx_types 1.1.1",
+ "sgx_urts",
  "thiserror 1.0.22",
  "tracing",
  "tracing-subscriber",
@@ -4041,18 +4042,18 @@ dependencies = [
 [[package]]
 name = "serde"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
+source = "git+https://github.com/mesalock-linux/serde-sgx.git#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
- "serde_derive 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3)",
+ "serde_derive 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git)",
  "sgx_tstd",
 ]
 
 [[package]]
 name = "serde"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx.git#db0226f1d5d70fca6b96af2c285851502204e21c"
+source = "git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
- "serde_derive 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git)",
+ "serde_derive 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3)",
  "sgx_tstd",
 ]
 
@@ -4089,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "serde_derive"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
+source = "git+https://github.com/mesalock-linux/serde-sgx.git#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4099,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "serde_derive"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx.git#db0226f1d5d70fca6b96af2c285851502204e21c"
+source = "git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4483,8 +4484,7 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 [[package]]
 name = "stream-cipher"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
 dependencies = [
  "generic-array 0.12.3",
 ]
@@ -4492,7 +4492,8 @@ dependencies = [
 [[package]]
 name = "stream-cipher"
 version = "0.3.2"
-source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
 dependencies = [
  "generic-array 0.12.3",
 ]
@@ -5219,18 +5220,18 @@ dependencies = [
 [[package]]
 name = "unicase"
 version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+source = "git+https://github.com/mesalock-linux/unicase-sgx#0b0519348572927118af47af3da4da9ffdca8ec6"
 dependencies = [
+ "sgx_tstd",
  "version_check",
 ]
 
 [[package]]
 name = "unicase"
 version = "2.6.0"
-source = "git+https://github.com/mesalock-linux/unicase-sgx#0b0519348572927118af47af3da4da9ffdca8ec6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "sgx_tstd",
  "version_check",
 ]
 

--- a/example/secret-backup/server/Cargo.toml
+++ b/example/secret-backup/server/Cargo.toml
@@ -31,3 +31,4 @@ anonify-eth-driver = { path = "../../../modules/anonify-eth-driver" }
 codec = { package = "parity-scale-codec", version = "1.1" }
 web3 = { git = "https://github.com/tomusdrw/rust-web3", rev = "d7393708e257f7ef4ad354917889a8001cf2927c" }
 ethabi = "12.0.0"
+sgx_urts = "1.1.1"

--- a/example/secret-backup/server/src/tests.rs
+++ b/example/secret-backup/server/src/tests.rs
@@ -25,7 +25,6 @@ use web3::{
     Web3,
 };
 
-
 #[actix_rt::test]
 async fn test_backup_path_secret() {
     set_env_vars();
@@ -48,7 +47,7 @@ async fn test_backup_path_secret() {
             .route("/api/v1/start", web::post().to(handle_start))
             .route("/api/v1/stop", web::post().to(handle_stop)),
     )
-        .await;
+    .await;
 
     let req = test::TestRequest::post().uri("/api/v1/start").to_request();
     let resp = test::call_service(&mut key_vault_app, req).await;
@@ -92,7 +91,7 @@ async fn test_backup_path_secret() {
                 web::get().to(handle_encrypting_key::<EthDeployer, EthSender, EventWatcher>),
             ),
     )
-        .await;
+    .await;
 
     // Ensure not to exist path_secret directory on both local and remote
     let path_secrets_dir = PJ_ROOT_DIR
@@ -178,6 +177,152 @@ async fn test_backup_path_secret() {
     assert_eq!(balance.0.as_raw(), 100);
 }
 
+#[actix_rt::test]
+async fn test_recover_without_key_vault() {
+    set_env_vars();
+    set_server_env_vars();
+    clear_path_secrets();
+
+    let abi_path = env::var("ABI_PATH").expect("ABI_PATH is not set");
+    let eth_url = env::var("ETH_URL").expect("ETH_URL is not set");
+
+    // Setup key-vault server
+    let key_vault_server_enclave = EnclaveDir::new()
+        .init_enclave(true)
+        .expect("Failed to initialize server enclave.");
+    let key_vault_server_eid = key_vault_server_enclave.geteid();
+    let key_vault_server = Arc::new(KeyVaultServer::new(key_vault_server_eid));
+
+    let mut key_vault_app = test::init_service(
+        App::new()
+            .data(key_vault_server.clone())
+            .route("/api/v1/start", web::post().to(handle_start))
+            .route("/api/v1/stop", web::post().to(handle_stop)),
+    )
+    .await;
+
+    let req = test::TestRequest::post().uri("/api/v1/start").to_request();
+    let resp = test::call_service(&mut key_vault_app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let start_response: secret_backup_api::start::post::Response = test::read_body_json(resp).await;
+    assert_eq!(start_response.status, "success".to_string());
+
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
+    // Setup ERC20 application
+    env::set_var("ENCLAVE_PKG_NAME", "erc20");
+    let app_enclave = EnclaveDir::new()
+        .init_enclave(true)
+        .expect("Failed to initialize client enclave.");
+    let app_eid = app_enclave.geteid();
+
+    let erc20_server = Arc::new(ERC20Server::<EthDeployer, EthSender, EventWatcher>::new(
+        app_eid,
+    ));
+    let mut app = test::init_service(
+        App::new()
+            .data(erc20_server.clone())
+            .route(
+                "/api/v1/deploy",
+                web::post().to(handle_deploy::<EthDeployer, EthSender, EventWatcher>),
+            )
+            .route(
+                "/api/v1/init_state",
+                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
+            )
+            .route(
+                "/api/v1/balance_of",
+                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+            )
+            .route(
+                "/api/v1/key_rotation",
+                web::post().to(handle_key_rotation::<EthDeployer, EthSender, EventWatcher>),
+            )
+            .route(
+                "/api/v1/encrypting_key",
+                web::get().to(handle_encrypting_key::<EthDeployer, EthSender, EventWatcher>),
+            ),
+    )
+    .await;
+
+    // Ensure not to exist path_secret directory on both local and remote
+    let path_secrets_dir = PJ_ROOT_DIR
+        .join(&env::var("LOCAL_PATH_SECRETS_DIR").expect("LOCAL_PATH_SECRETS_DIR is not set"));
+    assert!(!path_secrets_dir.exists());
+
+    // Deploy
+    let req = test::TestRequest::post().uri("/api/v1/deploy").to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let contract_addr: erc20_api::deploy::post::Response = test::read_body_json(resp).await;
+    println!("contract address: {:?}", contract_addr.0);
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/balance_of")
+        .set_json(&BALANCE_OF_REQ)
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
+    assert_eq!(balance.0.as_raw(), 0);
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/encrypting_key")
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+
+    let enc_key_resp: erc20_api::encrypting_key::get::Response = test::read_body_json(resp).await;
+    let enc_key =
+        verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
+
+    // check storing path_secret
+    let id = get_path_secret_id().unwrap();
+    // local
+    assert!(path_secrets_dir.join(&id).exists());
+    // remote
+    assert!(path_secrets_dir
+        .join(env::var("MY_ROSTER_IDX").unwrap().as_str())
+        .join(&id)
+        .exists());
+
+    // Init state
+    let init_100_req = init_100_req(&enc_key);
+    let req = test::TestRequest::post()
+        .uri("/api/v1/init_state")
+        .set_json(&init_100_req)
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/balance_of")
+        .set_json(&BALANCE_OF_REQ)
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
+    assert_eq!(balance.0.as_raw(), 100);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/key_rotation")
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+
+    // stop key-vault server
+    sgx_urts::rsgx_destroy_enclave(key_vault_server_eid).unwrap();
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/balance_of")
+        .set_json(&BALANCE_OF_REQ)
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
+    assert_eq!(balance.0.as_raw(), 100);
+}
+
 pub static SUBSCRIBER_INIT: Lazy<()> = Lazy::new(|| {
     tracing_subscriber::fmt::init();
 });
@@ -232,7 +377,7 @@ fn get_path_secret_id() -> Option<String> {
         PJ_ROOT_DIR
             .join(&env::var("LOCAL_PATH_SECRETS_DIR").expect("LOCAL_PATH_SECRETS_DIR is not set")),
     )
-        .unwrap()
+    .unwrap()
     {
         if path.as_ref().unwrap().file_type().unwrap().is_dir() {
             continue;


### PR DESCRIPTION
key-vault serverが落ちている状態でもlocalからpath_secretが復元できることのテストを追加

key-vault serverは`sgx_urts::rsgx_destroy_enclave`で落とした。