### PR TITLE
`GET: /api/v1/state` のアップデート

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.27",
  "tokio 0.2.22",
  "tokio-util 0.3.1",
@@ -30,7 +30,7 @@ dependencies = [
  "either",
  "futures-util",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-proto",
  "trust-dns-resolver",
 ]
@@ -68,7 +68,7 @@ dependencies = [
  "itoa 0.4.6",
  "language-tags",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime",
  "percent-encoding 2.1.0",
  "pin-project 1.0.1",
@@ -100,7 +100,7 @@ checksum = "bbd1f7dbda1645bf7da33554db60891755f6c01c1b2169e2f4c492098d30c235"
 dependencies = [
  "bytestring",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.4.2",
  "serde 1.0.117",
 ]
@@ -132,7 +132,7 @@ dependencies = [
  "actix-utils",
  "futures-channel",
  "futures-util",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio",
  "mio-uds",
  "num_cpus",
@@ -160,7 +160,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2",
 ]
 
@@ -173,7 +173,7 @@ dependencies = [
  "derive_more",
  "futures-channel",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus",
  "parking_lot 0.11.0",
  "threadpool",
@@ -206,7 +206,7 @@ dependencies = [
  "futures-channel",
  "futures-sink",
  "futures-util",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.27",
  "slab",
 ]
@@ -237,7 +237,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "fxhash",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime",
  "pin-project 1.0.1",
  "regex 1.4.2",
@@ -531,7 +531,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
  "futures-core",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime",
  "percent-encoding 2.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -874,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2db2df1ebc842c41fd2c4ae5b5a577faf63bd5151b953db752fc686812bee318"
 dependencies = [
  "clap",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "serde 1.0.117",
@@ -1055,7 +1055,7 @@ dependencies = [
  "cookie 0.12.0",
  "failure",
  "idna 0.1.5",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix",
  "serde 1.0.117",
  "serde_json 1.0.59",
@@ -1374,7 +1374,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.4.2",
  "termcolor",
 ]
@@ -1409,7 +1409,7 @@ dependencies = [
  "ethabi",
  "frame-common",
  "frame-treekem",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
  "serde_json 1.0.59",
@@ -2018,7 +2018,7 @@ dependencies = [
  "futures 0.1.30",
  "http 0.1.21",
  "indexmap",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab",
  "string",
  "tokio-io",
@@ -2280,7 +2280,7 @@ dependencies = [
  "httparse",
  "iovec",
  "itoa 0.4.6",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2",
  "rustc_version",
  "time 0.1.44",
@@ -2523,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0745a6379e3edc893c84ec203589790774e4247420033e71a76d3ab4687991fa"
 dependencies = [
  "futures 0.1.30",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.117",
  "serde_derive 1.0.117",
  "serde_json 1.0.59",
@@ -2716,20 +2716,20 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.8"
-source = "git+https://github.com/mesalock-linux/log-sgx#76b29e33718e0ce45587ce16af7abae1afc2f674"
-dependencies = [
- "cfg-if 0.1.10",
- "sgx_tstd",
-]
-
-[[package]]
-name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "log"
+version = "0.4.11"
+source = "git+https://github.com/mesalock-linux/log-sgx#5a057d237cf96e9137de08387eb70105d5705648"
+dependencies = [
+ "cfg-if 0.1.10",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -2831,7 +2831,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1",
  "net2",
  "slab",
@@ -2844,7 +2844,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio",
  "miow 0.3.5",
  "winapi 0.3.9",
@@ -2891,7 +2891,7 @@ checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -3767,7 +3767,7 @@ dependencies = [
  "http 0.1.21",
  "hyper 0.12.35",
  "hyper-tls 0.3.2",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime",
  "mime_guess",
  "native-tls",
@@ -3880,7 +3880,7 @@ version = "0.16.0"
 source = "git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3#d51a1bc80fddf5e18cf68688e81f49b5663ca7c9"
 dependencies = [
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.8",
+ "log 0.4.11 (git+https://github.com/mesalock-linux/log-sgx)",
  "ring 0.16.19",
  "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx)",
  "sgx_tstd",
@@ -3894,7 +3894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
  "base64 0.13.0",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.15",
  "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.3",
@@ -3906,7 +3906,7 @@ version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.8",
+ "log 0.4.11 (git+https://github.com/mesalock-linux/log-sgx)",
  "ring 0.16.19",
  "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx)",
  "sgx_tstd",
@@ -4476,7 +4476,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures 0.3.7",
  "httparse",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1",
 ]
@@ -4980,7 +4980,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5003,7 +5003,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.30",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio",
  "num_cpus",
  "parking_lot 0.9.0",
@@ -5048,7 +5048,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.30",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus",
  "slab",
  "tokio-executor",
@@ -5085,7 +5085,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.11",
  "tokio 0.2.22",
 ]
@@ -5100,7 +5100,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.2.4",
  "tokio 0.3.6",
 ]
@@ -5127,7 +5127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.11",
  "tracing-attributes",
  "tracing-core",
@@ -5170,7 +5170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-core",
 ]
 
@@ -5218,7 +5218,7 @@ dependencies = [
  "futures 0.3.7",
  "idna 0.2.0",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.4.2",
  "thiserror 1.0.22",
@@ -5237,7 +5237,7 @@ dependencies = [
  "futures 0.3.7",
  "ipconfig",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache",
  "resolv-conf",
  "smallvec 1.4.2",
@@ -5438,7 +5438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.30",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock",
 ]
 
@@ -5448,7 +5448,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock",
 ]
 
@@ -5482,7 +5482,7 @@ checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.48",
@@ -5547,7 +5547,7 @@ dependencies = [
  "hyper-proxy",
  "hyper-tls 0.4.3",
  "jsonrpc-core",
- "log 0.4.11",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls",
  "parking_lot 0.11.0",
  "pin-project 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "parking_lot 0.10.2",
+ "serde_json 1.0.59",
  "sgx_types 1.1.3",
  "thiserror 1.0.22",
  "tracing",
@@ -1356,6 +1357,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.117",
  "serde-big-array 0.2.0",
+ "serde_json 1.0.59",
  "web3",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "anonify-ecall-types",
  "anyhow 1.0.34",
  "async-trait",
+ "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek",
  "ethabi",
  "frame-common",
@@ -1468,9 +1469,6 @@ name = "erc20-state-transition"
 version = "0.1.0"
 dependencies = [
  "frame-runtime",
- "serde 1.0.117",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git)",
- "serde_json 1.0.51",
  "sgx_tstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "pin-project 0.4.27",
  "tokio 0.2.22",
  "tokio-util 0.3.1",
@@ -30,7 +30,7 @@ dependencies = [
  "either",
  "futures-util",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "trust-dns-proto",
  "trust-dns-resolver",
 ]
@@ -68,7 +68,7 @@ dependencies = [
  "itoa 0.4.6",
  "language-tags",
  "lazy_static",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "mime",
  "percent-encoding 2.1.0",
  "pin-project 1.0.1",
@@ -100,7 +100,7 @@ checksum = "bbd1f7dbda1645bf7da33554db60891755f6c01c1b2169e2f4c492098d30c235"
 dependencies = [
  "bytestring",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "regex 1.4.2",
  "serde 1.0.117",
 ]
@@ -132,7 +132,7 @@ dependencies = [
  "actix-utils",
  "futures-channel",
  "futures-util",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "mio",
  "mio-uds",
  "num_cpus",
@@ -160,7 +160,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "socket2",
 ]
 
@@ -173,7 +173,7 @@ dependencies = [
  "derive_more",
  "futures-channel",
  "lazy_static",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "num_cpus",
  "parking_lot 0.11.0",
  "threadpool",
@@ -206,7 +206,7 @@ dependencies = [
  "futures-channel",
  "futures-sink",
  "futures-util",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "pin-project 0.4.27",
  "slab",
 ]
@@ -237,7 +237,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "fxhash",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "mime",
  "pin-project 1.0.1",
  "regex 1.4.2",
@@ -531,7 +531,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
  "futures-core",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "mime",
  "percent-encoding 2.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -874,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2db2df1ebc842c41fd2c4ae5b5a577faf63bd5151b953db752fc686812bee318"
 dependencies = [
  "clap",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "serde 1.0.117",
@@ -1055,7 +1055,7 @@ dependencies = [
  "cookie 0.12.0",
  "failure",
  "idna 0.1.5",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "publicsuffix",
  "serde 1.0.117",
  "serde_json 1.0.59",
@@ -1374,7 +1374,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "regex 1.4.2",
  "termcolor",
 ]
@@ -1409,7 +1409,7 @@ dependencies = [
  "ethabi",
  "frame-common",
  "frame-treekem",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
  "serde_json 1.0.59",
@@ -2018,7 +2018,7 @@ dependencies = [
  "futures 0.1.30",
  "http 0.1.21",
  "indexmap",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "slab",
  "string",
  "tokio-io",
@@ -2280,7 +2280,7 @@ dependencies = [
  "httparse",
  "iovec",
  "itoa 0.4.6",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "net2",
  "rustc_version",
  "time 0.1.44",
@@ -2523,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0745a6379e3edc893c84ec203589790774e4247420033e71a76d3ab4687991fa"
 dependencies = [
  "futures 0.1.30",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "serde 1.0.117",
  "serde_derive 1.0.117",
  "serde_json 1.0.59",
@@ -2716,20 +2716,20 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+version = "0.4.8"
+source = "git+https://github.com/mesalock-linux/log-sgx#76b29e33718e0ce45587ce16af7abae1afc2f674"
 dependencies = [
  "cfg-if 0.1.10",
+ "sgx_tstd",
 ]
 
 [[package]]
 name = "log"
 version = "0.4.11"
-source = "git+https://github.com/mesalock-linux/log-sgx#5a057d237cf96e9137de08387eb70105d5705648"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
- "sgx_tstd",
 ]
 
 [[package]]
@@ -2831,7 +2831,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "miow 0.2.1",
  "net2",
  "slab",
@@ -2844,7 +2844,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "mio",
  "miow 0.3.5",
  "winapi 0.3.9",
@@ -2891,7 +2891,7 @@ checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -3767,7 +3767,7 @@ dependencies = [
  "http 0.1.21",
  "hyper 0.12.35",
  "hyper-tls 0.3.2",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "mime",
  "mime_guess",
  "native-tls",
@@ -3880,7 +3880,7 @@ version = "0.16.0"
 source = "git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3#d51a1bc80fddf5e18cf68688e81f49b5663ca7c9"
 dependencies = [
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.11 (git+https://github.com/mesalock-linux/log-sgx)",
+ "log 0.4.8",
  "ring 0.16.19",
  "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx)",
  "sgx_tstd",
@@ -3894,7 +3894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
  "base64 0.13.0",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "ring 0.16.15",
  "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.3",
@@ -3906,7 +3906,7 @@ version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.11 (git+https://github.com/mesalock-linux/log-sgx)",
+ "log 0.4.8",
  "ring 0.16.19",
  "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx)",
  "sgx_tstd",
@@ -4476,7 +4476,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures 0.3.7",
  "httparse",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1",
 ]
@@ -4980,7 +4980,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -5003,7 +5003,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.30",
  "lazy_static",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "mio",
  "num_cpus",
  "parking_lot 0.9.0",
@@ -5048,7 +5048,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.30",
  "lazy_static",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "num_cpus",
  "slab",
  "tokio-executor",
@@ -5085,7 +5085,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "pin-project-lite 0.1.11",
  "tokio 0.2.22",
 ]
@@ -5100,7 +5100,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "pin-project-lite 0.2.4",
  "tokio 0.3.6",
 ]
@@ -5127,7 +5127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "pin-project-lite 0.1.11",
  "tracing-attributes",
  "tracing-core",
@@ -5170,7 +5170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "tracing-core",
 ]
 
@@ -5218,7 +5218,7 @@ dependencies = [
  "futures 0.3.7",
  "idna 0.2.0",
  "lazy_static",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.4.2",
  "thiserror 1.0.22",
@@ -5237,7 +5237,7 @@ dependencies = [
  "futures 0.3.7",
  "ipconfig",
  "lazy_static",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "lru-cache",
  "resolv-conf",
  "smallvec 1.4.2",
@@ -5438,7 +5438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.30",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "try-lock",
 ]
 
@@ -5448,7 +5448,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "try-lock",
 ]
 
@@ -5482,7 +5482,7 @@ checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.48",
@@ -5547,7 +5547,7 @@ dependencies = [
  "hyper-proxy",
  "hyper-tls 0.4.3",
  "jsonrpc-core",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
  "native-tls",
  "parking_lot 0.11.0",
  "pin-project 1.0.1",

--- a/example/erc20/api/Cargo.toml
+++ b/example/erc20/api/Cargo.toml
@@ -12,5 +12,4 @@ ed25519-dalek = { version = "1.0.0-pre.2", features = ["serde"] }
 rand = "0.7"
 serde-big-array = "0.2"
 web3 = "0.14"
-
-[features]
+serde_json = "1.0"

--- a/example/erc20/api/src/lib.rs
+++ b/example/erc20/api/src/lib.rs
@@ -49,8 +49,8 @@ pub mod state {
             }
         }
 
-        #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Default, Deserialize, Serialize)]
-        pub struct Response<S: State>(pub S);
+        #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+        pub struct Response(pub serde_json::Value);
     }
 }
 

--- a/example/erc20/api/src/lib.rs
+++ b/example/erc20/api/src/lib.rs
@@ -37,46 +37,15 @@ pub mod state {
 
     pub mod get {
         use super::super::*;
-        big_array! { BigArray; }
 
-        #[derive(Clone, Deserialize, Serialize)]
+        #[derive(Debug, Clone, Deserialize, Serialize)]
         pub struct Request {
-            #[serde(with = "BigArray")]
-            pub sig: [u8; SIGNATURE_LENGTH],
-            pub pubkey: [u8; PUBLIC_KEY_LENGTH],
-            pub challenge: [u8; 32],
+            pub encrypted_req: EciesCiphertext,
         }
 
         impl Request {
-            pub fn new<R: Rng>(keypair: &Keypair, rng: &mut R) -> Self {
-                let challenge: [u8; 32] = rng.gen();
-                let sig = keypair.sign(&challenge[..]);
-                assert!(keypair.verify(&challenge, &sig).is_ok());
-
-                Request {
-                    sig: sig.to_bytes(),
-                    pubkey: keypair.public.to_bytes(),
-                    challenge,
-                }
-            }
-
-            pub fn into_access_right(&self) -> Result<Ed25519ChallengeResponse, SignatureError> {
-                let sig = Signature::from_bytes(&self.sig)?;
-                let pubkey = PublicKey::from_bytes(&self.pubkey)?;
-
-                Ok(Ed25519ChallengeResponse::new(sig, pubkey, self.challenge))
-            }
-        }
-
-        impl fmt::Debug for Request {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "Request {{ sig: {:?}, pubkey: {:?}, challenge: {:?} }}",
-                    &self.sig[..],
-                    self.pubkey,
-                    self.challenge
-                )
+            pub fn new(encrypted_req: EciesCiphertext) -> Self {
+                Request { encrypted_req }
             }
         }
 

--- a/example/erc20/api/src/lib.rs
+++ b/example/erc20/api/src/lib.rs
@@ -50,7 +50,9 @@ pub mod state {
         }
 
         #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
-        pub struct Response(pub serde_json::Value);
+        pub struct Response {
+            pub state: serde_json::Value,
+        }
     }
 }
 

--- a/example/erc20/cli/src/commands.rs
+++ b/example/erc20/cli/src/commands.rs
@@ -297,6 +297,7 @@ pub(crate) fn allowance<R: Rng>(
     anonify_url: String,
     index: usize,
     spender: AccountId,
+    encrypting_key: &DhPubKey,
     rng: &mut R,
 ) -> Result<()> {
     let password = prompt_password(term)?;
@@ -328,6 +329,7 @@ pub(crate) fn balance_of<R: Rng>(
     root_dir: PathBuf,
     anonify_url: String,
     index: usize,
+    encrypting_key: &DhPubKey,
     rng: &mut R,
 ) -> Result<()> {
     let password = prompt_password(term)?;

--- a/example/erc20/cli/src/commands.rs
+++ b/example/erc20/cli/src/commands.rs
@@ -315,7 +315,7 @@ pub(crate) fn allowance<R: Rng>(
         EciesCiphertext::encrypt(&encrypting_key, serde_json::to_vec(&req).unwrap())
             .map_err(|e| anyhow!("{:?}", e))?;
     let res = Client::new()
-        .get(&format!("{}/api/v1/allowance", &anonify_url))
+        .get(&format!("{}/api/v1/state", &anonify_url))
         .json(&erc20_api::state::get::Request::new(encrypted_req))
         .send()?
         .text()?;
@@ -345,7 +345,7 @@ pub(crate) fn balance_of<R: Rng>(
         EciesCiphertext::encrypt(&encrypting_key, serde_json::to_vec(&req).unwrap())
             .map_err(|e| anyhow!("{:?}", e))?;
     let res = Client::new()
-        .get(&format!("{}/api/v1/balance_of", &anonify_url))
+        .get(&format!("{}/api/v1/state", &anonify_url))
         .json(&erc20_api::state::get::Request::new(encrypted_req))
         .send()?
         .text()?;

--- a/example/erc20/cli/src/main.rs
+++ b/example/erc20/cli/src/main.rs
@@ -277,6 +277,7 @@ fn subcommand_anonify<R: Rng>(
                 anonify_url,
                 keyfile_index,
                 spender_addr,
+                encrypting_key,
                 rng,
             )
             .expect("Failed allowance command");
@@ -288,7 +289,7 @@ fn subcommand_anonify<R: Rng>(
                 .parse()
                 .expect("Failed to parse keyfile-index");
 
-            commands::balance_of(&mut term, root_dir, anonify_url, keyfile_index, rng)
+            commands::balance_of(&mut term, root_dir, anonify_url, keyfile_index, encrypting_key, rng)
                 .expect("Failed balance_of command");
         }
         ("start_sync_bc", Some(_)) => {

--- a/example/erc20/server/src/handlers.rs
+++ b/example/erc20/server/src/handlers.rs
@@ -4,7 +4,7 @@ use actix_web::{web, HttpResponse};
 use anonify_eth_driver::traits::*;
 use anyhow::anyhow;
 use erc20_state_transition::cmd::*;
-use frame_runtime::primitives::{Approved, U64};
+use frame_runtime::primitives::U64;
 use std::{sync::Arc, time};
 use tracing::{debug, error, info};
 
@@ -172,7 +172,7 @@ where
 
     let state = server
         .dispatcher
-        .get_state::<_, _>(req.encrypted_req, GET_STATE_CMD)
+        .get_state(req.encrypted_req.clone(), GET_STATE_CMD)
         .map_err(|e| ServerError::from(e))?;
 
     Ok(HttpResponse::Ok().json(erc20_api::state::get::Response(state)))

--- a/example/erc20/server/src/handlers.rs
+++ b/example/erc20/server/src/handlers.rs
@@ -175,7 +175,7 @@ where
         .get_state(req.encrypted_req.clone(), GET_STATE_CMD)
         .map_err(|e| ServerError::from(e))?;
 
-    Ok(HttpResponse::Ok().json(erc20_api::state::get::Response(state)))
+    Ok(HttpResponse::Ok().json(erc20_api::state::get::Response { state }))
 }
 
 pub async fn handle_encrypting_key<D, S, W>(

--- a/example/erc20/server/src/handlers.rs
+++ b/example/erc20/server/src/handlers.rs
@@ -154,64 +154,7 @@ where
     Ok(HttpResponse::Ok().json(erc20_api::key_rotation::post::Response(tx_hash)))
 }
 
-/// Fetch events from blockchain nodes manually, and then get the balance of the address approved by the owner from enclave.
-pub async fn handle_allowance<D, S, W>(
-    server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::allowance::get::Request>,
-) -> Result<HttpResponse>
-where
-    D: Deployer,
-    S: Sender,
-    W: Watcher,
-{
-    server
-        .dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
-    let access_right = req
-        .into_access_right()
-        .map_err(|e| ServerError::from(anyhow!("{:?}", e)))?;
-    let owner_approved = server
-        .dispatcher
-        .get_state::<Approved, _>(access_right, "approved", GET_STATE_CMD)
-        .map_err(|e| ServerError::from(e))?;
-    let approved_amount = owner_approved.allowance(&req.spender).unwrap();
-
-    Ok(HttpResponse::Ok().json(erc20_api::allowance::get::Response(
-        (*approved_amount).as_raw(),
-    )))
-}
-
-/// Fetch events from blockchain nodes manually, and then get balance of the address from enclave.
-pub async fn handle_balance_of<D, S, W>(
-    server: web::Data<Arc<Server<D, S, W>>>,
-    req: web::Json<erc20_api::state::get::Request>,
-) -> Result<HttpResponse>
-where
-    D: Deployer,
-    S: Sender,
-    W: Watcher,
-{
-    server
-        .dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
-    let access_right = req
-        .into_access_right()
-        .map_err(|e| ServerError::from(anyhow!("{:?}", e)))?;
-    let state = server
-        .dispatcher
-        .get_state::<U64, _>(access_right, "balance_of", GET_STATE_CMD)
-        .map_err(|e| ServerError::from(e))?;
-
-    Ok(HttpResponse::Ok().json(erc20_api::state::get::Response(state.as_raw())))
-}
-
-/// Fetch events from blockchain nodes manually, and then get balance of the address from enclave.
+/// Fetch events from blockchain nodes manually, and then get the state data from enclave.
 pub async fn handle_get_state<D, S, W>(
     server: web::Data<Arc<Server<D, S, W>>>,
     req: web::Json<erc20_api::state::get::Request>,
@@ -229,10 +172,10 @@ where
 
     let state = server
         .dispatcher
-        .get_state::<U64, _>(req.encrypted_req, GET_STATE_CMD)
+        .get_state::<_, _>(req.encrypted_req, GET_STATE_CMD)
         .map_err(|e| ServerError::from(e))?;
 
-    Ok(HttpResponse::Ok().json(erc20_api::state::get::Response(state.as_raw())))
+    Ok(HttpResponse::Ok().json(erc20_api::state::get::Response(state)))
 }
 
 pub async fn handle_encrypting_key<D, S, W>(

--- a/example/erc20/server/src/main.rs
+++ b/example/erc20/server/src/main.rs
@@ -41,16 +41,12 @@ async fn main() -> io::Result<()> {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
+            )
+            .route(
                 "/api/v1/key_rotation",
                 web::post().to(handle_key_rotation::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/allowance",
-                web::get().to(handle_allowance::<EthDeployer, EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/start_sync_bc",

--- a/example/erc20/server/src/tests.rs
+++ b/example/erc20/server/src/tests.rs
@@ -69,8 +69,8 @@ async fn test_multiple_messages() {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/encrypting_key",
@@ -86,15 +86,6 @@ async fn test_multiple_messages() {
     println!("contract address: {:?}", contract_addr.0);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 0);
-
-    let req = test::TestRequest::get()
         .uri("/api/v1/encrypting_key")
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -102,6 +93,15 @@ async fn test_multiple_messages() {
     let enc_key_resp: erc20_api::encrypting_key::get::Response = test::read_body_json(resp).await;
     let enc_key =
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/balance_of")
+        .set_json(&balance_of_req(&enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0.to_string(), r#"{ "state": 0 }"#);
 
     let init_100_req = init_100_req(&enc_key);
     let req = test::TestRequest::post()
@@ -113,12 +113,12 @@ async fn test_multiple_messages() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 100);
 
     let transfer_10_req = transfer_10_req(&enc_key);
     // Sending five messages before receiving any messages
@@ -133,12 +133,12 @@ async fn test_multiple_messages() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 50);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 50);
 }
 
 #[actix_rt::test]
@@ -170,8 +170,8 @@ async fn test_skip_invalid_event() {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/encrypting_key",
@@ -211,12 +211,12 @@ async fn test_skip_invalid_event() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 100);
 
     let transfer_110_req = transfer_110_req(&enc_key);
     let req = test::TestRequest::post()
@@ -228,12 +228,12 @@ async fn test_skip_invalid_event() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 100);
 
     let transfer_10_req = transfer_10_req(&enc_key);
     let req = test::TestRequest::post()
@@ -245,12 +245,12 @@ async fn test_skip_invalid_event() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 90);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 90);
 }
 
 #[actix_rt::test]
@@ -283,8 +283,8 @@ async fn test_node_recovery() {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/encrypting_key",
@@ -305,8 +305,8 @@ async fn test_node_recovery() {
         App::new()
             .data(recovered_server.clone())
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/start_sync_bc",
@@ -362,12 +362,12 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 100);
 
     let transfer_10_req_ = transfer_10_req(&enc_key);
     let req = test::TestRequest::post()
@@ -379,12 +379,12 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 90);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 90);
 
     // Assume the TEE node is down, and then recovered.
 
@@ -410,12 +410,12 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 90);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 90);
 
     let req = test::TestRequest::get()
         .uri("/api/v1/encrypting_key")
@@ -436,12 +436,12 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 80);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 80);
 }
 
 #[actix_rt::test]
@@ -491,8 +491,8 @@ async fn test_join_group_then_handshake() {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/start_sync_bc",
@@ -575,12 +575,12 @@ async fn test_join_group_then_handshake() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 100);
 
     let req = test::TestRequest::post()
         .uri("/api/v1/key_rotation")
@@ -599,12 +599,12 @@ async fn test_join_group_then_handshake() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 90);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.0, 90);
 }
 
 fn set_server_env_vars() {
@@ -751,20 +751,29 @@ fn transfer_110_req(enc_key: &DhPubKey) -> erc20_api::state::post::Request {
     erc20_api::state::post::Request { encrypted_req }
 }
 
-// me
-const BALANCE_OF_REQ: erc20_api::state::get::Request = erc20_api::state::get::Request {
-    sig: [
+fn balance_of_req(enc_key: &DhPubKey) -> erc20_api::state::get::Request {
+    let sig = [
         21, 54, 136, 84, 150, 59, 196, 71, 164, 136, 222, 128, 100, 84, 208, 219, 84, 7, 61, 11,
         230, 220, 25, 138, 67, 247, 95, 97, 30, 76, 120, 160, 73, 48, 110, 43, 94, 79, 192, 195,
         82, 199, 73, 80, 48, 148, 233, 143, 87, 237, 159, 97, 252, 226, 68, 160, 137, 127, 195,
         116, 128, 181, 47, 2,
-    ],
-    pubkey: [
+    ];
+    let pubkey = [
         164, 189, 195, 42, 48, 163, 27, 74, 84, 147, 25, 254, 16, 14, 206, 134, 153, 148, 33, 189,
         55, 149, 7, 15, 11, 101, 106, 28, 48, 130, 133, 143,
-    ],
-    challenge: [
+    ];
+    let challenge = [
         119, 177, 182, 220, 100, 44, 96, 179, 173, 47, 220, 49, 105, 204, 132, 230, 211, 24, 166,
         219, 82, 76, 27, 205, 211, 232, 142, 98, 66, 130, 150, 202,
-    ],
-};
+    ];
+    let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_command": {},
+        "state_name": "balance_of",
+    });
+    let encrypted_req =
+        EciesCiphertext::encrypt(&enc_key, serde_json::to_vec(&req).unwrap()).unwrap();
+
+    erc20_api::state::get::Request { encrypted_req }
+}

--- a/example/erc20/server/src/tests.rs
+++ b/example/erc20/server/src/tests.rs
@@ -95,7 +95,7 @@ async fn test_multiple_messages() {
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -112,7 +112,7 @@ async fn test_multiple_messages() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -132,7 +132,7 @@ async fn test_multiple_messages() {
     }
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -210,7 +210,7 @@ async fn test_skip_invalid_event() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -227,7 +227,7 @@ async fn test_skip_invalid_event() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -244,7 +244,7 @@ async fn test_skip_invalid_event() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -361,7 +361,7 @@ async fn test_node_recovery() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -378,7 +378,7 @@ async fn test_node_recovery() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -409,7 +409,7 @@ async fn test_node_recovery() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
@@ -435,7 +435,7 @@ async fn test_node_recovery() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
@@ -574,7 +574,7 @@ async fn test_join_group_then_handshake() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
@@ -598,7 +598,7 @@ async fn test_join_group_then_handshake() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;

--- a/example/erc20/state-transition/Cargo.toml
+++ b/example/erc20/state-transition/Cargo.toml
@@ -7,21 +7,13 @@ edition = "2018"
 [dependencies]
 frame-runtime = { path = "../../../frame/runtime", default-features = false }
 sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-serde-std = { package = "serde", version = "1", default-features = false, optional = true }
-serde-sgx = { package = "serde", git = "https://github.com/mesalock-linux/serde-sgx.git", default-features = false, optional = true, features = ["derive"] }
-serde_json = { rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx", optional = true }
 
 [features]
 default = ["std"]
 std = [
     "frame-runtime/std",
-    "serde-std/std",
-    "serde-std/derive",
 ]
 sgx = [
     "frame-runtime/sgx",
     "sgx_tstd",
-    "serde-sgx",
-    "serde-sgx/derive",
-    "serde_json",
 ]

--- a/example/erc20/state-transition/src/lib.rs
+++ b/example/erc20/state-transition/src/lib.rs
@@ -146,10 +146,11 @@ impl_runtime! {
 
     pub fn approved(
         self,
-        caller: AccountId
+        caller: AccountId,
+        spender: AccountId
     ) {
         let approved = self.get_map::<Approved>(caller, "Approved")?;
-        get_state![approved]
+        get_state![approved.get(spender)]
     }
 
     pub fn total_supply(

--- a/example/erc20/state-transition/src/lib.rs
+++ b/example/erc20/state-transition/src/lib.rs
@@ -2,13 +2,8 @@
 #[cfg(feature = "sgx")]
 #[macro_use]
 extern crate sgx_tstd as localstd;
-#[cfg(all(feature = "sgx", not(feature = "std")))]
-use serde_sgx as serde;
-#[cfg(feature = "std")]
-use serde_std as serde;
 
 use frame_runtime::prelude::*;
-use serde::{Deserialize, Serialize};
 
 pub mod cmd;
 

--- a/example/secret-backup/server/src/tests.rs
+++ b/example/secret-backup/server/src/tests.rs
@@ -115,7 +115,7 @@ async fn test_backup_path_secret() {
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -143,7 +143,7 @@ async fn test_backup_path_secret() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -167,7 +167,7 @@ async fn test_backup_path_secret() {
         .exists());
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -265,7 +265,7 @@ async fn test_recover_without_key_vault() {
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -293,7 +293,7 @@ async fn test_recover_without_key_vault() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -311,7 +311,7 @@ async fn test_recover_without_key_vault() {
     sgx_urts::rsgx_destroy_enclave(key_vault_server_eid).unwrap();
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -413,7 +413,7 @@ async fn test_manually_backup_all() {
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -431,7 +431,7 @@ async fn test_manually_backup_all() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -446,7 +446,7 @@ async fn test_manually_backup_all() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -570,7 +570,7 @@ async fn test_manually_recover_all() {
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -588,7 +588,7 @@ async fn test_manually_recover_all() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -603,7 +603,7 @@ async fn test_manually_recover_all() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
+        .uri("/api/v1/state")
         .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;

--- a/example/secret-backup/server/src/tests.rs
+++ b/example/secret-backup/server/src/tests.rs
@@ -80,8 +80,8 @@ async fn test_backup_path_secret() {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/key_rotation",
@@ -105,15 +105,6 @@ async fn test_backup_path_secret() {
     println!("contract address: {:?}", contract_addr.0);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 0);
-
-    let req = test::TestRequest::get()
         .uri("/api/v1/encrypting_key")
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -122,6 +113,15 @@ async fn test_backup_path_secret() {
     let enc_key_resp: erc20_api::encrypting_key::get::Response = test::read_body_json(resp).await;
     let enc_key =
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/balance_of")
+        .set_json(&balance_of_req(&enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 0);
 
     // check storing path_secret
     let id = get_local_id().unwrap();
@@ -144,12 +144,12 @@ async fn test_backup_path_secret() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 100);
 
     let req = test::TestRequest::post()
         .uri("/api/v1/key_rotation")
@@ -168,12 +168,12 @@ async fn test_backup_path_secret() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 100);
 }
 
 #[actix_rt::test]
@@ -230,8 +230,8 @@ async fn test_recover_without_key_vault() {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/key_rotation",
@@ -255,15 +255,6 @@ async fn test_recover_without_key_vault() {
     println!("contract address: {:?}", contract_addr.0);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 0);
-
-    let req = test::TestRequest::get()
         .uri("/api/v1/encrypting_key")
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -272,6 +263,15 @@ async fn test_recover_without_key_vault() {
     let enc_key_resp: erc20_api::encrypting_key::get::Response = test::read_body_json(resp).await;
     let enc_key =
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/balance_of")
+        .set_json(&balance_of_req(&enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 0);
 
     // check storing path_secret
     let id = get_local_id().unwrap();
@@ -294,12 +294,12 @@ async fn test_recover_without_key_vault() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 100);
 
     let req = test::TestRequest::post()
         .uri("/api/v1/key_rotation")
@@ -312,12 +312,12 @@ async fn test_recover_without_key_vault() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 100);
 }
 
 #[actix_rt::test]
@@ -374,8 +374,8 @@ async fn test_manually_backup_all() {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/key_rotation",
@@ -403,15 +403,6 @@ async fn test_manually_backup_all() {
     println!("contract address: {:?}", contract_addr.0);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 0);
-
-    let req = test::TestRequest::get()
         .uri("/api/v1/encrypting_key")
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -420,6 +411,15 @@ async fn test_manually_backup_all() {
     let enc_key_resp: erc20_api::encrypting_key::get::Response = test::read_body_json(resp).await;
     let enc_key =
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/balance_of")
+        .set_json(&balance_of_req(&enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 0);
 
     // Init state
     let init_100_req = init_100_req(&enc_key);
@@ -432,12 +432,12 @@ async fn test_manually_backup_all() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 100);
 
     let req = test::TestRequest::post()
         .uri("/api/v1/key_rotation")
@@ -447,12 +447,12 @@ async fn test_manually_backup_all() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 100);
 
     // check storing path_secret
     // local
@@ -534,8 +534,8 @@ async fn test_manually_recover_all() {
                 web::post().to(handle_send_command::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
-                "/api/v1/balance_of",
-                web::get().to(handle_balance_of::<EthDeployer, EthSender, EventWatcher>),
+                "/api/v1/state",
+                web::get().to(handle_get_state::<EthDeployer, EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/key_rotation",
@@ -560,15 +560,6 @@ async fn test_manually_recover_all() {
     println!("contract address: {:?}", contract_addr.0);
 
     let req = test::TestRequest::get()
-        .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 0);
-
-    let req = test::TestRequest::get()
         .uri("/api/v1/encrypting_key")
         .to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -577,6 +568,15 @@ async fn test_manually_recover_all() {
     let enc_key_resp: erc20_api::encrypting_key::get::Response = test::read_body_json(resp).await;
     let enc_key =
         verify_encrypting_key(enc_key_resp.0, &abi_path, &eth_url, &contract_addr.0).await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/balance_of")
+        .set_json(&balance_of_req(&enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 0);
 
     // Init state
     let init_100_req = init_100_req(&enc_key);
@@ -589,12 +589,12 @@ async fn test_manually_recover_all() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 100);
 
     let req = test::TestRequest::post()
         .uri("/api/v1/key_rotation")
@@ -604,12 +604,12 @@ async fn test_manually_recover_all() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/balance_of")
-        .set_json(&BALANCE_OF_REQ)
+        .set_json(&balance_of_req(&enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
-    let balance: erc20_api::state::get::Response<U64> = test::read_body_json(resp).await;
-    assert_eq!(balance.0.as_raw(), 100);
+    let balance: erc20_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 100);
 
     // check storing path_secret
     // local
@@ -807,19 +807,29 @@ fn init_100_req(enc_key: &DhPubKey) -> erc20_api::state::post::Request {
     erc20_api::state::post::Request { encrypted_req }
 }
 
-const BALANCE_OF_REQ: erc20_api::state::get::Request = erc20_api::state::get::Request {
-    sig: [
+fn balance_of_req(enc_key: &DhPubKey) -> erc20_api::state::get::Request {
+    let sig = [
         21, 54, 136, 84, 150, 59, 196, 71, 164, 136, 222, 128, 100, 84, 208, 219, 84, 7, 61, 11,
         230, 220, 25, 138, 67, 247, 95, 97, 30, 76, 120, 160, 73, 48, 110, 43, 94, 79, 192, 195,
         82, 199, 73, 80, 48, 148, 233, 143, 87, 237, 159, 97, 252, 226, 68, 160, 137, 127, 195,
         116, 128, 181, 47, 2,
-    ],
-    pubkey: [
+    ];
+    let pubkey = [
         164, 189, 195, 42, 48, 163, 27, 74, 84, 147, 25, 254, 16, 14, 206, 134, 153, 148, 33, 189,
         55, 149, 7, 15, 11, 101, 106, 28, 48, 130, 133, 143,
-    ],
-    challenge: [
+    ];
+    let challenge = [
         119, 177, 182, 220, 100, 44, 96, 179, 173, 47, 220, 49, 105, 204, 132, 230, 211, 24, 166,
         219, 82, 76, 27, 205, 211, 232, 142, 98, 66, 130, 150, 202,
-    ],
-};
+    ];
+    let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_command": {},
+        "state_name": "balance_of",
+    });
+    let encrypted_req =
+        EciesCiphertext::encrypt(&enc_key, serde_json::to_vec(&req).unwrap()).unwrap();
+
+    erc20_api::state::get::Request { encrypted_req }
+}

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -51,7 +51,7 @@ impl From<AccountId> for StateType {
 #[serde(crate = "crate::serde")]
 pub enum ReturnState<S: State> {
     Updated(#[serde(bound(deserialize = "S: State"))] Vec<UpdatedState<S>>),
-    Get(serde_json::Value),
+    Get(#[serde(bound(deserialize = "S: State"))] S),
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -1,6 +1,7 @@
 use crate::crypto::AccountId;
 use crate::local_anyhow::{anyhow, Result};
 use crate::localstd::vec::Vec;
+use crate::serde::Serialize;
 use crate::traits::State;
 use codec::{Decode, Encode};
 
@@ -13,7 +14,8 @@ pub trait RawState: Encode + Decode + Clone + Default {}
 //         StateType::new(state.encode_s())
 //     }
 // }
-#[derive(Clone, Debug, Default, Decode, Encode)]
+#[derive(Clone, Debug, Default, Decode, Encode, Serialize)]
+#[serde(crate = "crate::serde")]
 pub struct StateType(Vec<u8>);
 
 impl StateType {

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -8,13 +8,6 @@ use crate::traits::State;
 
 pub trait RawState: Clone + Default {}
 
-// TODO: Remove Encode trait bound cause StateType has already be encoded.
-// then, implement
-// impl<S: State> From<S> for StateType {
-//     fn from(state: S) -> Self {
-//         StateType::new(state.encode_s())
-//     }
-// }
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(crate = "crate::serde")]
 pub struct StateType(#[serde(with = "serde_bytes")] Vec<u8>);

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -49,7 +49,7 @@ impl From<AccountId> for StateType {
 #[derive(Debug, Clone, Encode, Decode)]
 pub enum ReturnState<S: State> {
     Updated(Vec<UpdatedState<S>>),
-    Get(S),
+    Get(serde_json::Value),
 }
 
 #[derive(Debug, Clone, Default, Encode, Decode)]

--- a/frame/common/src/traits.rs
+++ b/frame/common/src/traits.rs
@@ -20,7 +20,7 @@ pub trait EcallInput {}
 pub trait EcallOutput {}
 
 /// Trait of each user's state.
-pub trait State: Sized + Default + Clone + Encode + Decode + Debug {
+pub trait State: Sized + Default + Clone + Encode + Decode + Debug + Serialize {
     fn encode_s(&self) -> Vec<u8> {
         self.encode()
     }
@@ -39,7 +39,7 @@ pub trait State: Sized + Default + Clone + Encode + Decode + Debug {
     }
 }
 
-impl<T: Sized + Default + Clone + Encode + Decode + Debug> State for T {}
+impl<T: Sized + Default + Clone + Encode + Decode + Debug + Serialize> State for T {}
 
 /// A decoder traits for the types implemented state trait
 pub trait StateDecoder: State {

--- a/frame/runtime/src/impls.rs
+++ b/frame/runtime/src/impls.rs
@@ -203,6 +203,8 @@ macro_rules! return_update {
 #[macro_export]
 macro_rules! get_state {
     ( $state:expr ) => {
-        Ok(ReturnState::Get($state.into()))
+        Ok(ReturnState::Get(StateType::new(bincode::serialize(
+            &serde_json::to_vec(&$state)?,
+        )?)))
     };
 }

--- a/frame/runtime/src/impls.rs
+++ b/frame/runtime/src/impls.rs
@@ -203,6 +203,6 @@ macro_rules! return_update {
 #[macro_export]
 macro_rules! get_state {
     ( $state:expr ) => {
-        Ok(ReturnState::Get(serde_json::to_value($state)))
+        Ok(ReturnState::Get($state.into()))
     };
 }

--- a/frame/runtime/src/impls.rs
+++ b/frame/runtime/src/impls.rs
@@ -202,6 +202,6 @@ macro_rules! return_update {
 #[macro_export]
 macro_rules! get_state {
     ( $state:expr ) => {
-        Ok(ReturnState::Get($state.into()))
+        Ok(ReturnState::Get(serde_json::to_value($state)))
     };
 }

--- a/frame/runtime/src/lib.rs
+++ b/frame/runtime/src/lib.rs
@@ -12,17 +12,17 @@ use std as localstd;
 #[cfg(all(not(feature = "std"), not(feature = "sgx")))]
 extern crate core as localstd;
 #[cfg(all(feature = "sgx", not(feature = "std")))]
-use bincode_sgx as bincode;
+pub use bincode_sgx as bincode;
 #[cfg(feature = "std")]
-use bincode_std as bincode;
+pub use bincode_std as bincode;
 #[cfg(all(feature = "sgx", not(feature = "std")))]
 use serde_bytes_sgx as serde_bytes;
 #[cfg(feature = "std")]
 use serde_bytes_std as serde_bytes;
 #[cfg(all(feature = "sgx", not(feature = "std")))]
-use serde_sgx as serde;
+pub use serde_sgx as serde;
 #[cfg(feature = "std")]
-use serde_std as serde;
+pub use serde_std as serde;
 
 pub mod impls;
 pub mod prelude;

--- a/frame/runtime/src/prelude.rs
+++ b/frame/runtime/src/prelude.rs
@@ -1,7 +1,9 @@
+pub use crate::bincode;
 pub use crate::local_anyhow::{anyhow, ensure, Result};
 pub use crate::localstd::marker::PhantomData;
 pub use crate::localstd::prelude::v1::*;
 pub use crate::primitives::*;
+pub use crate::serde::{self, de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(feature = "sgx")]
 pub use crate::traits::*;
 pub use crate::{
@@ -13,3 +15,5 @@ pub use frame_common::{
     state_types::*,
     traits::*,
 };
+#[cfg(feature = "sgx")]
+pub use serde_json;

--- a/frame/runtime/src/primitives.rs
+++ b/frame/runtime/src/primitives.rs
@@ -183,6 +183,10 @@ impl Approved {
         self.0.iter().fold(U64(0), |acc, (_, &amount)| acc + amount)
     }
 
+    pub fn get(&self, account_id: AccountId) -> U64 {
+        self.0.get(&account_id).map(|e| *e).unwrap_or_default()
+    }
+
     pub fn approve(&mut self, account_id: AccountId, amount: U64) {
         match self.allowance(&account_id) {
             Some(&existing_amount) => {

--- a/frame/runtime/src/primitives.rs
+++ b/frame/runtime/src/primitives.rs
@@ -125,7 +125,8 @@ impl_uint!(U16, u16);
 impl_uint!(U32, u32);
 impl_uint!(U64, u64);
 
-#[derive(Encode, Decode, Clone, Debug, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Encode, Decode, Clone, Debug, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize)]
+#[serde(crate = "crate::serde")]
 pub struct Bytes(Vec<u8>);
 
 impl From<Vec<u8>> for Bytes {
@@ -171,7 +172,8 @@ impl From<Bytes> for StateType {
     }
 }
 
-#[derive(Encode, Decode, Clone, Debug, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Encode, Decode, Clone, Debug, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize)]
+#[serde(crate = "crate::serde")]
 pub struct Approved(BTreeMap<AccountId, U64>);
 
 impl Approved {

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -89,7 +89,7 @@ pub trait StateOps {
         cmd_name: &str,
         account_id: U,
         runtime_cmd: serde_json::Value,
-    ) -> Result<serde_json::Value>
+    ) -> Result<Self::S>
     where
         U: Into<AccountId>,
         R: RuntimeExecutor<CTX, S = Self::S>,

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -87,7 +87,7 @@ pub trait StateOps {
         cmd_name: &str,
         account_id: U,
         runtime_cmd: serde_json::Value,
-    ) -> Result<Self::S>
+    ) -> Result<serde_json::Value>
     where
         U: Into<AccountId>,
         R: RuntimeExecutor<CTX, S = Self::S>,

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -82,7 +82,12 @@ pub trait StateOps {
 
     /// Get state using call id.
     /// this is called in user-defined state getting functions.
-    fn get_state_by_cmd_name<U, R, CTX>(ctx: CTX, cmd_name: &str, account_id: U) -> Result<Self::S>
+    fn get_state_by_state_name<U, R, CTX>(
+        ctx: CTX,
+        cmd_name: &str,
+        account_id: U,
+        runtime_cmd: serde_json::Value,
+    ) -> Result<Self::S>
     where
         U: Into<AccountId>,
         R: RuntimeExecutor<CTX, S = Self::S>,

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -370,16 +370,16 @@ pub mod output {
 
     impl EcallOutput for Empty {}
 
-    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[derive(Serialize, Deserialize, Debug, Clone, Default)]
     #[serde(crate = "crate::serde")]
     pub struct ReturnState {
-        state: serde_json::Value,
+        state: StateType,
     }
 
     impl EcallOutput for ReturnState {}
 
     impl ReturnState {
-        pub fn new(state: serde_json::Value) -> Self {
+        pub fn new(state: StateType) -> Self {
             ReturnState { state }
         }
     }

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -370,16 +370,24 @@ pub mod output {
 
     impl EcallOutput for Empty {}
 
-    #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
     #[serde(crate = "crate::serde")]
     pub struct ReturnState {
-        state: StateType,
+        state: serde_json::Value,
     }
 
     impl EcallOutput for ReturnState {}
 
+    impl Default for ReturnState {
+        fn default() -> Self {
+            Self {
+                state: serde_json::Value::Null,
+            }
+        }
+    }
+
     impl ReturnState {
-        pub fn new(state: StateType) -> Self {
+        pub fn new(state: serde_json::Value) -> Self {
             ReturnState { state }
         }
     }

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -370,24 +370,16 @@ pub mod output {
 
     impl EcallOutput for Empty {}
 
-    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[derive(Serialize, Deserialize, Debug, Clone, Default)]
     #[serde(crate = "crate::serde")]
     pub struct ReturnState {
-        state: serde_json::Value,
+        pub state: StateType,
     }
 
     impl EcallOutput for ReturnState {}
 
-    impl Default for ReturnState {
-        fn default() -> Self {
-            Self {
-                state: serde_json::Value::Null,
-            }
-        }
-    }
-
     impl ReturnState {
-        pub fn new(state: serde_json::Value) -> Self {
+        pub fn new(state: StateType) -> Self {
             ReturnState { state }
         }
     }

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -122,9 +122,9 @@ pub mod input {
     #[serde(crate = "crate::serde")]
     pub struct GetState<AP: AccessPolicy> {
         #[serde(deserialize_with = "AP::deserialize")]
-        access_policy: AP,
-        runtime_command: serde_json::Value,
-        state_name: String,
+        pub access_policy: AP,
+        pub runtime_command: serde_json::Value,
+        pub state_name: String,
     }
 
     impl<AP> Default for GetState<AP>

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -152,7 +152,11 @@ pub mod input {
     }
 
     impl<AP: AccessPolicy> GetState<AP> {
-        pub fn new(access_policy: AP, runtime_command: serde_json::Value, state_name: String) -> Self {
+        pub fn new(
+            access_policy: AP,
+            runtime_command: serde_json::Value,
+            state_name: String,
+        ) -> Self {
             GetState {
                 access_policy,
                 runtime_command,

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -328,24 +328,16 @@ pub mod output {
 
     impl EcallOutput for Empty {}
 
-    #[derive(Encode, Decode, Debug, Clone, Default)]
+    #[derive(Debug, Clone, Default, Serialize)]
     pub struct ReturnState {
-        state: StateType,
+        state: serde_json::Value,
     }
 
     impl EcallOutput for ReturnState {}
 
     impl ReturnState {
-        pub fn new(state: StateType) -> Self {
+        pub fn new(state: serde_json::Value) -> Self {
             ReturnState { state }
-        }
-
-        pub fn into_vec(self) -> Vec<u8> {
-            self.state.into_vec()
-        }
-
-        pub fn as_mut_bytes(&mut self) -> &mut [u8] {
-            self.state.as_mut_bytes()
         }
     }
 

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -94,7 +94,7 @@ impl StateOps for AnonifyEnclaveContext {
         cmd_name: &str,
         account_id: U,
         runtime_cmd: serde_json::Value,
-    ) -> anyhow::Result<Self::S>
+    ) -> anyhow::Result<serde_json::Value>
     where
         U: Into<AccountId>,
         R: RuntimeExecutor<CTX, S = Self::S>,

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -322,8 +322,9 @@ impl<AP: AccessPolicy> EnclaveEngine for GetState<AP> {
             access_policy.into_account_id(),
             runtime_command,
         )?;
+        let json = serde_json::from_slice(&user_state.as_bytes)?;
 
-        Ok(output::ReturnState::new(user_state))
+        Ok(output::ReturnState::new(serde_json::to_value(json)))
     }
 }
 

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -94,7 +94,7 @@ impl StateOps for AnonifyEnclaveContext {
         cmd_name: &str,
         account_id: U,
         runtime_cmd: serde_json::Value,
-    ) -> anyhow::Result<serde_json::Value>
+    ) -> anyhow::Result<Self::S>
     where
         U: Into<AccountId>,
         R: RuntimeExecutor<CTX, S = Self::S>,

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -322,9 +322,8 @@ impl<AP: AccessPolicy> EnclaveEngine for GetState<AP> {
             access_policy.into_account_id(),
             runtime_command,
         )?;
-        let json = serde_json::from_slice(&user_state.as_bytes)?;
 
-        Ok(output::ReturnState::new(serde_json::to_value(json)))
+        Ok(output::ReturnState::new(user_state))
     }
 }
 

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -288,17 +288,17 @@ pub struct GetState<AP: AccessPolicy> {
 }
 
 impl<AP: AccessPolicy> EnclaveEngine for GetState<AP> {
-    type EI = input::GetState<AP>;
+    type EI = EciesCiphertext;
     type EO = output::ReturnState;
 
     fn decrypt<C>(ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        // TODO: decrypt
-        Ok(Self {
-            ecall_input: ciphertext,
-        })
+        let buf = enclave_context.decrypt(ciphertext)?;
+        let ecall_input = serde_json::from_slice(&buf[..])?;
+
+        Ok(Self { ecall_input })
     }
 
     fn eval_policy(&self) -> anyhow::Result<()> {

--- a/modules/anonify-eth-driver/Cargo.toml
+++ b/modules/anonify-eth-driver/Cargo.toml
@@ -24,6 +24,7 @@ ethabi = "12.0.0"
 hex = "0.4"
 async-trait = "0.1"
 tracing = "0.1"
+serde_json = "1.0"
 
 [features]
 default = ["backup-enable"]

--- a/modules/anonify-eth-driver/Cargo.toml
+++ b/modules/anonify-eth-driver/Cargo.toml
@@ -24,6 +24,7 @@ hex = "0.4"
 async-trait = "0.1"
 tracing = "0.1"
 serde_json = "1.0"
+bincode = "1.3"
 
 [features]
 default = ["backup-enable"]

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -12,7 +12,6 @@ use frame_common::{state_types::UpdatedState, traits::*};
 use frame_host::engine::HostEngine;
 use frame_treekem::{DhPubKey, EciesCiphertext};
 use parking_lot::RwLock;
-use serde_json::json;
 use sgx_types::sgx_enclave_id_t;
 use std::{fmt::Debug, marker::Send, path::Path};
 use web3::types::{Address, H256};
@@ -207,12 +206,8 @@ where
             .ecall_output
             .ok_or_else(|| HostError::EcallOutputNotSet)?;
 
-        let state_json: serde_json::Value = bincode::deserialize(&state.state.as_bytes())?;
-        let res = json!({
-            "state": state_json,
-        });
-
-        serde_json::to_value(res).map_err(Into::into)
+        let bytes: Vec<u8> = bincode::deserialize(&state.state.as_bytes())?;
+        serde_json::from_slice(&bytes[..]).map_err(Into::into)
     }
 
     pub async fn handshake(&self, signer: Address, gas: u64, ecall_cmd: u32) -> Result<H256> {

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -195,29 +195,20 @@ where
         }
     }
 
-    pub fn get_state<ST, AP>(
+    pub fn get_state<AP>(
         &self,
         encrypted_req: EciesCiphertext,
         ecall_cmd: u32,
     ) -> Result<serde_json::Value>
     where
-        ST: State + StateDecoder,
         AP: AccessPolicy,
     {
-        fn json_convert(state: impl StateDecoder) -> serde_json::Value {
-
-        }
-        use codec::Decode;
-
         let eid = self.inner.read().deployer.get_enclave_id();
         let input = host_input::GetState::new(encrypted_req, ecall_cmd);
-
-        let vec = GetStateWorkflow::exec(input, eid)?
+        let state = GetStateWorkflow::exec(input, eid)?
             .ecall_output
-            .ok_or_else(|| HostError::EcallOutputNotSet)?
-            .into_vec(); // into Vec<u8> in StateType
+            .ok_or_else(|| HostError::EcallOutputNotSet)?;
 
-        let state = <impl Decode as Decode>::decode_vec(vec)?;
         serde_json::to_value(state).map_err(Into::into)
     }
 

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -207,6 +207,7 @@ where
         fn json_convert(state: impl StateDecoder) -> serde_json::Value {
 
         }
+        use codec::Decode;
 
         let eid = self.inner.read().deployer.get_enclave_id();
         let input = host_input::GetState::new(encrypted_req, ecall_cmd);
@@ -216,7 +217,7 @@ where
             .ok_or_else(|| HostError::EcallOutputNotSet)?
             .into_vec(); // into Vec<u8> in StateType
 
-        let state = Box<dyn StateDecoder>::decode_vec(vec)?;
+        let state = <impl Decode as Decode>::decode_vec(vec)?;
         serde_json::to_value(state).map_err(Into::into)
     }
 

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -197,8 +197,7 @@ where
 
     pub fn get_state<ST, AP>(
         &self,
-        access_policy: AP,
-        call_name: &str,
+        encrypted_req: EciesCiphertext,
         ecall_cmd: u32,
     ) -> Result<ST>
     where
@@ -206,7 +205,7 @@ where
         AP: AccessPolicy,
     {
         let eid = self.inner.read().deployer.get_enclave_id();
-        let input = host_input::GetState::new(access_policy, call_name.to_string(), ecall_cmd);
+        let input = host_input::GetState::new(encrypted_req, ecall_cmd);
 
         let vec = GetStateWorkflow::exec(input, eid)?
             .ecall_output

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -12,6 +12,7 @@ use frame_common::{state_types::UpdatedState, traits::*};
 use frame_host::engine::HostEngine;
 use frame_treekem::{DhPubKey, EciesCiphertext};
 use parking_lot::RwLock;
+use serde_json::json;
 use sgx_types::sgx_enclave_id_t;
 use std::{fmt::Debug, marker::Send, path::Path};
 use web3::types::{Address, H256};
@@ -206,9 +207,12 @@ where
             .ecall_output
             .ok_or_else(|| HostError::EcallOutputNotSet)?;
 
-        let json = bincode::deserialize(&state.state.as_bytes()).unwrap();
+        let state_json: serde_json::Value = bincode::deserialize(&state.state.as_bytes())?;
+        let res = json!({
+            "state": state_json,
+        });
 
-        serde_json::to_value(json).map_err(Into::into)
+        serde_json::to_value(res).map_err(Into::into)
     }
 
     pub async fn handshake(&self, signer: Address, gas: u64, ecall_cmd: u32) -> Result<H256> {

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -206,7 +206,9 @@ where
             .ecall_output
             .ok_or_else(|| HostError::EcallOutputNotSet)?;
 
-        serde_json::to_value(state).map_err(Into::into)
+        let json = bincode::deserialize(&state.state.as_bytes()).unwrap();
+
+        serde_json::to_value(json).map_err(Into::into)
     }
 
     pub async fn handshake(&self, signer: Address, gas: u64, ecall_cmd: u32) -> Result<H256> {

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -195,14 +195,11 @@ where
         }
     }
 
-    pub fn get_state<AP>(
+    pub fn get_state(
         &self,
         encrypted_req: EciesCiphertext,
         ecall_cmd: u32,
-    ) -> Result<serde_json::Value>
-    where
-        AP: AccessPolicy,
-    {
+    ) -> Result<serde_json::Value> {
         let eid = self.inner.read().deployer.get_enclave_id();
         let input = host_input::GetState::new(encrypted_req, ecall_cmd);
         let state = GetStateWorkflow::exec(input, eid)?

--- a/modules/anonify-eth-driver/src/error.rs
+++ b/modules/anonify-eth-driver/src/error.rs
@@ -27,5 +27,7 @@ pub enum HostError {
     #[error("Frame host error: {0}")]
     FrameHostError(#[from] frame_host::Error),
     #[error("Serde json error: {0}")]
-    SerdeJsontError(#[from] serde_json::Error),
+    SerdeJsonError(#[from] serde_json::Error),
+    #[error("Bincode error: {0}")]
+    BincodeError(#[from] bincode::Error),
 }

--- a/modules/anonify-eth-driver/src/error.rs
+++ b/modules/anonify-eth-driver/src/error.rs
@@ -28,4 +28,6 @@ pub enum HostError {
     CodecError(#[from] codec::Error),
     #[error("Frame host error: {0}")]
     FrameHostError(#[from] frame_host::Error),
+    #[error("Serde json error: {0}")]
+    SerdeJsontError(#[from] serde_json::Error),
 }


### PR DESCRIPTION
fixed: #379 , fixed: #395 , fixed: #388

* 状態データ取得系エンドポイントを`GET: /api/v1/state`に統一
* リクエストボディにruntimeパラメタを導入し、状態取得時にロジック実行可能に ( `allowance`の`spender`などで `BtreeMap`が返ってくるのではなくvalueの`U64`がレスポンス）
* `GET: /api/v1/state` のリクエストボディ暗号化（認証情報&状態データ名&runtimeパラメタ）


TODO
* notificationの型の一般化
```
server
        .dispatcher
        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
```

* `get_state`, `send_command` 以外のリクエストボディの暗号化
* サーバー部分のmodule移行 (#402)
* rename: `runtime_cmd` -> `runtime_params`