### PR TITLE
クライアントリクエストをjson化 (send_command)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,6 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "actix-rt",
- "anonify-ecall-types",
  "anonify-eth-driver",
  "erc20-state-transition",
  "ethabi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,7 +1363,6 @@ dependencies = [
 name = "erc20-cli"
 version = "0.1.0"
 dependencies = [
- "anonify-ecall-types",
  "anonify-wallet",
  "anyhow 1.0.34",
  "clap",
@@ -1375,7 +1374,6 @@ dependencies = [
  "erc20-api",
  "ethabi",
  "frame-common",
- "frame-runtime",
  "frame-treekem",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/example/erc20/cli/Cargo.toml
+++ b/example/erc20/cli/Cargo.toml
@@ -6,10 +6,8 @@ edition = "2018"
 
 [dependencies]
 erc20-api = { path = "../api" }
-anonify-ecall-types = { path = "../../../modules/anonify-ecall-types" }
 frame-common = { path = "../../../frame/common" }
 frame-treekem = { path = "../../../frame/treekem" }
-frame-runtime = { path = "../../../frame/runtime" }
 anonify-wallet = { path = "../../../wallet" }
 reqwest = "0.9"
 clap = "~2.32"

--- a/example/erc20/cli/src/commands.rs
+++ b/example/erc20/cli/src/commands.rs
@@ -82,10 +82,13 @@ pub(crate) fn init_state<R: Rng>(
     let password = prompt_password(term)?;
     let keypair = get_keypair_from_keystore(root_dir, &password, index)?;
     let access_policy = Ed25519ChallengeResponse::new_from_keypair(keypair, rng);
-    let init_state = json!({
-        "total_supply": U64::from_raw(total_supply),
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_command": {
+            "total_supply": U64::from_raw(total_supply),
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(access_policy, init_state, "construct");
     let encrypted_req =
         EciesCiphertext::encrypt(&encrypting_key, serde_json::to_vec(&req).unwrap())
             .map_err(|e| anyhow!("{:?}", e))?;

--- a/example/erc20/cli/src/commands.rs
+++ b/example/erc20/cli/src/commands.rs
@@ -3,13 +3,11 @@ use crate::{
     error::Result,
     term::Term,
 };
-use anonify_ecall_types::input;
 use anonify_wallet::{DirOperations, KeyFile, KeystoreDirectory, WalletDirectory};
 use anyhow::anyhow;
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use ed25519_dalek::Keypair;
 use frame_common::crypto::{AccountId, Ed25519ChallengeResponse};
-use frame_runtime::primitives::U64;
 use frame_treekem::{DhPubKey, EciesCiphertext};
 use rand::Rng;
 use reqwest::Client;
@@ -85,7 +83,7 @@ pub(crate) fn init_state<R: Rng>(
     let req = json!({
         "access_policy": access_policy,
         "runtime_command": {
-            "total_supply": U64::from_raw(total_supply),
+            "total_supply": total_supply,
         },
         "cmd_name": "construct",
     });
@@ -116,11 +114,14 @@ pub(crate) fn transfer<R: Rng>(
     let password = prompt_password(term)?;
     let keypair = get_keypair_from_keystore(root_dir, &password, index)?;
     let access_policy = Ed25519ChallengeResponse::new_from_keypair(keypair, rng);
-    let transfer_cmd = json!({
-        "amount": U64::from_raw(amount),
-        "recipient": recipient,
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_command": {
+            "amount": amount,
+            "recipient": recipient,
+        },
+        "cmd_name": "transfer",
     });
-    let req = input::Command::new(access_policy, transfer_cmd, "transfer");
     let encrypted_transfer_cmd =
         EciesCiphertext::encrypt(&encrypting_key, serde_json::to_vec(&req).unwrap())
             .map_err(|e| anyhow!("{:?}", e))?;
@@ -150,11 +151,14 @@ pub(crate) fn approve<R: Rng>(
     let password = prompt_password(term)?;
     let keypair = get_keypair_from_keystore(root_dir, &password, index)?;
     let access_policy = Ed25519ChallengeResponse::new_from_keypair(keypair, rng);
-    let approve_cmd = json!({
-        "amount": U64::from_raw(amount),
-        "spender": spender,
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_command": {
+            "amount": amount,
+            "spender": spender,
+        },
+        "cmd_name": "approve",
     });
-    let req = input::Command::new(access_policy, approve_cmd, "approve");
     let encrypted_approve_cmd =
         EciesCiphertext::encrypt(&encrypting_key, serde_json::to_vec(&req).unwrap())
             .map_err(|e| anyhow!("{:?}", e))?;
@@ -182,14 +186,16 @@ pub(crate) fn transfer_from<R: Rng>(
 ) -> Result<()> {
     let password = prompt_password(term)?;
     let keypair = get_keypair_from_keystore(root_dir, &password, index)?;
-
     let access_policy = Ed25519ChallengeResponse::new_from_keypair(keypair, rng);
-    let transfer_from_cmd = json!({
-        "amount": U64::from_raw(amount),
-        "owner": owner,
-        "recipient": recipient,
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_command": {
+            "amount": amount,
+            "owner": owner,
+            "recipient": recipient,
+        },
+        "cmd_name": "transfer_from",
     });
-    let req = input::Command::new(access_policy, transfer_from_cmd, "transfer_from");
     let encrypted_transfer_from_cmd =
         EciesCiphertext::encrypt(&encrypting_key, serde_json::to_vec(&req).unwrap())
             .map_err(|e| anyhow!("{:?}", e))?;
@@ -218,13 +224,15 @@ pub(crate) fn mint<R: Rng>(
 ) -> Result<()> {
     let password = prompt_password(term)?;
     let keypair = get_keypair_from_keystore(root_dir, &password, index)?;
-
     let access_policy = Ed25519ChallengeResponse::new_from_keypair(keypair, rng);
-    let mint_cmd = json!({
-        "amount": U64::from_raw(amount),
-        "recipient": recipient,
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_command": {
+            "amount": amount,
+            "recipient": recipient,
+        },
+        "cmd_name": "mint",
     });
-    let req = input::Command::new(access_policy, mint_cmd, "mint");
     let encrypted_mint_cmd =
         EciesCiphertext::encrypt(&encrypting_key, serde_json::to_vec(&req).unwrap())
             .map_err(|e| anyhow!("{:?}", e))?;
@@ -250,12 +258,14 @@ pub(crate) fn burn<R: Rng>(
 ) -> Result<()> {
     let password = prompt_password(term)?;
     let keypair = get_keypair_from_keystore(root_dir, &password, index)?;
-
     let access_policy = Ed25519ChallengeResponse::new_from_keypair(keypair, rng);
-    let burn_cmd = json!({
-        "amount": U64::from_raw(amount),
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_command": {
+            "amount": amount,
+        },
+        "cmd_name": "burn",
     });
-    let req = input::Command::new(access_policy, burn_cmd, "burn");
     let encrypted_burn_cmd =
         EciesCiphertext::encrypt(&encrypting_key, serde_json::to_vec(&req).unwrap())
             .map_err(|e| anyhow!("{:?}", e))?;

--- a/example/erc20/state-transition/src/lib.rs
+++ b/example/erc20/state-transition/src/lib.rs
@@ -23,7 +23,6 @@ impl_memory! {
 }
 
 impl_runtime! {
-    #[fn_id=0]
     pub fn construct(
         self,
         sender: AccountId,
@@ -36,7 +35,6 @@ impl_runtime! {
         return_update![owner_account_id, sender_balance, total_supply]
     }
 
-    #[fn_id=1]
     pub fn transfer(
         self,
         sender: AccountId,
@@ -54,7 +52,6 @@ impl_runtime! {
         return_update![sender_update, recipient_update]
     }
 
-    #[fn_id=2]
     pub fn approve(
         self,
         owner: AccountId,
@@ -74,7 +71,6 @@ impl_runtime! {
         return_update![owner_approved_update]
     }
 
-    #[fn_id=3]
     pub fn transfer_from(
         self,
         sender: AccountId,
@@ -107,7 +103,6 @@ impl_runtime! {
         return_update![owner_approved_update, owner_balance_update, recipient_balance_update]
     }
 
-    #[fn_id=4]
     pub fn mint(
         self,
         executer: AccountId,
@@ -126,7 +121,6 @@ impl_runtime! {
         return_update![recipient_balance_update, total_supply_update]
     }
 
-    #[fn_id=5]
     pub fn burn(
         self,
         sender: AccountId,
@@ -142,7 +136,6 @@ impl_runtime! {
         return_update![balance_update, total_supply_update]
     }
 
-    #[fn_id=6]
     pub fn balance_of(
         self,
         caller: AccountId
@@ -151,7 +144,6 @@ impl_runtime! {
         get_state![balance]
     }
 
-    #[fn_id=7]
     pub fn approved(
         self,
         caller: AccountId
@@ -160,7 +152,6 @@ impl_runtime! {
         get_state![approved]
     }
 
-    #[fn_id=8]
     pub fn total_supply(
         self,
         caller: AccountId
@@ -169,7 +160,6 @@ impl_runtime! {
         get_state![total_supply]
     }
 
-    #[fn_id=9]
     pub fn owner(
         self,
         caller: AccountId

--- a/frame/runtime/src/impls.rs
+++ b/frame/runtime/src/impls.rs
@@ -59,7 +59,7 @@ macro_rules! impl_runtime {
 macro_rules! __impl_inner_runtime {
     (@imp
         $(
-            pub fn $fn_name:ident(
+            pub fn $cmd_name:ident(
                 $runtime:ident,
                 $sender:ident : $account_id:ty
                 $(, $param_name:ident : $param:ty )*
@@ -72,7 +72,7 @@ macro_rules! __impl_inner_runtime {
             #[derive(Serialize, Deserialize, Encode, Decode, Debug, Clone, Default)]
             #[serde(crate = "crate::serde")]
             #[allow(non_camel_case_types)]
-            pub struct $fn_name {
+            pub struct $cmd_name {
                 $( pub $param_name: $param, )*
             }
 
@@ -83,7 +83,7 @@ macro_rules! __impl_inner_runtime {
         pub enum CallKind {
             $(
                 #[allow(non_camel_case_types)]
-                $fn_name($fn_name),
+                $cmd_name($cmd_name),
             )*
         }
 
@@ -97,11 +97,11 @@ macro_rules! __impl_inner_runtime {
 
             fn new(cmd_name: &str, cmd: serde_json::Value) -> Result<Self> {
                 match cmd_name {
-                    $( stringify!($fn_name) => {
+                    $( stringify!($cmd_name) => {
                         if cmd.is_null() {
-                            Ok(CallKind::$fn_name($fn_name::default()))
+                            Ok(CallKind::$cmd_name($cmd_name::default()))
                         } else {
-                            Ok(CallKind::$fn_name(serde_json::from_value(cmd)?))
+                            Ok(CallKind::$cmd_name(serde_json::from_value(cmd)?))
                         }
                     },)*
                     _ => return Err(anyhow!("Invalid Command Name")),
@@ -110,10 +110,10 @@ macro_rules! __impl_inner_runtime {
 
             fn execute(self, runtime: Self::R, my_account_id: AccountId) -> Result<ReturnState<Self::S>> {
                 match self {
-                    $( CallKind::$fn_name($fn_name) => {
-                        runtime.$fn_name(
+                    $( CallKind::$cmd_name($cmd_name) => {
+                        runtime.$cmd_name(
                             my_account_id,
-                            $( $fn_name.$param_name, )*
+                            $( $cmd_name.$param_name, )*
                         )
                     }, )*
                     _ => unimplemented!()
@@ -169,7 +169,7 @@ macro_rules! __impl_inner_runtime {
             }
 
             $(
-                pub fn $fn_name (
+                pub fn $cmd_name (
                     $runtime,
                     $sender: $account_id
                     $(, $param_name : $param )*

--- a/frame/runtime/src/impls.rs
+++ b/frame/runtime/src/impls.rs
@@ -59,7 +59,6 @@ macro_rules! impl_runtime {
 macro_rules! __impl_inner_runtime {
     (@imp
         $(
-            #[fn_id=$fn_id:expr]
             pub fn $fn_name:ident(
                 $runtime:ident,
                 $sender:ident : $account_id:ty

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -23,7 +23,7 @@ pub mod input {
         #[serde(deserialize_with = "AP::deserialize")]
         pub access_policy: AP,
         pub runtime_command: serde_json::Value,
-        pub fn_name: String,
+        pub cmd_name: String,
     }
 
     impl<AP> Default for Command<AP>
@@ -34,7 +34,7 @@ pub mod input {
             Self {
                 access_policy: AP::default(),
                 runtime_command: serde_json::Value::Null,
-                fn_name: String::default(),
+                cmd_name: String::default(),
             }
         }
     }
@@ -48,12 +48,12 @@ pub mod input {
         pub fn new(
             access_policy: AP,
             runtime_command: serde_json::Value,
-            fn_name: impl ToString,
+            cmd_name: impl ToString,
         ) -> Self {
             Command {
                 access_policy,
                 runtime_command,
-                fn_name: fn_name.to_string(),
+                cmd_name: cmd_name.to_string(),
             }
         }
 
@@ -61,8 +61,8 @@ pub mod input {
             &self.access_policy
         }
 
-        pub fn fn_name(&self) -> &str {
-            &self.fn_name
+        pub fn cmd_name(&self) -> &str {
+            &self.cmd_name
         }
     }
 
@@ -123,16 +123,16 @@ pub mod input {
     #[derive(Encode, Decode, Debug, Clone, Default)]
     pub struct GetState<AP: AccessPolicy> {
         access_policy: AP,
-        pub fn_name: Vec<u8>, // codec does not support for `String`
+        pub cmd_name: Vec<u8>, // codec does not support for `String`
     }
 
     impl<AP: AccessPolicy> EcallInput for GetState<AP> {}
 
     impl<AP: AccessPolicy> GetState<AP> {
-        pub fn new(access_policy: AP, fn_name: String) -> Self {
+        pub fn new(access_policy: AP, cmd_name: String) -> Self {
             GetState {
                 access_policy,
-                fn_name: fn_name.into_bytes(),
+                cmd_name: cmd_name.into_bytes(),
             }
         }
 
@@ -140,8 +140,8 @@ pub mod input {
             &self.access_policy
         }
 
-        pub fn fn_name(&self) -> &str {
-            str::from_utf8(&self.fn_name).unwrap()
+        pub fn cmd_name(&self) -> &str {
+            str::from_utf8(&self.cmd_name).unwrap()
         }
     }
 

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -81,7 +81,6 @@ where
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        // TODO: decrypt
         Ok(Self {
             ecall_input: ciphertext,
             ap: PhantomData,

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -143,7 +143,7 @@ where
     AP: AccessPolicy,
 {
     pub fn new(my_account_id: AccountId, ecall_input: input::Command<AP>) -> Result<Self> {
-        let call_kind = R::C::new(ecall_input.fn_name(), ecall_input.runtime_command.clone())?;
+        let call_kind = R::C::new(ecall_input.cmd_name(), ecall_input.runtime_command.clone())?;
 
         Ok(Commands {
             my_account_id,

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -313,7 +313,7 @@ impl<AP: AccessPolicy> EnclaveEngine for GetState<AP> {
         let account_id = self.ecall_input.access_policy().into_account_id();
         let user_state = C::get_state_by_cmd_name::<_, R, _>(
             enclave_context.clone(),
-            self.ecall_input.fn_name(),
+            self.ecall_input.cmd_name(),
             account_id,
         )?;
 

--- a/modules/anonify-enclave/src/handshake.rs
+++ b/modules/anonify-enclave/src/handshake.rs
@@ -120,7 +120,6 @@ impl EnclaveEngine for HandshakeReceiver {
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        // TODO: decrypt
         Ok(Self {
             ecall_input: ciphertext,
         })

--- a/modules/anonify-eth-driver/src/workflow.rs
+++ b/modules/anonify-eth-driver/src/workflow.rs
@@ -289,15 +289,15 @@ pub mod host_input {
 
     pub struct GetState<AP: AccessPolicy> {
         access_policy: AP,
-        fn_name: String,
+        cmd_name: String,
         ecall_cmd: u32,
     }
 
     impl<AP: AccessPolicy> GetState<AP> {
-        pub fn new(access_policy: AP, fn_name: String, ecall_cmd: u32) -> Self {
+        pub fn new(access_policy: AP, cmd_name: String, ecall_cmd: u32) -> Self {
             GetState {
                 access_policy,
-                fn_name,
+                cmd_name,
                 ecall_cmd,
             }
         }
@@ -308,7 +308,7 @@ pub mod host_input {
         type HostOutput = host_output::GetState;
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
-            let ecall_input = Self::EcallInput::new(self.access_policy, self.fn_name);
+            let ecall_input = Self::EcallInput::new(self.access_policy, self.cmd_name);
 
             Ok((ecall_input, Self::HostOutput::new()))
         }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -11,7 +11,6 @@ frame-common = { path = "../../frame/common" }
 frame-runtime = { path = "../../frame/runtime" }
 frame-host = { path = "../../frame/host" }
 anonify-eth-driver = { path = "../../modules/anonify-eth-driver" }
-anonify-ecall-types = { path = "../../modules/anonify-ecall-types" }
 erc20-state-transition = { path = "../../example/erc20/state-transition" }
 actix-rt = "1.1"
 tracing = "0.1"

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -105,10 +105,13 @@ async fn test_integration_eth_construct() {
     // Init state
     let total_supply = U64::from_raw(100);
     let pubkey = get_encrypting_key(&contract_addr, &dispatcher).await;
-    let init_cmd = json!({
-        "total_supply": total_supply,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "total_supply": total_supply,
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(my_access_policy.clone(), init_cmd, "construct");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -1,9 +1,8 @@
 #[macro_use]
 extern crate lazy_static;
-use anonify_ecall_types::input;
 use anonify_eth_driver::{dispatcher::*, eth::*, EventCache};
 use codec::{Decode, Encode};
-use erc20_state_transition::{approve, burn, cmd::*, construct, mint, transfer, transfer_from};
+use erc20_state_transition::cmd::*;
 use ethabi::Contract as ContractABI;
 use frame_common::{
     crypto::{AccountId, Ed25519ChallengeResponse, COMMON_ACCESS_POLICY},
@@ -192,11 +191,13 @@ async fn test_auto_notification() {
     // Init state
     let pubkey = get_encrypting_key(&contract_addr, &dispatcher).await;
     let total_supply = U64::from_raw(100);
-
-    let init_cmd = json!({
-        "total_supply": total_supply,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "total_supply": total_supply,
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(my_access_policy.clone(), init_cmd, "construct");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -229,11 +230,14 @@ async fn test_auto_notification() {
     // Send a transaction to contract
     let amount = U64::from_raw(30);
     let recipient = other_access_policy.into_account_id();
-    let transfer_cmd = json!({
-        "amount": amount,
-        "recipient": recipient,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "amount": amount,
+            "recipient": recipient,
+        },
+        "cmd_name": "transfer",
     });
-    let req = input::Command::new(my_access_policy.clone(), transfer_cmd, "transfer");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -304,10 +308,13 @@ async fn test_integration_eth_transfer() {
     let total_supply = U64::from_raw(100);
     let pubkey = get_encrypting_key(&contract_addr, &dispatcher).await;
 
-    let init_cmd = json!({
-        "total_supply": total_supply,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "total_supply": total_supply,
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(my_access_policy.clone(), init_cmd, "construct");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -345,11 +352,14 @@ async fn test_integration_eth_transfer() {
     // Send a transaction to contract
     let amount = U64::from_raw(30);
     let recipient = other_access_policy.into_account_id();
-    let transfer_cmd = json!({
-        "amount": amount,
-        "recipient": recipient,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "amount": amount,
+            "recipient": recipient,
+        },
+        "cmd_name": "transfer",
     });
-    let req = input::Command::new(my_access_policy.clone(), transfer_cmd, "transfer");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -438,10 +448,13 @@ async fn test_key_rotation() {
     // init state
     let total_supply = U64::from_raw(100);
     let pubkey = get_encrypting_key(&contract_addr, &dispatcher).await;
-    let init_cmd = json!({
-        "total_supply": total_supply,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "total_supply": total_supply,
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(my_access_policy.clone(), init_cmd, "construct");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -520,10 +533,13 @@ async fn test_integration_eth_approve() {
     // Init state
     let total_supply = U64::from_raw(100);
     let pubkey = get_encrypting_key(&contract_addr, &dispatcher).await;
-    let init_cmd = json!({
-        "total_supply": total_supply,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "total_supply": total_supply,
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(my_access_policy.clone(), init_cmd, "construct");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -557,11 +573,14 @@ async fn test_integration_eth_approve() {
     // Send a transaction to contract
     let amount = U64::from_raw(30);
     let spender = other_access_policy.into_account_id();
-    let approve_cmd = json!({
-        "amount": amount,
-        "spender": spender,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "amount": amount,
+            "spender": spender,
+        },
+        "cmd_name": "approve",
     });
-    let req = input::Command::new(my_access_policy.clone(), approve_cmd, "approve");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -637,10 +656,13 @@ async fn test_integration_eth_transfer_from() {
     // Init state
     let total_supply = U64::from_raw(100);
     let pubkey = get_encrypting_key(&contract_addr, &dispatcher).await;
-    let init_cmd = json!({
-        "total_supply": total_supply,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "total_supply": total_supply,
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(my_access_policy.clone(), init_cmd, "construct");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -691,11 +713,14 @@ async fn test_integration_eth_transfer_from() {
     // Send a transaction to contract
     let amount = U64::from_raw(30);
     let spender = other_access_policy.into_account_id();
-    let approve_cmd = json!({
-        "amount": amount,
-        "spender": spender,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "amount": amount,
+            "spender": spender,
+        },
+        "cmd_name": "approve",
     });
-    let req = input::Command::new(my_access_policy.clone(), approve_cmd, "approve");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -751,16 +776,15 @@ async fn test_integration_eth_transfer_from() {
     let amount = U64::from_raw(20);
     let owner = my_access_policy.into_account_id();
     let recipient = third_access_policy.into_account_id();
-    let transfer_from_cmd = json!({
-        "owner": owner,
-        "recipient": recipient,
-        "amount": amount,
+    let req = json!({
+        "access_policy": other_access_policy.clone(),
+        "runtime_command": {
+            "owner": owner,
+            "recipient": recipient,
+            "amount": amount,
+        },
+        "cmd_name": "transfer_from",
     });
-    let req = input::Command::new(
-        other_access_policy.clone(),
-        transfer_from_cmd,
-        "transfer_from",
-    );
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -852,10 +876,13 @@ async fn test_integration_eth_mint() {
     // Init state
     let total_supply = U64::from_raw(100);
     let pubkey = get_encrypting_key(&contract_addr, &dispatcher).await;
-    let init_cmd = json!({
-        "total_supply": total_supply,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "total_supply": total_supply,
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(my_access_policy.clone(), init_cmd, "construct");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -879,11 +906,14 @@ async fn test_integration_eth_mint() {
     // transit state
     let amount = U64::from_raw(50);
     let recipient = other_access_policy.into_account_id();
-    let mint_cmd = json!({
-        "amount": amount,
-        "recipient": recipient,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "amount": amount,
+            "recipient": recipient,
+        },
+        "cmd_name": "mint",
     });
-    let req = input::Command::new(my_access_policy.clone(), mint_cmd, "mint");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -958,10 +988,13 @@ async fn test_integration_eth_burn() {
     // Init state
     let total_supply = U64::from_raw(100);
     let pubkey = get_encrypting_key(&contract_addr, &dispatcher).await;
-    let init_cmd = json!({
-        "total_supply": total_supply,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "total_supply": total_supply,
+        },
+        "cmd_name": "construct",
     });
-    let req = input::Command::new(my_access_policy.clone(), init_cmd, "construct");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -985,11 +1018,14 @@ async fn test_integration_eth_burn() {
     // Send a transaction to contract
     let amount = U64::from_raw(30);
     let recipient = other_access_policy.into_account_id();
-    let transfer_cmd = json!({
-        "amount": amount,
-        "recipient": recipient,
+    let req = json!({
+        "access_policy": my_access_policy.clone(),
+        "runtime_command": {
+            "amount": amount,
+            "recipient": recipient,
+        },
+        "cmd_name": "transfer",
     });
-    let req = input::Command::new(my_access_policy.clone(), transfer_cmd, "transfer");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
@@ -1011,10 +1047,13 @@ async fn test_integration_eth_burn() {
 
     // Send a transaction to contract
     let amount = U64::from_raw(20);
-    let burn_cmd = json!({
-        "amount": amount,
+    let req = json!({
+        "access_policy": other_access_policy.clone(),
+        "runtime_command": {
+            "amount": amount,
+        },
+        "cmd_name": "burn",
     });
-    let req = input::Command::new(other_access_policy.clone(), burn_cmd, "burn");
     let encrypted_command =
         EciesCiphertext::encrypt(&pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher


### PR DESCRIPTION
* anonify-ecall-typesを使わずjsonのみでreq表現 in CLI
* state-transitionからfn_id消去
* 命名：`fn_name`から`cmd_name`へ変更