### PR TITLE
Implement recover request to key-vault node for AnonifyContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,12 +1400,12 @@ dependencies = [
 name = "erc20-enclave"
 version = "0.1.0"
 dependencies = [
- "anonify-config",
  "anonify-enclave",
  "anyhow 1.0.28",
  "ed25519-dalek",
  "erc20-state-transition",
  "frame-common",
+ "frame-config",
  "frame-enclave",
  "frame-treekem",
  "frame-types",
@@ -3967,9 +3967,9 @@ dependencies = [
 name = "secret-backup-enclave"
 version = "0.1.0"
 dependencies = [
- "anonify-config",
  "anyhow 1.0.28",
  "frame-common",
+ "frame-config",
  "frame-enclave",
  "frame-types",
  "key-vault-commands",
@@ -5305,8 +5305,8 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 name = "unit-tests-enclave"
 version = "0.1.0"
 dependencies = [
- "anonify-config",
  "anonify-enclave",
+ "frame-config",
  "frame-mra-tls",
  "frame-treekem",
  "once_cell 1.4.0 (git+https://github.com/mesalock-linux/once_cell-sgx?rev=sgx_1.1.3)",

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -83,8 +83,6 @@ lazy_static! {
             .expect("Cannot read measurement file");
         EnclaveMeasurement::new_from_dumpfile(content)
     };
-    pub static ref SPID: String = env::var("SPID").expect("SPID is not set");
-    pub static ref SUB_KEY: String = env::var("SUB_KEY").expect("SUB_KEY is not set");
 }
 
 lazy_static! {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -28,20 +28,6 @@ lazy_static! {
         let pem = pem::parse(ias_root_cert).expect("Cannot parse PEM File");
         pem.contents
     };
-    pub static ref ENCLAVE_SIGNED_SO: PathBuf = {
-        let pkg_name = env::var("ENCLAVE_PKG_NAME").expect("ENCLAVE_PKG_NAME is not set");
-        let mut measurement_file_path = PJ_ROOT_DIR.clone();
-
-        let measurement_file = match env::var("BACKUP") {
-            Ok(backup) if backup == "disable" => {
-                format!(".anonify/{}.backup_disabled.signed.so", pkg_name)
-            }
-            _ => format!(".anonify/{}.signed.so", pkg_name),
-        };
-
-        measurement_file_path.push(measurement_file);
-        measurement_file_path
-    };
     pub static ref ENCLAVE_MEASUREMENT: EnclaveMeasurement = {
         let pkg_name = env::var("ENCLAVE_PKG_NAME").expect("ENCLAVE_PKG_NAME is not set");
         let mut measurement_file_path = PJ_ROOT_DIR.clone();

--- a/example/erc20/enclave/Cargo.toml
+++ b/example/erc20/enclave/Cargo.toml
@@ -9,7 +9,7 @@ name = "anonifyenclave"
 crate-type = ["staticlib"]
 
 [dependencies]
-anonify-config = { path = "../../../config", default-features = false, features = ["sgx"]}
+frame-config = { path = "../../../frame/config", default-features = false, features = ["sgx"]}
 frame-enclave = { path = "../../../frame/enclave" }
 frame-types = { path = "../../../frame/types" }
 frame-treekem = { path = "../../../frame/treekem", default-features = false, features = ["sgx"] }

--- a/example/erc20/enclave/src/lib.rs
+++ b/example/erc20/enclave/src/lib.rs
@@ -14,7 +14,7 @@ const ANONIFY_MRENCLAVE_VERSION: usize = 0;
 
 pub static ENCLAVE_CONTEXT: Lazy<AnonifyEnclaveContext> = Lazy::new(|| {
     backtrace::enable_backtrace(
-        &*anonify_config::ENCLAVE_SIGNED_SO,
+        &*frame_config::ENCLAVE_SIGNED_SO,
         backtrace::PrintFormat::Short,
     )
     .unwrap();

--- a/example/secret-backup/enclave/Cargo.toml
+++ b/example/secret-backup/enclave/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 key-vault-commands = { path = "../commands", default-features = false, features = ["sgx"]}
-anonify-config = { path = "../../../config", default-features = false, features = ["sgx"]}
+frame-config = { path = "../../../frame/config", default-features = false, features = ["sgx"]}
 frame-enclave = { path = "../../../frame/enclave" }
 frame-types = { path = "../../../frame/types" }
 frame-common = { path = "../../../frame/common", default-features = false, features = ["sgx"] }

--- a/example/secret-backup/enclave/src/lib.rs
+++ b/example/secret-backup/enclave/src/lib.rs
@@ -14,7 +14,7 @@ const KEY_VAULT_MRENCLAVE_VERSION: usize = 0;
 
 pub static ENCLAVE_CONTEXT: Lazy<KeyVaultEnclaveContext> = Lazy::new(|| {
     backtrace::enable_backtrace(
-        &*anonify_config::ENCLAVE_SIGNED_SO,
+        &*frame_config::ENCLAVE_SIGNED_SO,
         backtrace::PrintFormat::Short,
     )
     .unwrap();

--- a/frame/config/src/envs.rs
+++ b/frame/config/src/envs.rs
@@ -1,6 +1,8 @@
 use crate::local_once_cell::sync::Lazy;
 use crate::localstd::{
     env,
+    ffi::OsStr,
+    path::PathBuf,
     string::{String, ToString},
 };
 
@@ -20,3 +22,32 @@ pub static RETRY_DELAY_MILLS: Lazy<u64> = Lazy::new(|| {
 
 pub static PATH_SECRETS_DIR: Lazy<String> =
     Lazy::new(|| env::var("PATH_SECRETS_DIR").unwrap_or(".anonify/pathsecrets".to_string()));
+
+pub static PJ_ROOT_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    let mut current_dir = env::current_dir().unwrap();
+    loop {
+        if current_dir.file_name() == Some(OsStr::new("anonify")) {
+            break;
+        }
+        if !current_dir.pop() {
+            break;
+        }
+    }
+
+    current_dir
+});
+
+#[cfg(feature = "sgx")]
+pub static ENCLAVE_SIGNED_SO: Lazy<PathBuf> = Lazy::new(|| {
+    let pkg_name = env::var("ENCLAVE_PKG_NAME").expect("ENCLAVE_PKG_NAME is not set");
+    let mut measurement_file_path = PJ_ROOT_DIR.clone();
+
+    let measurement_file = match env::var("BACKUP") {
+        Ok(backup) if backup == "disable" => {
+            format!(".anonify/{}.backup_disabled.signed.so", pkg_name)
+        }
+        _ => format!(".anonify/{}.signed.so", pkg_name),
+    };
+    measurement_file_path.push(measurement_file);
+    measurement_file_path
+});

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -119,15 +119,14 @@ pub trait IdentityKeyOps {
 pub trait GroupKeyOps: Sized {
     fn create_handshake(&self) -> Result<(HandshakeParams, PathSecret)>;
 
-    fn process_handshake(
+    fn process_handshake<F>(
         &mut self,
         store_path_secrets: &StorePathSecrets,
         handshake: &HandshakeParams,
-        spid: &str,
-        ias_url: &str,
-        sub_key: &str,
-        key_vault_url: &str,
-    ) -> Result<()>;
+        recover_path_secret: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(&[u8], u32) -> Result<PathSecret>;
 
     fn encrypt(&self, plaintext: Vec<u8>) -> Result<Ciphertext>;
 
@@ -154,6 +153,8 @@ pub trait QuoteGetter: Sized {
 
 pub trait KeyVaultOps {
     fn backup_path_secret(&self, backup_path_secret: BackupPathSecret) -> Result<()>;
+
+    fn recover_path_secret(&self, ps_id: &[u8], roster_idx: u32) -> Result<PathSecret>;
 
     fn manually_backup_path_secrets_all(
         &self,

--- a/frame/treekem/src/handshake.rs
+++ b/frame/treekem/src/handshake.rs
@@ -19,17 +19,16 @@ pub trait Handshake: Sized {
     fn create_handshake(&self, source: &PathSecretSource) -> Result<(HandshakeParams, PathSecret)>;
 
     /// Process a received handshake from other members.
-    fn process_handshake(
+    fn process_handshake<F>(
         &mut self,
         store_path_secrets: &StorePathSecrets,
         handshake: &HandshakeParams,
         source: &PathSecretSource,
         max_roster_idx: u32,
-        spid: &str,
-        ias_url: &str,
-        sub_key: &str,
-        server_address: &str,
-    ) -> Result<AppKeyChain>;
+        recover_path_secret_from_key_vault: F,
+    ) -> Result<AppKeyChain>
+    where
+        F: FnOnce(&[u8], u32) -> Result<PathSecret>;
 }
 
 // TODO: Does need signature over the group's history?

--- a/frame/treekem/src/test_funcs.rs
+++ b/frame/treekem/src/test_funcs.rs
@@ -6,7 +6,6 @@ use crate::local_rand;
 use crate::local_rand_core::SeedableRng;
 use crate::localstd::env;
 use crate::StorePathSecrets;
-use anonify_config::{SPID, SUB_KEY};
 use frame_config::PATH_SECRETS_DIR;
 
 pub fn init_path_secret_kvs(kvs: &mut PathSecretKVS, until_roster_idx: usize, until_epoch: usize) {
@@ -30,6 +29,8 @@ pub fn do_handshake_three_party(
         .unwrap();
     let ias_url = env::var("IAS_URL").expect("IAS_URL is not set");
     let key_vault_endpoint = env::var("KEY_VAULT_ENDPOINT").expect("KEY_VAULT_ENDPOINT is not set");
+    let spid = env::var("SPID").expect("SPID is not set");
+    let sub_key = env::var("SUB_KEY").expect("SUB_KEY is not set");
     let (handshake, _) = my_group.create_handshake(source).unwrap();
     let store_path_secrets = StorePathSecrets::new(&*PATH_SECRETS_DIR);
 
@@ -39,9 +40,9 @@ pub fn do_handshake_three_party(
             &handshake,
             source,
             max_roster_idx,
-            &*SPID,
+            &spid,
             &ias_url,
-            &*SUB_KEY,
+            &sub_key,
             &key_vault_endpoint,
         )
         .unwrap();
@@ -51,9 +52,9 @@ pub fn do_handshake_three_party(
             &handshake,
             source,
             max_roster_idx,
-            &*SPID,
+            &spid,
             &ias_url,
-            &*SUB_KEY,
+            &sub_key,
             &key_vault_endpoint,
         )
         .unwrap();
@@ -63,9 +64,9 @@ pub fn do_handshake_three_party(
             &handshake,
             source,
             max_roster_idx,
-            &*SPID,
+            &spid,
             &ias_url,
-            &*SUB_KEY,
+            &sub_key,
             &key_vault_endpoint,
         )
         .unwrap();

--- a/frame/treekem/src/test_funcs.rs
+++ b/frame/treekem/src/test_funcs.rs
@@ -5,7 +5,7 @@ use crate::local_anyhow::anyhow;
 use crate::local_rand;
 use crate::local_rand_core::SeedableRng;
 use crate::localstd::env;
-use crate::StorePathSecrets;
+use crate::{PathSecret, StorePathSecrets};
 use frame_config::PATH_SECRETS_DIR;
 
 pub fn init_path_secret_kvs(kvs: &mut PathSecretKVS, until_roster_idx: usize, until_epoch: usize) {
@@ -27,10 +27,6 @@ pub fn do_handshake_three_party(
         .expect("MAX_ROSTER_IDX is not set")
         .parse::<u32>()
         .unwrap();
-    let ias_url = env::var("IAS_URL").expect("IAS_URL is not set");
-    let key_vault_endpoint = env::var("KEY_VAULT_ENDPOINT").expect("KEY_VAULT_ENDPOINT is not set");
-    let spid = env::var("SPID").expect("SPID is not set");
-    let sub_key = env::var("SUB_KEY").expect("SUB_KEY is not set");
     let (handshake, _) = my_group.create_handshake(source).unwrap();
     let store_path_secrets = StorePathSecrets::new(&*PATH_SECRETS_DIR);
 
@@ -40,10 +36,7 @@ pub fn do_handshake_three_party(
             &handshake,
             source,
             max_roster_idx,
-            &spid,
-            &ias_url,
-            &sub_key,
-            &key_vault_endpoint,
+            recover_path_secret_from_key_vault_for_test,
         )
         .unwrap();
     let others_keychain1 = others_group1
@@ -52,10 +45,7 @@ pub fn do_handshake_three_party(
             &handshake,
             source,
             max_roster_idx,
-            &spid,
-            &ias_url,
-            &sub_key,
-            &key_vault_endpoint,
+            recover_path_secret_from_key_vault_for_test,
         )
         .unwrap();
     let others_keychain2 = others_group2
@@ -64,10 +54,7 @@ pub fn do_handshake_three_party(
             &handshake,
             source,
             max_roster_idx,
-            &spid,
-            &ias_url,
-            &sub_key,
-            &key_vault_endpoint,
+            recover_path_secret_from_key_vault_for_test,
         )
         .unwrap();
 
@@ -99,4 +86,29 @@ pub fn encrypt_decrypt_helper(
         },
         None => {}
     };
+}
+
+fn recover_path_secret_from_key_vault_for_test(
+    id: &[u8],
+    roster_idx: u32,
+) -> crate::local_anyhow::Result<PathSecret> {
+    use anonify_config::{ENCLAVE_MEASUREMENT_KEY_VAULT, IAS_ROOT_CERT};
+    use frame_common::crypto::{KeyVaultCmd, KeyVaultRequest, RecoverRequest, RecoveredPathSecret};
+    use frame_mra_tls::{AttestedTlsConfig, Client, ClientConfig};
+
+    let recover_request = RecoverRequest::new(roster_idx, id.to_vec());
+    let ias_url = env::var("IAS_URL").expect("IAS_URL is not set");
+    let key_vault_endpoint = env::var("KEY_VAULT_ENDPOINT").expect("KEY_VAULT_ENDPOINT is not set");
+    let spid = env::var("SPID").expect("SPID is not set");
+    let sub_key = env::var("SUB_KEY").expect("SUB_KEY is not set");
+
+    let attested_tls_config =
+        AttestedTlsConfig::new_by_ra(&spid, &ias_url, &sub_key, IAS_ROOT_CERT.to_vec())?;
+
+    let client_config = ClientConfig::from_attested_tls_config(attested_tls_config)?
+        .set_attestation_report_verifier(IAS_ROOT_CERT.to_vec(), *ENCLAVE_MEASUREMENT_KEY_VAULT);
+    let mut mra_tls_client = Client::new(&key_vault_endpoint, &client_config)?;
+    let backup_request = KeyVaultRequest::new(KeyVaultCmd::Recover, recover_request);
+    let recovered_path_secret: RecoveredPathSecret = mra_tls_client.send_json(backup_request)?;
+    Ok(PathSecret::from(recovered_path_secret.path_secret()))
 }

--- a/modules/anonify-enclave/src/group_key.rs
+++ b/modules/anonify-enclave/src/group_key.rs
@@ -41,24 +41,21 @@ impl GroupKeyOps for GroupKey {
         self.group_state.create_handshake(&self.source)
     }
 
-    fn process_handshake(
+    fn process_handshake<F>(
         &mut self,
         store_path_secrets: &StorePathSecrets,
         handshake: &HandshakeParams,
-        spid: &str,
-        ias_url: &str,
-        sub_key: &str,
-        server_address: &str,
-    ) -> Result<()> {
+        recover_path_secret: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(&[u8], u32) -> Result<PathSecret>,
+    {
         let keychain = self.group_state.process_handshake(
             store_path_secrets,
             handshake,
             &self.source,
             self.max_roster_idx as u32,
-            spid,
-            ias_url,
-            sub_key,
-            server_address,
+            recover_path_secret,
         )?;
         // TODO: If the handshake transaction is flying out the air, wait updating the sender_keychain until the all remaining messages are processed.
         // The number of remaining messages are difference between sender_keychain's generation and receiver_keychain's one.

--- a/modules/anonify-enclave/src/handshake.rs
+++ b/modules/anonify-enclave/src/handshake.rs
@@ -137,19 +137,10 @@ impl EnclaveEngine for HandshakeReceiver {
         let handshake = HandshakeParams::decode(&mut &ecall_input.handshake().handshake()[..])
             .map_err(|_| anyhow!("HandshakeParams::decode Error"))?;
 
-        let spid = enclave_context.spid();
-        let ias_url = enclave_context.ias_url();
-        let sub_key = enclave_context.sub_key();
-        let server_address = enclave_context.key_vault_endpoint();
-        let store_path_secrets = enclave_context.store_path_secrets();
-
         group_key.process_handshake(
-            store_path_secrets,
+            enclave_context.store_path_secrets(),
             &handshake,
-            spid,
-            ias_url,
-            sub_key,
-            server_address,
+            |ps_id, roster_idx| C::recover_path_secret(enclave_context, ps_id, roster_idx),
         )?;
 
         Ok(output::Empty::default())

--- a/tests/units/enclave/Cargo.toml
+++ b/tests/units/enclave/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib"]
 [dependencies]
 frame-treekem = { path = "../../../frame/treekem", default-features = false, features = ["sgx"] }
 frame-mra-tls = { path = "../../../frame/mra-tls" }
-anonify-config = { path = "../../../config", default-features = false, features = ["sgx"] }
+frame-config = { path = "../../../frame/config", default-features = false, features = ["sgx"] }
 anonify-enclave = { path = "../../../modules/anonify-enclave", default-features = false }
 sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git"}
 once_cell = { rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/once_cell-sgx" }

--- a/tests/units/enclave/src/lib.rs
+++ b/tests/units/enclave/src/lib.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 
 static ENABLE_BACKTRACE: Lazy<()> = Lazy::new(|| {
     backtrace::enable_backtrace(
-        &*anonify_config::ENCLAVE_SIGNED_SO,
+        &*frame_config::ENCLAVE_SIGNED_SO,
         backtrace::PrintFormat::Short,
     )
     .unwrap();


### PR DESCRIPTION
* Key-Vaultノードでへのリカバリリクエストを `AnonifyContext` に実装（ClientConfigが毎回使いまわせる）
* `ENCLAVE_SIGNED_SO`などanonify-configから削除