### PR TITLE
Implement retry to remote-attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,8 +3672,10 @@ checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 name = "remote-attestation"
 version = "0.1.0"
 dependencies = [
+ "anonify-config",
  "anyhow 1.0.28",
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
+ "frame-retrier",
  "frame-types",
  "hex",
  "http_req",

--- a/edl/Anonify_common.edl
+++ b/edl/Anonify_common.edl
@@ -10,6 +10,7 @@ enclave {
     from "sgx_env.edl" import *;
     from "sgx_pthread.edl" import *;
     from "sgx_sys.edl" import *;
+    from "sgx_thread.edl" import *;
 
     include "sgx_quote.h"
     include "frame-types.h"

--- a/frame/remote-attestation/Cargo.toml
+++ b/frame/remote-attestation/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 frame-types = { path = "../types" }
+frame-retrier = { path = "../retrier", default-features = false, features = ["sgx"]}
+anonify-config = { path = "../../config", default-features = false, features = ["sgx"]}
 anyhow = { rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/anyhow-sgx.git" }
 webpki = { branch = "mesalock_sgx", git = "https://github.com/mesalock-linux/webpki" } # Specify branch name due to rustls dependency
 sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["net"] }

--- a/frame/remote-attestation/src/client.rs
+++ b/frame/remote-attestation/src/client.rs
@@ -111,6 +111,10 @@ pub struct AttestedReport {
 
 impl AttestedReport {
     pub(crate) fn from_response(body: Vec<u8>, resp: Response) -> Result<Self> {
+        if !resp.status_code().is_success() {
+            return Err(FrameRAError::StatusCodeError(resp));
+        }
+
         let headers = resp.headers();
         let sig = headers
             .get("X-IASReport-Signature")

--- a/frame/remote-attestation/src/client.rs
+++ b/frame/remote-attestation/src/client.rs
@@ -14,9 +14,7 @@ use std::{io::Write, prelude::v1::*, str, string::String, time::SystemTime};
 /// Define a retry condition of remote attestation request
 /// If it returns false, don't need to retry remote attestation request
 const fn ra_retry_condition(err: &FrameRAError) -> bool {
-    match err {
-        _ => true,
-    }
+    false
 }
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];

--- a/frame/remote-attestation/src/error.rs
+++ b/frame/remote-attestation/src/error.rs
@@ -32,6 +32,8 @@ pub enum FrameRAError {
         function: &'static str,
     },
 
+    #[error("The status code indicates that it's not Successful, response: {0:?}")]
+    StatusCodeError(http_req::response::Response),
     #[error("The Remote Attestation API version ({0}) is not supported")]
     ApiVersionError(u64),
     #[error("Invalid Enclave Quote Status: {0}")]

--- a/frame/remote-attestation/src/error.rs
+++ b/frame/remote-attestation/src/error.rs
@@ -1,29 +1,45 @@
 use frame_types::UntrustedStatus;
-use std::io;
-use std::vec::Vec;
+use std::{io, string::String, vec::Vec};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, FrameRAError>;
 
 #[derive(Error, Debug)]
 pub enum FrameRAError {
+    #[error("Parse int error: {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
     #[error("I/O error: {0}")]
     IoError(#[from] io::Error),
     #[error("Anyhow error: {0}")]
     AnyhowError(#[from] anyhow::Error),
+    #[error("base64 error: {0}")]
+    Base64Error(#[from] base64::DecodeError),
+    #[error("serde json error: {0}")]
+    SerdeJsonError(#[from] serde_json::Error),
+    #[error("web pki error: {0}")]
+    WebpkiJsonError(#[from] webpki::Error),
+    #[error("http req error: {0}")]
+    HttpReqError(#[from] http_req::error::Error),
 
     #[error("Ocall Error: function: {function:?}, status: {status:?}")]
     OcallError {
         status: sgx_types::sgx_status_t,
         function: &'static str,
     },
-
     #[error("Error caused in untrusted part: function: {function:?}, status: {status:?}")]
     UntrustedError {
         status: UntrustedStatus,
         function: &'static str,
     },
 
+    #[error("The Remote Attestation API version ({0}) is not supported")]
+    ApiVersionError(u64),
+    #[error("Invalid Enclave Quote Status: {0}")]
+    QuoteStatusError(String),
+    #[error("Failed to fetch isvEnclaveQuoteStatus from attestation report")]
+    NotFoundisvEnclaveQuoteStatusError,
+    #[error("Certificate is blank")]
+    BlankCertError,
     #[error("qe_report is not valid: {0}")]
     VerifyReportError(sgx_types::sgx_status_t),
     #[error("received quote is modified or replayed: report.data[..32]: {rhs:?}, SHA256(p_nonce||p_quote): {lhs:?}")]

--- a/frame/retrier/src/retry.rs
+++ b/frame/retrier/src/retry.rs
@@ -53,12 +53,11 @@ where
                 if let Some((curr_tries, delay)) = iterator.next() {
                     warn!(
                         "The {} operation retries {} times... (result: {:?})",
-                        self.name, curr_tries, res
+                        self.name, curr_tries + 1, res
                     );
                     thread::sleep(delay);
                 } else {
                     // if it overs the number of retries
-                    // TODO: return err?
                     return res;
                 }
             } else {
@@ -81,12 +80,11 @@ where
                 if let Some((curr_tries, delay)) = iterator.next() {
                     warn!(
                         "The {} operation retries {} times... (result: {:?})",
-                        self.name, curr_tries, res
+                        self.name, curr_tries + 1, res
                     );
                     actix_rt::time::delay_for(delay).await;
                 } else {
                     // if it overs the number of retries
-                    // TODO: return err?
                     return res;
                 }
             } else {

--- a/frame/retrier/src/retry.rs
+++ b/frame/retrier/src/retry.rs
@@ -1,5 +1,10 @@
 #[cfg(feature = "std")]
 use crate::localstd::future::Future;
+#[cfg(feature = "sgx")]
+use crate::localstd::{
+    boxed::Box,
+    string::{String, ToString},
+};
 use crate::localstd::{fmt, result::Result, thread, time::Duration};
 use tracing::warn;
 

--- a/frame/retrier/src/retry.rs
+++ b/frame/retrier/src/retry.rs
@@ -120,6 +120,10 @@ mod tests {
     fn test_fixed_delay_strategy_success() {
         let mut counter = 1..=4;
         let res = Retry::new("test_counter_success", 4, strategy::FixedDelay::new(10))
+            .set_condition(|res| match res {
+                Ok(_) => false,
+                Err(_) => true,
+            })
             .spawn(|| match counter.next() {
                 Some(c) if c == 4 => Ok(c),
                 Some(_) => Err("Not 4"),
@@ -134,13 +138,16 @@ mod tests {
     #[test]
     fn test_fixed_delay_strategy_error() {
         let mut counter = 1..=5;
-        let res = Retry::new("test_counter_error", 3, strategy::FixedDelay::new(10)).spawn(|| {
-            match counter.next() {
+        let res = Retry::new("test_counter_error", 3, strategy::FixedDelay::new(10))
+            .set_condition(|res| match res {
+                Ok(_) => false,
+                Err(_) => true,
+            })
+            .spawn(|| match counter.next() {
                 Some(c) if c == 5 => Ok(c),
                 Some(_) => Err("Some: Not 4"),
                 None => Err("None: Not 4"),
-            }
-        });
+            });
 
         assert_eq!(res, Err("Some: Not 4"));
     }

--- a/modules/anonify-eth-driver/src/eth/deployer.rs
+++ b/modules/anonify-eth-driver/src/eth/deployer.rs
@@ -14,20 +14,23 @@ use web3::types::Address;
 
 /// Define a retry condition of deploying contracts.
 /// If it returns true, retry deploying contracts.
-const fn deployer_retry_condition(err: &HostError) -> bool {
-    match err {
-        HostError::Web3ContractError(web3_err) => match web3_err {
-            web3::contract::Error::Abi(_) => false,
+const fn deployer_retry_condition(res: &Result<Address>) -> bool {
+    match res {
+        Ok(_) => false,
+        Err(err) => match err {
+            HostError::Web3ContractError(web3_err) => match web3_err {
+                web3::contract::Error::Abi(_) => false,
+                _ => true,
+            },
+            HostError::Web3ContractDeployError(web3_err) => match web3_err {
+                web3::contract::deploy::Error::Abi(_) => false,
+                _ => true,
+            },
+            HostError::EcallOutputNotSet => false,
+            // error reading abi and bin path
+            HostError::IoError(_) => false,
             _ => true,
         },
-        HostError::Web3ContractDeployError(web3_err) => match web3_err {
-            web3::contract::deploy::Error::Abi(_) => false,
-            _ => true,
-        },
-        HostError::EcallOutputNotSet => false,
-        // error reading abi and bin path
-        HostError::IoError(_) => false,
-        _ => true,
     }
 }
 

--- a/modules/anonify-eth-driver/src/eth/sender.rs
+++ b/modules/anonify-eth-driver/src/eth/sender.rs
@@ -15,14 +15,17 @@ use web3::types::{Address, H256};
 
 /// Define a retry condition of sending transactions.
 /// If it returns false, don't need to retry sending transactions.
-const fn sender_retry_condition(err: &HostError) -> bool {
-    match err {
-        HostError::Web3ContractError(web3_err) => match web3_err {
-            web3::contract::Error::Abi(_) => false,
+const fn sender_retry_condition(res: &Result<H256>) -> bool {
+    match res {
+        Ok(_) => false,
+        Err(err) => match err {
+            HostError::Web3ContractError(web3_err) => match web3_err {
+                web3::contract::Error::Abi(_) => false,
+                _ => true,
+            },
+            HostError::EcallOutputNotSet => false,
             _ => true,
         },
-        HostError::EcallOutputNotSet => false,
-        _ => true,
     }
 }
 


### PR DESCRIPTION
* remote-attestationにリトライ実装
500, 503のとき、IoErrorのときはリトライ
* リトライ条件をエラー時だけでなく、ステータスコードなどで設定可能に
* remote attestationレスポンスのステータスコード検証追加