### PR TITLE
状態遷移APIの一般化

### DIFF
--- a/example/erc20/api/src/lib.rs
+++ b/example/erc20/api/src/lib.rs
@@ -16,6 +16,117 @@ use web3::types::H256;
 //  GET and POST types
 // ----------------------
 
+pub mod state {
+    pub mod post {
+        use super::super::*;
+        big_array! { BigArray; }
+
+        #[derive(Clone, Deserialize, Serialize)]
+        pub struct Request {
+            pub function: String,
+            #[serde(with = "BigArray")]
+            pub sig: [u8; SIGNATURE_LENGTH],
+            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
+            pub challenge: [u8; 32],
+            pub encrypted_command: EciesCiphertext,
+        }
+
+        impl Request {
+            pub fn new<R: Rng>(
+                function: impl ToString,
+                keypair: &Keypair,
+                encrypted_command: EciesCiphertext,
+                rng: &mut R,
+            ) -> Self {
+                let challenge: [u8; 32] = rng.gen();
+                let sig = keypair.sign(&challenge[..]);
+                assert!(keypair.verify(&challenge, &sig).is_ok());
+
+                Request {
+                    function: function.to_string(),
+                    sig: sig.to_bytes(),
+                    pubkey: keypair.public.to_bytes(),
+                    challenge,
+                    encrypted_command,
+                }
+            }
+
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
+                let sig = Signature::from_bytes(&self.sig)?;
+                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
+
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
+            }
+        }
+
+        impl fmt::Debug for Request {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    "Request {{ function: {}, sig: {:?}, pubkey: {:?}, challenge: {:?}, encrypted_command: {:?} }}",
+                    &self.function,
+                    &self.sig[..],
+                    self.pubkey,
+                    self.challenge,
+                    self.encrypted_command
+                )
+            }
+        }
+
+        #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+        pub struct Response(pub H256);
+    }
+
+    pub mod get {
+        use super::super::*;
+        big_array! { BigArray; }
+
+        #[derive(Clone, Deserialize, Serialize)]
+        pub struct Request {
+            #[serde(with = "BigArray")]
+            pub sig: [u8; SIGNATURE_LENGTH],
+            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
+            pub challenge: [u8; 32],
+        }
+
+        impl Request {
+            pub fn new<R: Rng>(keypair: &Keypair, rng: &mut R) -> Self {
+                let challenge: [u8; 32] = rng.gen();
+                let sig = keypair.sign(&challenge[..]);
+                assert!(keypair.verify(&challenge, &sig).is_ok());
+
+                Request {
+                    sig: sig.to_bytes(),
+                    pubkey: keypair.public.to_bytes(),
+                    challenge,
+                }
+            }
+
+            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
+                let sig = Signature::from_bytes(&self.sig)?;
+                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
+
+                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
+            }
+        }
+
+        impl fmt::Debug for Request {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?} }}",
+                    &self.sig[..],
+                    self.pubkey,
+                    self.challenge
+                )
+            }
+        }
+
+        #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Default, Deserialize, Serialize)]
+        pub struct Response<S: State>(pub S);
+    }
+}
+
 pub mod deploy {
     pub mod post {
         use super::super::*;
@@ -54,348 +165,12 @@ pub mod update_mrenclave {
     }
 }
 
-pub mod init_state {
-    pub mod post {
-        use super::super::*;
-        big_array! { BigArray; }
-
-        #[derive(Clone, Deserialize, Serialize)]
-        pub struct Request {
-            #[serde(with = "BigArray")]
-            pub sig: [u8; SIGNATURE_LENGTH],
-            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
-            pub challenge: [u8; 32],
-            pub encrypted_total_supply: EciesCiphertext,
-        }
-
-        impl Request {
-            pub fn new<R: Rng>(
-                keypair: &Keypair,
-                encrypted_total_supply: EciesCiphertext,
-                rng: &mut R,
-            ) -> Self {
-                let challenge: [u8; 32] = rng.gen();
-                let sig = keypair.sign(&challenge[..]);
-                assert!(keypair.verify(&challenge, &sig).is_ok());
-
-                Request {
-                    sig: sig.to_bytes(),
-                    pubkey: keypair.public.to_bytes(),
-                    challenge,
-                    encrypted_total_supply,
-                }
-            }
-
-            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
-                let sig = Signature::from_bytes(&self.sig)?;
-                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
-
-                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
-            }
-        }
-
-        impl fmt::Debug for Request {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?}, encrypted_total_supply: {:?} }}",
-                    &self.sig[..],
-                    self.pubkey,
-                    self.challenge,
-                    self.encrypted_total_supply
-                )
-            }
-        }
-
-        #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
-        pub struct Response(pub H256);
-    }
-}
-
 pub mod encrypting_key {
     pub mod get {
         use super::super::*;
 
         #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
         pub struct Response(pub DhPubKey);
-    }
-}
-
-pub mod transfer {
-    pub mod post {
-        use super::super::*;
-        big_array! { BigArray; }
-
-        #[derive(Clone, Deserialize, Serialize)]
-        pub struct Request {
-            #[serde(with = "BigArray")]
-            pub sig: [u8; SIGNATURE_LENGTH],
-            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
-            pub challenge: [u8; 32],
-            pub encrypted_transfer_cmd: EciesCiphertext,
-        }
-
-        impl Request {
-            pub fn new<R: Rng>(
-                keypair: &Keypair,
-                encrypted_transfer_cmd: EciesCiphertext,
-                rng: &mut R,
-            ) -> Self {
-                let challenge: [u8; 32] = rng.gen();
-                let sig = keypair.sign(&challenge[..]);
-                assert!(keypair.verify(&challenge, &sig).is_ok());
-
-                Request {
-                    sig: sig.to_bytes(),
-                    pubkey: keypair.public.to_bytes(),
-                    challenge,
-                    encrypted_transfer_cmd,
-                }
-            }
-
-            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
-                let sig = Signature::from_bytes(&self.sig)?;
-                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
-
-                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
-            }
-        }
-
-        impl fmt::Debug for Request {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?}, encrypted_transfer_cmd: {:?} }}",
-                    &self.sig[..], self.pubkey, self.challenge, self.encrypted_transfer_cmd,
-                )
-            }
-        }
-
-        #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
-        pub struct Response(pub H256);
-    }
-}
-
-pub mod approve {
-    pub mod post {
-        use super::super::*;
-        big_array! { BigArray; }
-
-        #[derive(Clone, Deserialize, Serialize)]
-        pub struct Request {
-            #[serde(with = "BigArray")]
-            pub sig: [u8; SIGNATURE_LENGTH],
-            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
-            pub challenge: [u8; 32],
-            pub encrypted_approve_cmd: EciesCiphertext,
-        }
-
-        impl Request {
-            pub fn new<R: Rng>(
-                keypair: &Keypair,
-                encrypted_approve_cmd: EciesCiphertext,
-                rng: &mut R,
-            ) -> Self {
-                let challenge: [u8; 32] = rng.gen();
-                let sig = keypair.sign(&challenge[..]);
-                assert!(keypair.verify(&challenge, &sig).is_ok());
-
-                Request {
-                    sig: sig.to_bytes(),
-                    pubkey: keypair.public.to_bytes(),
-                    challenge,
-                    encrypted_approve_cmd,
-                }
-            }
-
-            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
-                let sig = Signature::from_bytes(&self.sig)?;
-                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
-
-                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
-            }
-        }
-
-        impl fmt::Debug for Request {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?}, encrypted_approve_cmd: {:?} }}",
-                    &self.sig[..], self.pubkey, self.challenge, self.encrypted_approve_cmd
-                )
-            }
-        }
-
-        #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
-        pub struct Response(pub H256);
-    }
-}
-
-pub mod transfer_from {
-    pub mod post {
-        use super::super::*;
-        big_array! { BigArray; }
-
-        #[derive(Clone, Deserialize, Serialize)]
-        pub struct Request {
-            #[serde(with = "BigArray")]
-            pub sig: [u8; SIGNATURE_LENGTH],
-            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
-            pub challenge: [u8; 32],
-            pub encrypted_transfer_from_cmd: EciesCiphertext,
-        }
-
-        impl Request {
-            pub fn new<R: Rng>(
-                keypair: &Keypair,
-                encrypted_transfer_from_cmd: EciesCiphertext,
-                rng: &mut R,
-            ) -> Self {
-                let challenge: [u8; 32] = rng.gen();
-                let sig = keypair.sign(&challenge[..]);
-                assert!(keypair.verify(&challenge, &sig).is_ok());
-
-                Request {
-                    sig: sig.to_bytes(),
-                    pubkey: keypair.public.to_bytes(),
-                    challenge,
-                    encrypted_transfer_from_cmd,
-                }
-            }
-
-            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
-                let sig = Signature::from_bytes(&self.sig)?;
-                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
-
-                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
-            }
-        }
-
-        impl fmt::Debug for Request {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?}, encrypted_transfer_from_cmd: {:?} }}",
-                    &self.sig[..], self.pubkey, self.challenge, self.encrypted_transfer_from_cmd
-                )
-            }
-        }
-
-        #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
-        pub struct Response(pub H256);
-    }
-}
-
-pub mod mint {
-    pub mod post {
-        use super::super::*;
-        big_array! { BigArray; }
-
-        #[derive(Clone, Deserialize, Serialize)]
-        pub struct Request {
-            #[serde(with = "BigArray")]
-            pub sig: [u8; SIGNATURE_LENGTH],
-            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
-            pub challenge: [u8; 32],
-            pub encrypted_mint_cmd: EciesCiphertext,
-        }
-
-        impl Request {
-            pub fn new<R: Rng>(
-                keypair: &Keypair,
-                encrypted_mint_cmd: EciesCiphertext,
-                rng: &mut R,
-            ) -> Self {
-                let challenge: [u8; 32] = rng.gen();
-                let sig = keypair.sign(&challenge[..]);
-                assert!(keypair.verify(&challenge, &sig).is_ok());
-
-                Request {
-                    sig: sig.to_bytes(),
-                    pubkey: keypair.public.to_bytes(),
-                    challenge,
-                    encrypted_mint_cmd,
-                }
-            }
-
-            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
-                let sig = Signature::from_bytes(&self.sig)?;
-                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
-
-                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
-            }
-        }
-
-        impl fmt::Debug for Request {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?}, encrypted_mint_cmd: {:?} }}",
-                    &self.sig[..], self.pubkey, self.challenge, self.encrypted_mint_cmd
-                )
-            }
-        }
-
-        #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
-        pub struct Response(pub H256);
-    }
-}
-
-pub mod burn {
-    pub mod post {
-        use super::super::*;
-        big_array! { BigArray; }
-
-        #[derive(Clone, Deserialize, Serialize)]
-        pub struct Request {
-            #[serde(with = "BigArray")]
-            pub sig: [u8; SIGNATURE_LENGTH],
-            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
-            pub challenge: [u8; 32],
-            pub encrypted_burn_cmd: EciesCiphertext,
-        }
-
-        impl Request {
-            pub fn new<R: Rng>(
-                keypair: &Keypair,
-                encrypted_burn_cmd: EciesCiphertext,
-                rng: &mut R,
-            ) -> Self {
-                let challenge: [u8; 32] = rng.gen();
-                let sig = keypair.sign(&challenge[..]);
-                assert!(keypair.verify(&challenge, &sig).is_ok());
-
-                Request {
-                    sig: sig.to_bytes(),
-                    pubkey: keypair.public.to_bytes(),
-                    challenge,
-                    encrypted_burn_cmd,
-                }
-            }
-
-            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
-                let sig = Signature::from_bytes(&self.sig)?;
-                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
-
-                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
-            }
-        }
-
-        impl fmt::Debug for Request {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?}, encrypted_burn_cmd: {:?} }}",
-                    &self.sig[..],
-                    self.pubkey,
-                    self.challenge,
-                    self.encrypted_burn_cmd
-                )
-            }
-        }
-
-        #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
-        pub struct Response(pub H256);
     }
 }
 
