### PR TITLE
Notification to host agentの一般化実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,7 @@ dependencies = [
  "serde_bytes 0.11.3",
  "serde_bytes 0.11.5",
  "serde_json 1.0.51",
+ "serde_json 1.0.59",
  "sgx_trts",
  "sgx_tstd",
  "sha2 0.8.2",

--- a/example/erc20/enclave/src/ecalls.rs
+++ b/example/erc20/enclave/src/ecalls.rs
@@ -12,9 +12,9 @@ register_ecall!(
     MAX_MEM_SIZE,
     Runtime<AnonifyEnclaveContext>,
     AnonifyEnclaveContext,
-    (SEND_COMMAND_CMD, MsgSender<Ed25519ChallengeResponse>),
+    (SEND_COMMAND_CMD, CmdSender<Ed25519ChallengeResponse>),
     // Fetch a ciphertext in event logs from blockchain nodes into enclave's memory database.
-    (FETCH_CIPHERTEXT_CMD, MsgReceiver<Ed25519ChallengeResponse>),
+    (FETCH_CIPHERTEXT_CMD, CmdReceiver<Ed25519ChallengeResponse>),
     // Fetch handshake received from blockchain nodes into enclave.
     (FETCH_HANDSHAKE_CMD, HandshakeReceiver),
     // Get current state of the user represented the given public key from enclave memory database.
@@ -35,9 +35,9 @@ register_ecall!(
     MAX_MEM_SIZE,
     Runtime<AnonifyEnclaveContext>,
     AnonifyEnclaveContext,
-    (SEND_COMMAND_CMD, MsgSender<Ed25519ChallengeResponse>),
+    (SEND_COMMAND_CMD, CmdSender<Ed25519ChallengeResponse>),
     // Fetch a ciphertext in event logs from blockchain nodes into enclave's memory database.
-    (FETCH_CIPHERTEXT_CMD, MsgReceiver<Ed25519ChallengeResponse>),
+    (FETCH_CIPHERTEXT_CMD, CmdReceiver<Ed25519ChallengeResponse>),
     // Fetch handshake received from blockchain nodes into enclave.
     (FETCH_HANDSHAKE_CMD, HandshakeReceiver),
     // Get current state of the user represented the given public key from enclave memory database.

--- a/example/erc20/server/Cargo.toml
+++ b/example/erc20/server/Cargo.toml
@@ -9,7 +9,6 @@ erc20-api = { path = "../api" }
 erc20-state-transition = { path = "../state-transition" }
 anonify-eth-driver = { path = "../../../modules/anonify-eth-driver" }
 frame-host = { path = "../../../frame/host" }
-frame-runtime = { path = "../../../frame/runtime" }
 frame-common = { path = "../../../frame/common" }
 sgx_types = "1.1.1"
 actix-web = "3"

--- a/example/erc20/server/src/handlers.rs
+++ b/example/erc20/server/src/handlers.rs
@@ -3,7 +3,6 @@ use crate::Server;
 use actix_web::{web, HttpResponse};
 use anonify_eth_driver::traits::*;
 use erc20_state_transition::cmd::*;
-use frame_runtime::primitives::U64;
 use std::{sync::Arc, time};
 use tracing::{debug, error, info};
 
@@ -165,7 +164,7 @@ where
 {
     server
         .dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .map_err(|e| ServerError::from(e))?;
 
@@ -207,7 +206,7 @@ where
             loop {
                 match server
                     .dispatcher
-                    .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+                    .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
                     .await
                 {
                     Ok(updated_states) => info!("State updated: {:?}", updated_states),

--- a/example/erc20/state-transition/src/lib.rs
+++ b/example/erc20/state-transition/src/lib.rs
@@ -23,9 +23,9 @@ impl_runtime! {
         sender: AccountId,
         total_supply: U64
     ) {
-        let owner_account_id = update!(*OWNER_ACCOUNT_ID, "Owner", sender);
-        let sender_balance = update!(sender, "Balance", total_supply);
-        let total_supply = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply);
+        let owner_account_id = update!(*OWNER_ACCOUNT_ID, "Owner", sender, AccountId);
+        let sender_balance = update!(sender, "Balance", total_supply, U64);
+        let total_supply = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply, U64);
 
         return_update![owner_account_id, sender_balance, total_supply]
     }
@@ -41,8 +41,8 @@ impl_runtime! {
 
         ensure!(sender_balance > amount, "transfer amount ({:?}) exceeds balance ({:?}).", amount, sender_balance);
 
-        let sender_update = update!(sender, "Balance", sender_balance - amount);
-        let recipient_update = update!(recipient, "Balance", recipient_balance + amount);
+        let sender_update = update!(sender, "Balance", sender_balance - amount, U64);
+        let recipient_update = update!(recipient, "Balance", recipient_balance + amount, U64);
 
         return_update![sender_update, recipient_update]
     }
@@ -62,7 +62,7 @@ impl_runtime! {
         );
 
         owner_approved.approve(spender, amount);
-        let owner_approved_update = update!(owner, "Approved", owner_approved);
+        let owner_approved_update = update!(owner, "Approved", owner_approved, Approved);
         return_update![owner_approved_update]
     }
 
@@ -88,12 +88,12 @@ impl_runtime! {
         );
 
         owner_approved.consume(sender, amount)?;
-        let owner_approved_update = update!(owner, "Approved", owner_approved);
+        let owner_approved_update = update!(owner, "Approved", owner_approved, Approved);
 
         let recipient_balance = self.get_map::<U64>(recipient, "Balance")?;
 
-        let owner_balance_update = update!(owner, "Balance", owner_balance - amount);
-        let recipient_balance_update = update!(recipient, "Balance", recipient_balance + amount);
+        let owner_balance_update = update!(owner, "Balance", owner_balance - amount, U64);
+        let recipient_balance_update = update!(recipient, "Balance", recipient_balance + amount, U64);
 
         return_update![owner_approved_update, owner_balance_update, recipient_balance_update]
     }
@@ -108,10 +108,10 @@ impl_runtime! {
         ensure!(executer == owner_account_id, "only owner can mint");
 
         let recipient_balance = self.get_map::<U64>(recipient, "Balance")?;
-        let recipient_balance_update = update!(recipient, "Balance", recipient_balance + amount);
+        let recipient_balance_update = update!(recipient, "Balance", recipient_balance + amount, U64);
 
         let total_supply = self.get_map::<U64>(*OWNER_ACCOUNT_ID, "TotalSupply")?;
-        let total_supply_update = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply + amount);
+        let total_supply_update = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply + amount, U64);
 
         return_update![recipient_balance_update, total_supply_update]
     }