@@ -453,57 +228,6 @@ pub mod allowance {
                     self.pubkey,
                     self.challenge,
                     self.spender
-                )
-            }
-        }
-
-        #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Default, Deserialize, Serialize)]
-        pub struct Response<S: State>(pub S);
-    }
-}
-
-pub mod state {
-    pub mod get {
-        use super::super::*;
-        big_array! { BigArray; }
-
-        #[derive(Clone, Deserialize, Serialize)]
-        pub struct Request {
-            #[serde(with = "BigArray")]
-            pub sig: [u8; SIGNATURE_LENGTH],
-            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
-            pub challenge: [u8; 32],
-        }
-
-        impl Request {
-            pub fn new<R: Rng>(keypair: &Keypair, rng: &mut R) -> Self {
-                let challenge: [u8; 32] = rng.gen();
-                let sig = keypair.sign(&challenge[..]);
-                assert!(keypair.verify(&challenge, &sig).is_ok());
-
-                Request {
-                    sig: sig.to_bytes(),
-                    pubkey: keypair.public.to_bytes(),
-                    challenge,
-                }
-            }
-
-            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
-                let sig = Signature::from_bytes(&self.sig)?;
-                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
-
-                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
-            }
-        }
-
-        impl fmt::Debug for Request {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?} }}",
-                    &self.sig[..],
-                    self.pubkey,
-                    self.challenge
                 )
             }
         }

--- a/example/erc20/cli/src/commands.rs
+++ b/example/erc20/cli/src/commands.rs
@@ -87,9 +87,10 @@ pub(crate) fn init_state<R: Rng>(
     let encrypted_total_supply = EciesCiphertext::encrypt(&encrypting_key, init_state.encode())
         .map_err(|e| anyhow!("{:?}", e))?;
 
-    let req = erc20_api::init_state::post::Request::new(&keypair, encrypted_total_supply, rng);
+    let req =
+        erc20_api::state::post::Request::new("init_state", &keypair, encrypted_total_supply, rng);
     let res = Client::new()
-        .post(&format!("{}/api/v1/init_state", &anonify_url))
+        .post(&format!("{}/api/v1/state", &anonify_url))
         .json(&req)
         .send()?
         .text()?;
@@ -117,9 +118,10 @@ pub(crate) fn transfer<R: Rng>(
     let encrypted_transfer_cmd = EciesCiphertext::encrypt(&encrypting_key, transfer_cmd.encode())
         .map_err(|e| anyhow!("{:?}", e))?;
 
-    let req = erc20_api::transfer::post::Request::new(&keypair, encrypted_transfer_cmd, rng);
+    let req =
+        erc20_api::state::post::Request::new("transfer", &keypair, encrypted_transfer_cmd, rng);
     let res = Client::new()
-        .post(&format!("{}/api/v1/transfer", &anonify_url))
+        .post(&format!("{}/api/v1/state", &anonify_url))
         .json(&req)
         .send()?
         .text()?;
@@ -147,9 +149,9 @@ pub(crate) fn approve<R: Rng>(
     let encrypted_approve_cmd = EciesCiphertext::encrypt(&encrypting_key, approve_cmd.encode())
         .map_err(|e| anyhow!("{:?}", e))?;
 
-    let req = erc20_api::approve::post::Request::new(&keypair, encrypted_approve_cmd, rng);
+    let req = erc20_api::state::post::Request::new("approve", &keypair, encrypted_approve_cmd, rng);
     let res = Client::new()
-        .post(&format!("{}/api/v1/approve", &anonify_url))
+        .post(&format!("{}/api/v1/state", &anonify_url))
         .json(&req)
         .send()?
         .text()?;
@@ -180,10 +182,14 @@ pub(crate) fn transfer_from<R: Rng>(
         EciesCiphertext::encrypt(&encrypting_key, transfer_from_cmd.encode())
             .map_err(|e| anyhow!("{:?}", e))?;
 
-    let req =
-        erc20_api::transfer_from::post::Request::new(&keypair, encrypted_transfer_from_cmd, rng);
+    let req = erc20_api::state::post::Request::new(
+        "transfer_from",
+        &keypair,
+        encrypted_transfer_from_cmd,
+        rng,
+    );
     let res = Client::new()
-        .post(&format!("{}/api/v1/transfer_from", &anonify_url))
+        .post(&format!("{}/api/v1/state", &anonify_url))
         .json(&req)
         .send()?
         .text()?;
@@ -211,9 +217,9 @@ pub(crate) fn mint<R: Rng>(
     let encrypted_mint_cmd = EciesCiphertext::encrypt(&encrypting_key, mint_cmd.encode())
         .map_err(|e| anyhow!("{:?}", e))?;
 
-    let req = erc20_api::mint::post::Request::new(&keypair, encrypted_mint_cmd, rng);
+    let req = erc20_api::state::post::Request::new("mint", &keypair, encrypted_mint_cmd, rng);
     let res = Client::new()
-        .post(&format!("{}/api/v1/mint", &anonify_url))
+        .post(&format!("{}/api/v1/state", &anonify_url))
         .json(&req)
         .send()?
         .text()?;
@@ -239,9 +245,9 @@ pub(crate) fn burn<R: Rng>(
     let encrypted_burn_cmd = EciesCiphertext::encrypt(&encrypting_key, burn_cmd.encode())
         .map_err(|e| anyhow!("{:?}", e))?;
 
-    let req = erc20_api::burn::post::Request::new(&keypair, encrypted_burn_cmd, rng);
+    let req = erc20_api::state::post::Request::new("burn", &keypair, encrypted_burn_cmd, rng);
     let res = Client::new()
-        .post(&format!("{}/api/v1/burn", &anonify_url))
+        .post(&format!("{}/api/v1/state", &anonify_url))
         .json(&req)
         .send()?
         .text()?;

--- a/example/erc20/cli/src/commands.rs
+++ b/example/erc20/cli/src/commands.rs
@@ -88,7 +88,7 @@ pub(crate) fn init_state<R: Rng>(
         .map_err(|e| anyhow!("{:?}", e))?;
 
     let req =
-        erc20_api::state::post::Request::new("init_state", &keypair, encrypted_total_supply, rng);
+        erc20_api::state::post::Request::new("construct", &keypair, encrypted_total_supply, rng);
     let res = Client::new()
         .post(&format!("{}/api/v1/state", &anonify_url))
         .json(&req)

--- a/example/erc20/server/src/handlers.rs
+++ b/example/erc20/server/src/handlers.rs
@@ -103,9 +103,9 @@ where
     Ok(HttpResponse::Ok().json(erc20_api::update_mrenclave::post::Response(tx_hash)))
 }
 
-pub async fn handle_init_state<D, S, W>(
+pub async fn handle_send_command<D, S, W>(
     server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::init_state::post::Request>,
+    req: web::Json<erc20_api::state::post::Request>,
 ) -> Result<HttpResponse>
 where
     D: Deployer,
@@ -120,14 +120,13 @@ where
     let access_right = req
         .into_access_right()
         .map_err(|e| ServerError::from(anyhow!("{:?}", e)))?;
-    let encrypted_total_supply = req.encrypted_total_supply.clone();
 
     let tx_hash = server
         .dispatcher
         .send_command::<CallName, _>(
             access_right,
-            encrypted_total_supply,
-            "construct",
+            req.encrypted_command.clone(),
+            &req.function,
             sender_address,
             DEFAULT_GAS,
             SEND_COMMAND_CMD,
@@ -135,182 +134,7 @@ where
         .await
         .map_err(|e| ServerError::from(e))?;
 
-    Ok(HttpResponse::Ok().json(erc20_api::init_state::post::Response(tx_hash)))
-}
-
-pub async fn handle_transfer<D, S, W>(
-    server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::transfer::post::Request>,
-) -> Result<HttpResponse>
-where
-    D: Deployer,
-    S: Sender,
-    W: Watcher,
-{
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, &server.password)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-    let access_right = req
-        .into_access_right()
-        .map_err(|e| ServerError::from(anyhow!("{:?}", e)))?;
-    let encrypted_transfer_cmd = req.encrypted_transfer_cmd.clone();
-
-    let tx_hash = server
-        .dispatcher
-        .send_command::<CallName, _>(
-            access_right,
-            encrypted_transfer_cmd,
-            "transfer",
-            sender_address,
-            DEFAULT_GAS,
-            SEND_COMMAND_CMD,
-        )
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
-    Ok(HttpResponse::Ok().json(erc20_api::transfer::post::Response(tx_hash)))
-}
-
-pub async fn handle_approve<D, S, W>(
-    server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::approve::post::Request>,
-) -> Result<HttpResponse>
-where
-    D: Deployer,
-    S: Sender,
-    W: Watcher,
-{
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, &server.password)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-    let access_right = req
-        .into_access_right()
-        .map_err(|e| ServerError::from(anyhow!("{:?}", e)))?;
-    let encrypted_approve_cmd = req.encrypted_approve_cmd.clone();
-
-    let tx_hash = server
-        .dispatcher
-        .send_command::<CallName, _>(
-            access_right,
-            encrypted_approve_cmd,
-            "approve",
-            sender_address,
-            DEFAULT_GAS,
-            SEND_COMMAND_CMD,
-        )
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
-    Ok(HttpResponse::Ok().json(erc20_api::approve::post::Response(tx_hash)))
-}
-
-pub async fn handle_mint<D, S, W>(
-    server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::mint::post::Request>,
-) -> Result<HttpResponse>
-where
-    D: Deployer,
-    S: Sender,
-    W: Watcher,
-{
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, &server.password)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-    let access_right = req
-        .into_access_right()
-        .map_err(|e| ServerError::from(anyhow!("{:?}", e)))?;
-    let encrypted_mint_cmd = req.encrypted_mint_cmd.clone();
-
-    let tx_hash = server
-        .dispatcher
-        .send_command::<CallName, _>(
-            access_right,
-            encrypted_mint_cmd,
-            "mint",
-            sender_address,
-            DEFAULT_GAS,
-            SEND_COMMAND_CMD,
-        )
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
-    Ok(HttpResponse::Ok().json(erc20_api::mint::post::Response(tx_hash)))
-}
-
-pub async fn handle_burn<D, S, W>(
-    server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::burn::post::Request>,
-) -> Result<HttpResponse>
-where
-    D: Deployer,
-    S: Sender,
-    W: Watcher,
-{
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, &server.password)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-    let access_right = req
-        .into_access_right()
-        .map_err(|e| ServerError::from(anyhow!("{:?}", e)))?;
-    let encrypted_burn_cmd = req.encrypted_burn_cmd.clone();
-
-    let tx_hash = server
-        .dispatcher
-        .send_command::<CallName, _>(
-            access_right,
-            encrypted_burn_cmd,
-            "burn",
-            sender_address,
-            DEFAULT_GAS,
-            SEND_COMMAND_CMD,
-        )
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
-    Ok(HttpResponse::Ok().json(erc20_api::burn::post::Response(tx_hash)))
-}
-
-pub async fn handle_transfer_from<D, S, W>(
-    server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::transfer_from::post::Request>,
-) -> Result<HttpResponse>
-where
-    D: Deployer,
-    S: Sender,
-    W: Watcher,
-{
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, &server.password)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-    let access_right = req
-        .into_access_right()
-        .map_err(|e| ServerError::from(anyhow!("{:?}", e)))?;
-    let encrypted_transfer_from_cmd = req.encrypted_transfer_from_cmd.clone();
-
-    let tx_hash = server
-        .dispatcher
-        .send_command::<CallName, _>(
-            access_right,
-            encrypted_transfer_from_cmd,
-            "transfer_from",
-            sender_address,
-            DEFAULT_GAS,
-            SEND_COMMAND_CMD,
-        )
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
-    Ok(HttpResponse::Ok().json(erc20_api::transfer_from::post::Response(tx_hash)))
+    Ok(HttpResponse::Ok().json(erc20_api::state::post::Response(tx_hash)))
 }
 
 pub async fn handle_key_rotation<D, S, W>(

--- a/example/erc20/server/src/main.rs
+++ b/example/erc20/server/src/main.rs
@@ -37,32 +37,12 @@ async fn main() -> io::Result<()> {
                 web::post().to(handle_update_mrenclave::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/transfer",
-                web::post().to(handle_transfer::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/key_rotation",
                 web::post().to(handle_key_rotation::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/approve",
-                web::post().to(handle_approve::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/transfer_from",
-                web::post().to(handle_transfer_from::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/mint",
-                web::post().to(handle_mint::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/burn",
-                web::post().to(handle_burn::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/allowance",

--- a/example/erc20/server/src/tests.rs
+++ b/example/erc20/server/src/tests.rs
@@ -65,12 +65,8 @@ async fn test_multiple_messages() {
                 web::post().to(handle_deploy::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/transfer",
-                web::post().to(handle_transfer::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/balance_of",
@@ -109,7 +105,7 @@ async fn test_multiple_messages() {
 
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/init_state")
+        .uri("/api/v1/state")
         .set_json(&init_100_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -128,7 +124,7 @@ async fn test_multiple_messages() {
     // Sending five messages before receiving any messages
     for _ in 0..5 {
         let req = test::TestRequest::post()
-            .uri("/api/v1/transfer")
+            .uri("/api/v1/state")
             .set_json(&transfer_10_req)
             .to_request();
         let resp = test::call_service(&mut app, req).await;
@@ -170,12 +166,8 @@ async fn test_skip_invalid_event() {
                 web::get().to(handle_start_sync_bc::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/transfer",
-                web::post().to(handle_transfer::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/balance_of",
@@ -211,7 +203,7 @@ async fn test_skip_invalid_event() {
 
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/init_state")
+        .uri("/api/v1/state")
         .set_json(&init_100_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -228,7 +220,7 @@ async fn test_skip_invalid_event() {
 
     let transfer_110_req = transfer_110_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/transfer")
+        .uri("/api/v1/state")
         .set_json(&transfer_110_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -245,7 +237,7 @@ async fn test_skip_invalid_event() {
 
     let transfer_10_req = transfer_10_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/transfer")
+        .uri("/api/v1/state")
         .set_json(&transfer_10_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -287,12 +279,8 @@ async fn test_node_recovery() {
                 web::get().to(handle_start_sync_bc::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/transfer",
-                web::post().to(handle_transfer::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/balance_of",
@@ -329,8 +317,8 @@ async fn test_node_recovery() {
                 web::get().to(handle_set_contract_addr::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/transfer",
-                web::post().to(handle_transfer::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/encrypting_key",
@@ -366,7 +354,7 @@ async fn test_node_recovery() {
 
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/init_state")
+        .uri("/api/v1/state")
         .set_json(&init_100_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -383,7 +371,7 @@ async fn test_node_recovery() {
 
     let transfer_10_req_ = transfer_10_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/transfer")
+        .uri("/api/v1/state")
         .set_json(&transfer_10_req_)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -440,7 +428,7 @@ async fn test_node_recovery() {
 
     let transfer_10_req = transfer_10_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/transfer")
+        .uri("/api/v1/state")
         .set_json(&transfer_10_req)
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
@@ -499,12 +487,8 @@ async fn test_join_group_then_handshake() {
                 web::post().to(handle_join_group::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/transfer",
-                web::post().to(handle_transfer::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/balance_of",
@@ -583,7 +567,7 @@ async fn test_join_group_then_handshake() {
 
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/init_state")
+        .uri("/api/v1/state")
         .set_json(&init_100_req)
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
@@ -607,7 +591,7 @@ async fn test_join_group_then_handshake() {
 
     let transfer_10_req = transfer_10_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/transfer")
+        .uri("/api/v1/state")
         .set_json(&transfer_10_req)
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
@@ -679,13 +663,14 @@ async fn verify_encrypting_key<P: AsRef<Path>>(
 }
 
 // to me
-fn init_100_req(enc_key: &DhPubKey) -> erc20_api::init_state::post::Request {
+fn init_100_req(enc_key: &DhPubKey) -> erc20_api::state::post::Request {
     let init_100 = construct {
         total_supply: U64::from_raw(100),
     };
     let enc_cmd = EciesCiphertext::encrypt(&enc_key, init_100.encode()).unwrap();
 
-    erc20_api::init_state::post::Request {
+    erc20_api::state::post::Request {
+        function: "init_state".to_string(),
         sig: [
             236, 103, 17, 252, 166, 199, 9, 46, 200, 107, 188, 0, 37, 111, 83, 105, 175, 81, 231,
             14, 81, 100, 221, 89, 102, 172, 30, 96, 15, 128, 117, 146, 181, 221, 149, 206, 163,
@@ -700,12 +685,12 @@ fn init_100_req(enc_key: &DhPubKey) -> erc20_api::init_state::post::Request {
             244, 158, 183, 202, 237, 236, 27, 67, 39, 95, 178, 136, 235, 162, 188, 106, 52, 56, 6,
             245, 3, 101, 33, 155, 58, 175, 168, 63, 73, 125, 205, 225,
         ],
-        encrypted_total_supply: enc_cmd,
+        encrypted_command: enc_cmd,
     }
 }
 
 // from me to other
-fn transfer_10_req(enc_key: &DhPubKey) -> erc20_api::transfer::post::Request {
+fn transfer_10_req(enc_key: &DhPubKey) -> erc20_api::state::post::Request {
     let transfer_10 = transfer {
         amount: U64::from_raw(10),
         recipient: AccountId([
@@ -715,7 +700,8 @@ fn transfer_10_req(enc_key: &DhPubKey) -> erc20_api::transfer::post::Request {
     };
     let enc_cmd = EciesCiphertext::encrypt(&enc_key, transfer_10.encode()).unwrap();
 
-    erc20_api::transfer::post::Request {
+    erc20_api::state::post::Request {
+        function: "transfer".to_string(),
         sig: [
             227, 77, 52, 167, 149, 64, 24, 23, 103, 227, 13, 120, 90, 186, 1, 62, 110, 60, 186,
             247, 143, 247, 19, 71, 85, 191, 224, 5, 38, 219, 96, 44, 196, 154, 181, 50, 99, 58, 20,
@@ -730,12 +716,12 @@ fn transfer_10_req(enc_key: &DhPubKey) -> erc20_api::transfer::post::Request {
             157, 61, 16, 189, 40, 124, 88, 101, 19, 36, 155, 229, 245, 123, 189, 124, 222, 114,
             215, 186, 25, 30, 135, 114, 237, 169, 138, 122, 81, 61, 43, 183,
         ],
-        encrypted_transfer_cmd: enc_cmd,
+        encrypted_command: enc_cmd,
     }
 }
 
 // from me to other
-fn transfer_110_req(enc_key: &DhPubKey) -> erc20_api::transfer::post::Request {
+fn transfer_110_req(enc_key: &DhPubKey) -> erc20_api::state::post::Request {
     let transfer_110 = transfer {
         amount: U64::from_raw(110),
         recipient: AccountId([
@@ -745,7 +731,8 @@ fn transfer_110_req(enc_key: &DhPubKey) -> erc20_api::transfer::post::Request {
     };
     let enc_cmd = EciesCiphertext::encrypt(&enc_key, transfer_110.encode()).unwrap();
 
-    erc20_api::transfer::post::Request {
+    erc20_api::state::post::Request {
+        function: "transfer".to_string(),
         sig: [
             227, 77, 52, 167, 149, 64, 24, 23, 103, 227, 13, 120, 90, 186, 1, 62, 110, 60, 186,
             247, 143, 247, 19, 71, 85, 191, 224, 5, 38, 219, 96, 44, 196, 154, 181, 50, 99, 58, 20,
@@ -760,7 +747,7 @@ fn transfer_110_req(enc_key: &DhPubKey) -> erc20_api::transfer::post::Request {
             157, 61, 16, 189, 40, 124, 88, 101, 19, 36, 155, 229, 245, 123, 189, 124, 222, 114,
             215, 186, 25, 30, 135, 114, 237, 169, 138, 122, 81, 61, 43, 183,
         ],
-        encrypted_transfer_cmd: enc_cmd,
+        encrypted_command: enc_cmd,
     }
 }
 

--- a/example/erc20/server/src/tests.rs
+++ b/example/erc20/server/src/tests.rs
@@ -670,7 +670,7 @@ fn init_100_req(enc_key: &DhPubKey) -> erc20_api::state::post::Request {
     let enc_cmd = EciesCiphertext::encrypt(&enc_key, init_100.encode()).unwrap();
 
     erc20_api::state::post::Request {
-        function: "init_state".to_string(),
+        function: "construct".to_string(),
         sig: [
             236, 103, 17, 252, 166, 199, 9, 46, 200, 107, 188, 0, 37, 111, 83, 105, 175, 81, 231,
             14, 81, 100, 221, 89, 102, 172, 30, 96, 15, 128, 117, 146, 181, 221, 149, 206, 163,

--- a/example/secret-backup/server/src/tests.rs
+++ b/example/secret-backup/server/src/tests.rs
@@ -75,8 +75,8 @@ async fn test_backup_path_secret() {
                 web::post().to(handle_deploy::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/balance_of",
@@ -135,7 +135,7 @@ async fn test_backup_path_secret() {
     // Init state
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/init_state")
+        .uri("/api/v1/state")
         .set_json(&init_100_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -225,8 +225,8 @@ async fn test_recover_without_key_vault() {
                 web::post().to(handle_deploy::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/balance_of",
@@ -285,7 +285,7 @@ async fn test_recover_without_key_vault() {
     // Init state
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/init_state")
+        .uri("/api/v1/state")
         .set_json(&init_100_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -369,8 +369,8 @@ async fn test_manually_backup_all() {
                 web::post().to(handle_deploy::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/balance_of",
@@ -423,7 +423,7 @@ async fn test_manually_backup_all() {
     // Init state
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/init_state")
+        .uri("/api/v1/state")
         .set_json(&init_100_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -529,8 +529,8 @@ async fn test_manually_recover_all() {
                 web::post().to(handle_deploy::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/init_state",
-                web::post().to(handle_init_state::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/balance_of",
@@ -550,9 +550,6 @@ async fn test_manually_recover_all() {
             ),
     )
     .await;
-
-    let path_secrets_dir =
-        PJ_ROOT_DIR.join(&env::var("PATH_SECRETS_DIR").expect("PATH_SECRETS_DIR is not set"));
 
     // Deploy
     let req = test::TestRequest::post().uri("/api/v1/deploy").to_request();
@@ -583,7 +580,7 @@ async fn test_manually_recover_all() {
     // Init state
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
-        .uri("/api/v1/init_state")
+        .uri("/api/v1/state")
         .set_json(&init_100_req)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -783,13 +780,14 @@ async fn verify_encrypting_key<P: AsRef<Path>>(
     encrypting_key
 }
 
-fn init_100_req(enc_key: &DhPubKey) -> erc20_api::init_state::post::Request {
+fn init_100_req(enc_key: &DhPubKey) -> erc20_api::state::post::Request {
     let init_100 = construct {
         total_supply: U64::from_raw(100),
     };
     let enc_cmd = EciesCiphertext::encrypt(&enc_key, init_100.encode()).unwrap();
 
-    erc20_api::init_state::post::Request {
+    erc20_api::state::post::Request {
+        function: "construct".to_string(),
         sig: [
             236, 103, 17, 252, 166, 199, 9, 46, 200, 107, 188, 0, 37, 111, 83, 105, 175, 81, 231,
             14, 81, 100, 221, 89, 102, 172, 30, 96, 15, 128, 117, 146, 181, 221, 149, 206, 163,
@@ -804,7 +802,7 @@ fn init_100_req(enc_key: &DhPubKey) -> erc20_api::init_state::post::Request {
             244, 158, 183, 202, 237, 236, 27, 67, 39, 95, 178, 136, 235, 162, 188, 106, 52, 56, 6,
             245, 3, 101, 33, 155, 58, 175, 168, 63, 73, 125, 205, 225,
         ],
-        encrypted_total_supply: enc_cmd,
+        encrypted_command: enc_cmd,
     }
 }
 


### PR DESCRIPTION
related: #379 
* (POST) `api/v1/state` に実行する状態遷移関数 `function` のパラメタを含めて定義