@@ -123,10 +123,10 @@ impl_runtime! {
     ) {
         let balance = self.get_map::<U64>(sender, "Balance")?;
         ensure!(balance >= amount, "not enough balance to burn");
-        let balance_update = update!(sender, "Balance", balance - amount);
+        let balance_update = update!(sender, "Balance", balance - amount, U64);
 
         let total_supply = self.get_map::<U64>(*OWNER_ACCOUNT_ID, "TotalSupply")?;
-        let total_supply_update = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply - amount);
+        let total_supply_update = update!(*OWNER_ACCOUNT_ID, "TotalSupply", total_supply - amount, U64);
 
         return_update![balance_update, total_supply_update]
     }

--- a/frame/common/Cargo.toml
+++ b/frame/common/Cargo.toml
@@ -17,7 +17,8 @@ bincode-std = { package = "bincode", version = "1.3", optional = true }
 bincode-sgx = { package = "bincode", git = "https://github.com/mesalock-linux/bincode-sgx", optional = true }
 serde_bytes_std = { package = "serde_bytes", version = "0.11", optional = true }
 serde_bytes_sgx = { package = "serde_bytes", git = "https://github.com/mesalock-linux/serde-bytes-sgx", optional = true }
-serde_json = { rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx", optional = true }
+serde_json_sgx = { package = "serde_json", rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx", optional = true }
+serde_json_std = { package = "serde_json", version = "1.0", optional = true }
 tiny-keccak = "1.4"
 ed25519-dalek = { version = "1.0.0-pre.2", default-features = false, features = ["u64_backend"] }
 sha2 = { version = "0.8", default-features = false }
@@ -45,6 +46,7 @@ std = [
     "rand_core",
     "rand_os",
     "once_cell_std",
+    "serde_json_std",
 ]
 sgx = [
     "sgx_tstd",
@@ -52,7 +54,7 @@ sgx = [
     "sgx-anyhow",
     "serde-sgx",
     "serde-sgx/derive",
-    "serde_json",
+    "serde_json_sgx",
     "bincode-sgx",
     "serde_bytes_sgx",
     "serde-big-array-sgx",

--- a/frame/common/src/lib.rs
+++ b/frame/common/src/lib.rs
@@ -28,6 +28,10 @@ use serde_bytes_std as serde_bytes;
 use serde_sgx as serde;
 #[cfg(feature = "std")]
 use serde_std as serde;
+#[cfg(all(feature = "sgx", not(feature = "std")))]
+use serde_json_sgx as serde_json;
+#[cfg(feature = "std")]
+use serde_json_std as serde_json;
 #[cfg(feature = "sgx")]
 use sgx_anyhow as local_anyhow;
 

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -44,7 +44,7 @@ impl From<AccountId> for StateType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(crate = "crate::serde")]
 pub enum ReturnState<S: State> {
-    Updated(#[serde(bound(deserialize = "S: State"))] (Vec<UpdatedState<S>>, Vec<NotifyState>)),
+    Updated(#[serde(bound(deserialize = "S: State"))] (Vec<UpdatedState<S>>, Vec<Option<NotifyState>>)),
     Get(#[serde(bound(deserialize = "S: State"))] S),
 }
 

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -4,6 +4,7 @@ use crate::local_anyhow::Result;
 use crate::localstd::vec::Vec;
 use crate::serde::{Deserialize, Serialize};
 use crate::serde_bytes;
+use crate::serde_json;
 use crate::traits::State;
 
 pub trait RawState: Clone + Default {}
@@ -43,7 +44,7 @@ impl From<AccountId> for StateType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(crate = "crate::serde")]
 pub enum ReturnState<S: State> {
-    Updated(#[serde(bound(deserialize = "S: State"))] Vec<UpdatedState<S>>),
+    Updated(#[serde(bound(deserialize = "S: State"))] (Vec<UpdatedState<S>>, Vec<NotifyState>)),
     Get(#[serde(bound(deserialize = "S: State"))] S),
 }
 
@@ -77,6 +78,24 @@ impl<S: State> UpdatedState<S> {
             mem_id: update.mem_id,
             state,
         })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(crate = "crate::serde")]
+pub struct NotifyState {
+    pub account_id: AccountId,
+    pub mem_id: MemId,
+    pub state: serde_json::Value,
+}
+
+impl NotifyState {
+    pub fn new(account_id: AccountId, mem_id: MemId, state: serde_json::Value) -> Self {
+        Self {
+            account_id,
+            mem_id,
+            state,
+        }
     }
 }
 

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -69,16 +69,6 @@ impl<S: State> UpdatedState<S> {
             state: state.into(),
         })
     }
-
-    pub fn from_state_type(update: UpdatedState<StateType>) -> Result<Self> {
-        let state = bincode::deserialize(&update.state.as_bytes()[..])?;
-
-        Ok(UpdatedState {
-            account_id: update.account_id,
-            mem_id: update.mem_id,
-            state,
-        })
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/frame/runtime/src/impls.rs
+++ b/frame/runtime/src/impls.rs
@@ -185,14 +185,21 @@ macro_rules! __impl_inner_runtime {
 #[macro_export]
 macro_rules! update {
     ($account_id:expr, $mem_name:expr, $value:expr, $state_type:ty) => {
-        (
-            UpdatedState::new($account_id, MemName::as_id($mem_name), $value.clone())?,
-            NotifyState::new(
-                $account_id,
-                MemName::as_id($mem_name),
-                serde_json::to_value::<$state_type>($value)?,
-            ),
-        )
+        if stringify!($state_type) == "Approved" {
+            (
+                UpdatedState::new($account_id, MemName::as_id($mem_name), $value.clone())?,
+                None,
+            )
+        } else {
+            (
+                UpdatedState::new($account_id, MemName::as_id($mem_name), $value.clone())?,
+                Some(NotifyState::new(
+                    $account_id,
+                    MemName::as_id($mem_name),
+                    serde_json::to_value::<$state_type>($value)?,
+                )),
+            )
+        }
     };
 }
 

--- a/frame/runtime/src/impls.rs
+++ b/frame/runtime/src/impls.rs
@@ -184,19 +184,24 @@ macro_rules! __impl_inner_runtime {
 
 #[macro_export]
 macro_rules! update {
-    ($account_id:expr, $mem_name:expr, $value:expr) => {
-        UpdatedState::new($account_id, MemName::as_id($mem_name), $value)?
-    };
-
-    ($mem_name:expr, $value:expr) => {
-        UpdatedState::new($mem_name, MemName::as_id($mem_name), $value)?
+    ($account_id:expr, $mem_name:expr, $value:expr, $state_type:ty) => {
+        (
+            UpdatedState::new($account_id, MemName::as_id($mem_name), $value.clone())?,
+            NotifyState::new(
+                $account_id,
+                MemName::as_id($mem_name),
+                serde_json::to_value::<$state_type>($value)?,
+            ),
+        )
     };
 }
 
 #[macro_export]
 macro_rules! return_update {
     ( $($update:expr),* ) => {
-        Ok(ReturnState::Updated(vec![$( $update),* ]))
+        Ok(
+            ReturnState::<StateType>::Updated((vec![$( $update.0),* ], vec![$( $update.1 ),* ]))
+        )
     };
 }
 

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -7,7 +7,7 @@ use crate::localstd::{
 use crate::serde::{de::DeserializeOwned, Serialize};
 use frame_common::{
     crypto::{AccountId, BackupPathSecret, Ciphertext, RecoverAllRequest, RecoveredPathSecret},
-    state_types::{MemId, ReturnState, UpdatedState},
+    state_types::{MemId, ReturnState, UpdatedState, NotifyState},
     traits::*,
 };
 use frame_treekem::{
@@ -98,8 +98,9 @@ pub trait StateOps {
     /// Returns a updated state of registered account_id in notification.
     fn update_state(
         &self,
-        state_iter: impl Iterator<Item = UpdatedState<Self::S>> + Clone,
-    ) -> Option<UpdatedState<Self::S>>;
+        updated_state_iter: impl Iterator<Item = UpdatedState<Self::S>>,
+        notify_state_iter: impl Iterator<Item = NotifyState>,
+    ) -> Option<NotifyState>;
 }
 
 pub trait GroupKeyGetter {

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -7,7 +7,7 @@ use crate::localstd::{
 use crate::serde::{de::DeserializeOwned, Serialize};
 use frame_common::{
     crypto::{AccountId, BackupPathSecret, Ciphertext, RecoverAllRequest, RecoveredPathSecret},
-    state_types::{MemId, ReturnState, UpdatedState, NotifyState},
+    state_types::{MemId, NotifyState, ReturnState, UpdatedState},
     traits::*,
 };
 use frame_treekem::{
@@ -99,7 +99,7 @@ pub trait StateOps {
     fn update_state(
         &self,
         updated_state_iter: impl Iterator<Item = UpdatedState<Self::S>>,
-        notify_state_iter: impl Iterator<Item = NotifyState>,
+        notify_state_iter: impl Iterator<Item = Option<NotifyState>>,
     ) -> Option<NotifyState>;
 }
 

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -9,11 +9,11 @@ use crate::serde::{
     ser::SerializeSeq,
     Deserialize, Serialize, Serializer,
 };
-use crate::serde_bytes;
+use crate::serde_bytes::{self, ByteBuf};
 use crate::serde_json;
 use frame_common::{
     crypto::{Ciphertext, ExportHandshake},
-    state_types::{StateType, UpdatedState},
+    state_types::StateType,
     traits::AccessPolicy,
     EcallInput, EcallOutput,
 };
@@ -293,7 +293,7 @@ pub mod output {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     #[serde(crate = "crate::serde")]
     pub struct ReturnUpdatedState {
-        pub updated_state: Option<UpdatedState<StateType>>,
+        pub updated_state: Option<ByteBuf>,
     }
 
     impl EcallOutput for ReturnUpdatedState {}
@@ -307,12 +307,8 @@ pub mod output {
     }
 
     impl ReturnUpdatedState {
-        pub fn new(updated_state: Option<UpdatedState<StateType>>) -> Self {
-            ReturnUpdatedState { updated_state }
-        }
-
-        pub fn update(&mut self, updated_state: UpdatedState<StateType>) {
-            self.updated_state = Some(updated_state)
+        pub fn update(&mut self, updated_state: Vec<u8>) {
+            self.updated_state = Some(ByteBuf::from(updated_state))
         }
     }
 

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -292,23 +292,23 @@ pub mod output {
 
     #[derive(Serialize, Deserialize, Debug, Clone)]
     #[serde(crate = "crate::serde")]
-    pub struct ReturnUpdatedState {
-        pub updated_state: Option<ByteBuf>,
+    pub struct ReturnNotifyState {
+        pub state: Option<ByteBuf>,
     }
 
-    impl EcallOutput for ReturnUpdatedState {}
+    impl EcallOutput for ReturnNotifyState {}
 
-    impl Default for ReturnUpdatedState {
+    impl Default for ReturnNotifyState {
         fn default() -> Self {
-            ReturnUpdatedState {
-                updated_state: None,
+            ReturnNotifyState {
+                state: None,
             }
         }
     }
 
-    impl ReturnUpdatedState {
-        pub fn update(&mut self, updated_state: Vec<u8>) {
-            self.updated_state = Some(ByteBuf::from(updated_state))
+    impl ReturnNotifyState {
+        pub fn update(&mut self, state: Vec<u8>) {
+            self.state = Some(ByteBuf::from(state))
         }
     }
 

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -9,7 +9,7 @@ use crate::serde::{
     ser::SerializeSeq,
     Deserialize, Serialize, Serializer,
 };
-use crate::serde_bytes::{self, ByteBuf};
+use crate::serde_bytes;
 use crate::serde_json;
 use frame_common::{
     crypto::{Ciphertext, ExportHandshake},
@@ -293,22 +293,20 @@ pub mod output {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     #[serde(crate = "crate::serde")]
     pub struct ReturnNotifyState {
-        pub state: Option<ByteBuf>,
+        pub state: Option<serde_bytes::ByteBuf>,
     }
 
     impl EcallOutput for ReturnNotifyState {}
 
     impl Default for ReturnNotifyState {
         fn default() -> Self {
-            ReturnNotifyState {
-                state: None,
-            }
+            ReturnNotifyState { state: None }
         }
     }
 
     impl ReturnNotifyState {
         pub fn update(&mut self, state: Vec<u8>) {
-            self.state = Some(ByteBuf::from(state))
+            self.state = Some(serde_bytes::ByteBuf::from(state))
         }
     }
 

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -181,7 +181,7 @@ where
     ) -> Result<
         Option<(
             impl Iterator<Item = UpdatedState<StateType>>,
-            impl Iterator<Item = NotifyState>,
+            impl Iterator<Item = Option<NotifyState>>,
         )>,
     > {
         if let Some(commands) = Commands::<R, CTX, AP>::decrypt(ciphertext, group_key)? {
@@ -202,7 +202,10 @@ where
         }
     }
 
-    fn stf_call(self, ctx: CTX) -> Result<(Vec<UpdatedState<StateType>>, Vec<NotifyState>)> {
+    fn stf_call(
+        self,
+        ctx: CTX,
+    ) -> Result<(Vec<UpdatedState<StateType>>, Vec<Option<NotifyState>>)> {
         let res = R::new(ctx).execute(self.call_kind, self.my_account_id)?;
 
         match res {

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -73,7 +73,7 @@ where
     AP: AccessPolicy,
 {
     type EI = input::InsertCiphertext;
-    type EO = output::ReturnUpdatedState;
+    type EO = output::ReturnNotifyState;
 
     fn decrypt<C>(ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
     where
@@ -112,7 +112,7 @@ where
             self.ecall_input.ciphertext(),
             group_key,
         )?;
-        let mut output = output::ReturnUpdatedState::default();
+        let mut output = output::ReturnNotifyState::default();
 
         if let Some(state_iter) = iter_op {
             if let Some(notify_state) = enclave_context.update_state(state_iter.0, state_iter.1) {

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -15,11 +15,11 @@ use std::{marker::PhantomData, vec::Vec};
 
 /// A message sender that encrypts commands
 #[derive(Debug, Clone, Default)]
-pub struct MsgSender<AP: AccessPolicy> {
+pub struct CmdSender<AP: AccessPolicy> {
     ecall_input: input::Command<AP>,
 }
 
-impl<AP> EnclaveEngine for MsgSender<AP>
+impl<AP> EnclaveEngine for CmdSender<AP>
 where
     AP: AccessPolicy,
 {
@@ -63,12 +63,12 @@ where
 
 /// A message receiver that decrypt commands and make state transition
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct MsgReceiver<AP> {
+pub struct CmdReceiver<AP> {
     ecall_input: input::InsertCiphertext,
     ap: PhantomData<AP>,
 }
 
-impl<AP> EnclaveEngine for MsgReceiver<AP>
+impl<AP> EnclaveEngine for CmdReceiver<AP>
 where
     AP: AccessPolicy,
 {

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -116,10 +116,19 @@ impl StateOps for AnonifyEnclaveContext {
     fn update_state(
         &self,
         updated_state_iter: impl Iterator<Item = UpdatedState<Self::S>>,
-        mut notify_state_iter: impl Iterator<Item = NotifyState>,
+        mut notify_state_iter: impl Iterator<Item = Option<NotifyState>>,
     ) -> Option<NotifyState> {
         updated_state_iter.for_each(|s| self.db.insert_by_updated_state(s));
-        notify_state_iter.find(|s| self.is_notified(&s.account_id))
+        notify_state_iter
+            .find(|state| {
+                if let Some(s) = state {
+                    self.is_notified(&s.account_id)
+                } else {
+                    // if the type of NotifyState is `Approved`
+                    false
+                }
+            })
+            .and_then(|e| e)
     }
 }
 

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -9,7 +9,7 @@ use frame_common::{
         AccountId, BackupPathSecret, KeyVaultCmd, KeyVaultRequest, RecoverAllRequest,
         RecoverRequest, RecoveredPathSecret,
     },
-    state_types::{MemId, ReturnState, StateType, UpdatedState},
+    state_types::{MemId, NotifyState, ReturnState, StateType, UpdatedState},
     AccessPolicy,
 };
 use frame_config::{IAS_ROOT_CERT, KEY_VAULT_ENCLAVE_MEASUREMENT, PATH_SECRETS_DIR};
@@ -115,12 +115,11 @@ impl StateOps for AnonifyEnclaveContext {
     // TODO: Enables to return multiple updated states.
     fn update_state(
         &self,
-        mut state_iter: impl Iterator<Item = UpdatedState<Self::S>> + Clone,
-    ) -> Option<UpdatedState<Self::S>> {
-        state_iter
-            .clone()
-            .for_each(|s| self.db.insert_by_updated_state(s));
-        state_iter.find(|s| self.is_notified(&s.account_id))
+        updated_state_iter: impl Iterator<Item = UpdatedState<Self::S>>,
+        mut notify_state_iter: impl Iterator<Item = NotifyState>,
+    ) -> Option<NotifyState> {
+        updated_state_iter.for_each(|s| self.db.insert_by_updated_state(s));
+        notify_state_iter.find(|s| self.is_notified(&s.account_id))
     }
 }
 

--- a/modules/anonify-enclave/src/lib.rs
+++ b/modules/anonify-enclave/src/lib.rs
@@ -19,7 +19,7 @@ mod notify;
 pub mod workflow {
     #[cfg(feature = "backup-enable")]
     pub use crate::backup::{PathSecretBackupper, PathSecretRecoverer};
-    pub use crate::commands::{MsgReceiver, MsgSender};
+    pub use crate::commands::{CmdReceiver, CmdSender};
     pub use crate::context::{GetState, ReportRegistration};
     pub use crate::handshake::{HandshakeReceiver, HandshakeSender, JoinGroupSender};
     pub use crate::identity_key::EncryptingKeyGetter;

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -8,7 +8,6 @@ use crate::{
     utils::*,
     workflow::host_input,
 };
-use frame_common::{state_types::UpdatedState, traits::*};
 use frame_host::engine::HostEngine;
 use frame_treekem::{DhPubKey, EciesCiphertext};
 use parking_lot::RwLock;
@@ -226,14 +225,11 @@ where
         Ok(tx_hash)
     }
 
-    pub async fn fetch_events<St>(
+    pub async fn fetch_events(
         &self,
         fetch_ciphertext_cmd: u32,
         fetch_handshake_cmd: u32,
-    ) -> Result<Option<Vec<UpdatedState<St>>>>
-    where
-        St: State,
-    {
+    ) -> Result<Option<Vec<serde_json::Value>>> {
         let inner = self.inner.read();
         let eid = inner.deployer.get_enclave_id();
         inner

--- a/modules/anonify-eth-driver/src/eth/event_watcher.rs
+++ b/modules/anonify-eth-driver/src/eth/event_watcher.rs
@@ -295,10 +295,16 @@ impl InnerEnclaveLog {
                             }) {
                             Ok(notify) => {
                                 if let Some(notify_state) = notify.state {
-                                    match bincode::deserialize::<serde_json::Value>(
+                                    match bincode::deserialize::<Vec<u8>>(
                                         &notify_state.into_vec()[..],
                                     ) {
-                                        Ok(s) => acc.push(s),
+                                        Ok(bytes) => match serde_json::from_slice(&bytes[..]) {
+                                            Ok(json) => acc.push(json),
+                                            Err(err) => error!(
+                                                "Error in serde_json::from_slice(&bytes[..]): {:?}",
+                                                err
+                                            ),
+                                        },
                                         Err(err) => {
                                             error!("Error in bincode::deserialize: {:?}", err)
                                         }

--- a/modules/anonify-eth-driver/src/traits.rs
+++ b/modules/anonify-eth-driver/src/traits.rs
@@ -3,7 +3,6 @@
 use crate::{cache::EventCache, error::Result, utils::*, workflow::*};
 
 use async_trait::async_trait;
-use frame_common::{state_types::UpdatedState, traits::*};
 use sgx_types::sgx_enclave_id_t;
 use std::{marker::Send, path::Path};
 use web3::types::{Address, H256};
@@ -73,12 +72,12 @@ pub trait Watcher: Sized {
     ) -> Result<Self>;
 
     /// Blocking event fetch from blockchain nodes.
-    async fn fetch_events<S: State>(
+    async fn fetch_events(
         &self,
         eid: sgx_enclave_id_t,
         fetch_ciphertext_cmd: u32,
         fetch_handshake_cmd: u32,
-    ) -> Result<Option<Vec<UpdatedState<S>>>>;
+    ) -> Result<Option<Vec<serde_json::Value>>>;
 
     fn get_contract(self) -> ContractKind;
 }

--- a/modules/anonify-eth-driver/src/workflow.rs
+++ b/modules/anonify-eth-driver/src/workflow.rs
@@ -71,7 +71,7 @@ pub struct InsertCiphertextWorkflow;
 impl HostEngine for InsertCiphertextWorkflow {
     type HI = host_input::InsertCiphertext;
     type EI = input::InsertCiphertext;
-    type EO = output::ReturnUpdatedState;
+    type EO = output::ReturnNotifyState;
     type HO = host_output::InsertCiphertext;
     const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
 }
@@ -571,11 +571,11 @@ pub mod host_output {
     }
 
     pub struct InsertCiphertext {
-        pub ecall_output: Option<output::ReturnUpdatedState>,
+        pub ecall_output: Option<output::ReturnNotifyState>,
     }
 
     impl HostOutput for InsertCiphertext {
-        type EcallOutput = output::ReturnUpdatedState;
+        type EcallOutput = output::ReturnNotifyState;
 
         fn set_ecall_output(mut self, output: Self::EcallOutput) -> anyhow::Result<Self> {
             self.ecall_output = Some(output);

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -5,6 +5,7 @@ use erc20_state_transition::cmd::*;
 use ethabi::Contract as ContractABI;
 use frame_common::{
     crypto::{AccountId, Ed25519ChallengeResponse, COMMON_ACCESS_POLICY},
+    state_types::NotifyState,
     traits::*,
 };
 use frame_host::EnclaveDir;
@@ -96,7 +97,7 @@ async fn test_integration_eth_construct() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -126,7 +127,7 @@ async fn test_integration_eth_construct() {
 
     // Get logs from contract and update state inside enclave.
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -204,7 +205,7 @@ async fn test_auto_notification() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -241,18 +242,25 @@ async fn test_auto_notification() {
 
     // Get logs from contract and update state inside enclave.
     let updated_state = dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap()
         .unwrap();
+    let notified_state: Vec<NotifyState> = updated_state
+        .into_iter()
+        .map(|e| serde_json::from_value(e).unwrap())
+        .collect();
 
-    assert_eq!(updated_state.len(), 1);
+    assert_eq!(notified_state.len(), 1);
     assert_eq!(
-        updated_state[0].account_id,
+        notified_state[0].account_id,
         my_access_policy.into_account_id()
     );
-    assert_eq!(updated_state[0].mem_id.as_raw(), 0);
-    assert_eq!(updated_state[0].state, U64::from_raw(total_supply));
+    assert_eq!(notified_state[0].mem_id.as_raw(), 0);
+    assert_eq!(
+        serde_json::from_value::<U64>(notified_state[0].state.clone()).unwrap(),
+        U64::from_raw(total_supply)
+    );
 
     // Send a transaction to contract
     let amount: u64 = 30;
@@ -275,18 +283,25 @@ async fn test_auto_notification() {
 
     // Update state inside enclave
     let updated_state = dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap()
         .unwrap();
+    let notified_state: Vec<NotifyState> = updated_state
+        .into_iter()
+        .map(|e| serde_json::from_value(e).unwrap())
+        .collect();
 
-    assert_eq!(updated_state.len(), 1);
+    assert_eq!(notified_state.len(), 1);
     assert_eq!(
-        updated_state[0].account_id,
+        notified_state[0].account_id,
         my_access_policy.into_account_id()
     );
-    assert_eq!(updated_state[0].mem_id.as_raw(), 0);
-    assert_eq!(updated_state[0].state, U64::from_raw(70));
+    assert_eq!(notified_state[0].mem_id.as_raw(), 0);
+    assert_eq!(
+        serde_json::from_value::<U64>(notified_state[0].state.clone()).unwrap(),
+        U64::from_raw(70)
+    );
 }
 
 #[actix_rt::test]
@@ -327,7 +342,7 @@ async fn test_integration_eth_transfer() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -358,7 +373,7 @@ async fn test_integration_eth_transfer() {
 
     // Get logs from contract and update state inside enclave.
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -414,7 +429,7 @@ async fn test_integration_eth_transfer() {
 
     // Update state inside enclave
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -489,7 +504,7 @@ async fn test_key_rotation() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -502,7 +517,7 @@ async fn test_key_rotation() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -531,7 +546,7 @@ async fn test_key_rotation() {
 
     // Get logs from contract and update state inside enclave.
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -604,7 +619,7 @@ async fn test_integration_eth_approve() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -634,7 +649,7 @@ async fn test_integration_eth_approve() {
 
     // Get logs from contract and update state inside enclave.
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -684,7 +699,7 @@ async fn test_integration_eth_approve() {
 
     // Update state inside enclave
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -753,7 +768,7 @@ async fn test_integration_eth_transfer_from() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -783,7 +798,7 @@ async fn test_integration_eth_transfer_from() {
 
     // Get logs from contract and update state inside enclave.
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -880,7 +895,7 @@ async fn test_integration_eth_transfer_from() {
 
     // Update state inside enclave
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -975,7 +990,7 @@ async fn test_integration_eth_transfer_from() {
 
     // Update state inside enclave
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -1085,7 +1100,7 @@ async fn test_integration_eth_mint() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -1115,7 +1130,7 @@ async fn test_integration_eth_mint() {
 
     // Get logs from contract and update state inside enclave.
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -1141,7 +1156,7 @@ async fn test_integration_eth_mint() {
 
     // Update state inside enclave
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -1214,7 +1229,7 @@ async fn test_integration_eth_burn() {
 
     // Get handshake from contract
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -1244,7 +1259,7 @@ async fn test_integration_eth_burn() {
 
     // Get logs from contract and update state inside enclave.
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -1274,7 +1289,7 @@ async fn test_integration_eth_burn() {
 
     // Update state inside enclave
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 
@@ -1297,7 +1312,7 @@ async fn test_integration_eth_burn() {
 
     // Update state inside enclave
     dispatcher
-        .fetch_events::<U64>(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
         .await
         .unwrap();
 


### PR DESCRIPTION
* 状態遷移の型が分かる段階でserializeしないといけないので、新たに `UpdatedState`の他に `NotifyState`定義しています
* `UpdatedState`は バイナリエンコードされる一方、 `NotifyState` は jsonエンコードした上でバイナリエンコードしています。
*  状態型が`Approved`の場合はNotificationスキップ （`BTreeMap`のキーがnot `String`の場合 `Serde_json::to_value()`できないため）（#414）