### PR TITLE
Implement a counter for enforcing the order of state transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,8 +352,8 @@ dependencies = [
 name = "anonify-ecall-types"
 version = "0.1.0"
 dependencies = [
- "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "frame-common",
  "frame-runtime",
  "frame-sodium",
@@ -586,9 +586,10 @@ dependencies = [
 [[package]]
 name = "base64"
 version = "0.10.1"
-source = "git+https://github.com/mesalock-linux/rust-base64-sgx#368a1db999e3005bb1bf2278dbe31f0906441f8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
- "sgx_tstd",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -602,10 +603,9 @@ dependencies = [
 [[package]]
 name = "base64"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+source = "git+https://github.com/mesalock-linux/rust-base64-sgx#368a1db999e3005bb1bf2278dbe31f0906441f8c"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -629,11 +629,11 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "bincode"
 version = "1.3.1"
-source = "git+https://github.com/mesalock-linux/bincode-sgx#58b004eb5bd7ab8e974a02b70344afcd9724bb2d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
- "byteorder 1.3.4 (git+https://github.com/mesalock-linux/byteorder-sgx)",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git)",
- "sgx_tstd",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -649,11 +649,11 @@ dependencies = [
 [[package]]
 name = "bincode"
 version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+source = "git+https://github.com/mesalock-linux/bincode-sgx#58b004eb5bd7ab8e974a02b70344afcd9724bb2d"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.117",
+ "byteorder 1.3.4 (git+https://github.com/mesalock-linux/byteorder-sgx)",
+ "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git)",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -702,23 +702,23 @@ dependencies = [
 [[package]]
 name = "block-buffer"
 version = "0.7.3"
-source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
-dependencies = [
- "block-padding 0.1.4",
- "byte-tools 0.3.1 (git+https://github.com/mesalock-linux/rustcrypto-utils-sgx)",
- "byteorder 1.3.4 (git+https://github.com/mesalock-linux/byteorder-sgx)",
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding 0.1.5",
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+dependencies = [
+ "block-padding 0.1.4",
+ "byte-tools 0.3.1 (git+https://github.com/mesalock-linux/rustcrypto-utils-sgx)",
+ "byteorder 1.3.4 (git+https://github.com/mesalock-linux/byteorder-sgx)",
  "generic-array 0.12.3",
 ]
 
@@ -808,13 +808,19 @@ checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 [[package]]
 name = "byte-tools"
 version = "0.3.1"
-source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byte-tools"
 version = "0.3.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+
+[[package]]
+name = "byteorder"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "byteorder"
@@ -823,12 +829,6 @@ source = "git+https://github.com/mesalock-linux/byteorder-sgx#325f392dcd294109eb
 dependencies = [
  "sgx_tstd",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
@@ -1151,13 +1151,13 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 [[package]]
 name = "cpuid-bool"
 version = "0.2.0"
-source = "git+https://github.com/cipepser/utils?branch=sgx#b68163b0515e3a63de4095ade35946ec7166286d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cpuid-bool"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+source = "git+https://github.com/cipepser/utils?branch=sgx#b68163b0515e3a63de4095ade35946ec7166286d"
 
 [[package]]
 name = "crc32fast"
@@ -1245,15 +1245,6 @@ dependencies = [
 [[package]]
 name = "crypto-mac"
 version = "0.8.0"
-source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
-dependencies = [
- "generic-array 0.12.3",
- "subtle 2.2.2",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
@@ -1262,16 +1253,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto_box"
-version = "0.5.0"
-source = "git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core#1c35142b1f204cd5b59527767736b7cdc2e93420"
+name = "crypto-mac"
+version = "0.8.0"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
 dependencies = [
- "chacha20poly1305 0.7.0",
- "rand_core 0.5.1 (git+https://github.com/cipepser/rand?branch=feature/only-trait)",
- "salsa20",
- "x25519-dalek 1.1.0 (git+https://github.com/cipepser/x25519-dalek?branch=feature/my-rand_core)",
- "xsalsa20poly1305 0.6.0 (git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core)",
- "zeroize 1.2.0",
+ "generic-array 0.12.3",
+ "subtle 2.2.2",
 ]
 
 [[package]]
@@ -1285,6 +1272,19 @@ dependencies = [
  "salsa20",
  "x25519-dalek 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xsalsa20poly1305 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.5.0"
+source = "git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core#1c35142b1f204cd5b59527767736b7cdc2e93420"
+dependencies = [
+ "chacha20poly1305 0.7.0",
+ "rand_core 0.5.1 (git+https://github.com/cipepser/rand?branch=feature/only-trait)",
+ "salsa20",
+ "x25519-dalek 1.1.0 (git+https://github.com/cipepser/x25519-dalek?branch=feature/my-rand_core)",
+ "xsalsa20poly1305 0.6.0 (git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core)",
  "zeroize 1.2.0",
 ]
 
@@ -1380,19 +1380,19 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.8.1"
-source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.3",
- "sgx_tstd",
 ]
 
 [[package]]
 name = "digest"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
 dependencies = [
  "generic-array 0.12.3",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -1702,8 +1702,8 @@ dependencies = [
  "anyhow 1.0.28",
  "anyhow 1.0.34",
  "base64 0.11.0",
- "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "ed25519-dalek",
  "hex",
  "once_cell 1.4.0 (git+https://github.com/mesalock-linux/once_cell-sgx?rev=sgx_1.1.3)",
@@ -1814,8 +1814,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28",
  "anyhow 1.0.34",
- "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "frame-common",
  "frame-sodium",
  "frame-treekem",
@@ -1836,14 +1836,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28",
  "anyhow 1.0.34",
- "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto_box 0.5.0 (git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core)",
+ "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "crypto_box 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto_box 0.5.0 (git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core)",
  "frame-common",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (git+https://github.com/cipepser/rand?branch=feature/only-trait)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (git+https://github.com/cipepser/rand?branch=feature/only-trait)",
  "serde 1.0.117",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git)",
  "serde_bytes 0.11.3",
@@ -1852,8 +1852,8 @@ dependencies = [
  "sgx_trts",
  "sgx_tstd",
  "sgx_types 1.1.3",
- "xsalsa20poly1305 0.6.0 (git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core)",
  "xsalsa20poly1305 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xsalsa20poly1305 0.6.0 (git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core)",
 ]
 
 [[package]]
@@ -1864,8 +1864,8 @@ dependencies = [
  "anyhow 1.0.34",
  "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "base64 0.11.0",
- "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.3.1 (git+https://github.com/mesalock-linux/bincode-sgx)",
  "frame-common",
  "frame-config",
  "frame-mra-tls",
@@ -2217,20 +2217,20 @@ dependencies = [
 [[package]]
 name = "hmac"
 version = "0.7.1"
-source = "git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx#e8e1410b9c82d2e59da42fa8b0d8ed38e80a203c"
-dependencies = [
- "crypto-mac 0.8.0 (git+https://github.com/mesalock-linux/rustcrypto-traits-sgx)",
- "digest 0.8.1 (git+https://github.com/mesalock-linux/rustcrypto-traits-sgx)",
-]
-
-[[package]]
-name = "hmac"
-version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac 0.7.0",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx#e8e1410b9c82d2e59da42fa8b0d8ed38e80a203c"
+dependencies = [
+ "crypto-mac 0.8.0 (git+https://github.com/mesalock-linux/rustcrypto-traits-sgx)",
+ "digest 0.8.1 (git+https://github.com/mesalock-linux/rustcrypto-traits-sgx)",
 ]
 
 [[package]]
@@ -2246,21 +2246,21 @@ dependencies = [
 [[package]]
 name = "hmac-drbg"
 version = "0.1.2"
-source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
-dependencies = [
- "generic-array 0.12.3",
- "hmac 0.7.1 (git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx)",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe727d41d2eec0a6574d887914347e5ff96a3b87177817e2a9820c5c87fecc2"
 dependencies = [
  "digest 0.6.2",
  "generic-array 0.8.3",
  "hmac 0.4.2",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.1.2"
+source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
+dependencies = [
+ "generic-array 0.12.3",
+ "hmac 0.7.1 (git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx)",
 ]
 
 [[package]]
@@ -2299,23 +2299,23 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.2.1"
-source = "git+https://github.com/mesalock-linux/http-sgx?rev=sgx_1.1.3#62544a1833f98f1810a44877c5f1efe45f5327c0"
-dependencies = [
- "bytes 0.5.4",
- "fnv 1.0.6",
- "itoa 0.4.5",
- "sgx_tstd",
-]
-
-[[package]]
-name = "http"
-version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
  "bytes 0.5.6",
  "fnv 1.0.7",
  "itoa 0.4.6",
+]
+
+[[package]]
+name = "http"
+version = "0.2.1"
+source = "git+https://github.com/mesalock-linux/http-sgx?rev=sgx_1.1.3#62544a1833f98f1810a44877c5f1efe45f5327c0"
+dependencies = [
+ "bytes 0.5.4",
+ "fnv 1.0.6",
+ "itoa 0.4.5",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -2870,19 +2870,19 @@ dependencies = [
 [[package]]
 name = "log"
 version = "0.4.11"
-source = "git+https://github.com/mesalock-linux/log-sgx#5a057d237cf96e9137de08387eb70105d5705648"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
- "sgx_tstd",
 ]
 
 [[package]]
 name = "log"
 version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+source = "git+https://github.com/mesalock-linux/log-sgx#5a057d237cf96e9137de08387eb70105d5705648"
 dependencies = [
  "cfg-if 0.1.10",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "once_cell"
 version = "1.4.0"
-source = "git+https://github.com/mesalock-linux/once_cell-sgx#cefcaa03fed4d85276b3235d875f1b45d399cc3c"
+source = "git+https://github.com/mesalock-linux/once_cell-sgx?rev=sgx_1.1.3#cefcaa03fed4d85276b3235d875f1b45d399cc3c"
 dependencies = [
  "sgx_tstd",
 ]
@@ -3156,7 +3156,7 @@ dependencies = [
 [[package]]
 name = "once_cell"
 version = "1.4.0"
-source = "git+https://github.com/mesalock-linux/once_cell-sgx?rev=sgx_1.1.3#cefcaa03fed4d85276b3235d875f1b45d399cc3c"
+source = "git+https://github.com/mesalock-linux/once_cell-sgx#cefcaa03fed4d85276b3235d875f1b45d399cc3c"
 dependencies = [
  "sgx_tstd",
 ]
@@ -3633,6 +3633,19 @@ dependencies = [
 [[package]]
 name = "rand"
 version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.15",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
 source = "git+https://github.com/mesalock-linux/rand-sgx?tag=v0.7.3_sgx1.1.3#55697c5a4007d13e8d5f37be7216be1b18fb8ebf"
 dependencies = [
  "getrandom 0.1.14",
@@ -3650,19 +3663,6 @@ dependencies = [
  "rand_chacha 0.2.1 (git+https://github.com/mesalock-linux/rand-sgx?rev=v0.7.3_sgx1.1.3)",
  "rand_core 0.5.1 (git+https://github.com/mesalock-linux/rand-sgx?rev=v0.7.3_sgx1.1.3)",
  "sgx_tstd",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.15",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -3723,16 +3723,20 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 [[package]]
 name = "rand_core"
 version = "0.5.1"
-source = "git+https://github.com/mesalock-linux/rand-sgx?tag=v0.7.3_sgx1.1.3#55697c5a4007d13e8d5f37be7216be1b18fb8ebf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.14",
- "sgx_tstd",
+ "getrandom 0.1.15",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.5.1"
-source = "git+https://github.com/cipepser/rand?branch=feature/only-trait#170c438bb13f94fb64f6b0190a156093ec0bc855"
+source = "git+https://github.com/mesalock-linux/rand-sgx?tag=v0.7.3_sgx1.1.3#55697c5a4007d13e8d5f37be7216be1b18fb8ebf"
+dependencies = [
+ "getrandom 0.1.14",
+ "sgx_tstd",
+]
 
 [[package]]
 name = "rand_core"
@@ -3746,11 +3750,7 @@ dependencies = [
 [[package]]
 name = "rand_core"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.15",
-]
+source = "git+https://github.com/cipepser/rand?branch=feature/only-trait#170c438bb13f94fb64f6b0190a156093ec0bc855"
 
 [[package]]
 name = "rand_hc"
@@ -4068,19 +4068,6 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.19.0"
-source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
-dependencies = [
- "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.11 (git+https://github.com/mesalock-linux/log-sgx)",
- "ring 0.16.19",
- "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx)",
- "sgx_tstd",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
-version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
@@ -4089,6 +4076,19 @@ dependencies = [
  "ring 0.16.15",
  "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.3",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.0"
+source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
+dependencies = [
+ "base64 0.10.1 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
+ "log 0.4.11 (git+https://github.com/mesalock-linux/log-sgx)",
+ "ring 0.16.19",
+ "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx)",
+ "sgx_tstd",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -4151,20 +4151,20 @@ dependencies = [
 [[package]]
 name = "sct"
 version = "0.6.0"
-source = "git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx#c4d859cca232e6c9d88ca12048df3bc26e1ed4ad"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
- "ring 0.16.19",
- "sgx_tstd",
+ "ring 0.16.15",
  "untrusted",
 ]
 
 [[package]]
 name = "sct"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+source = "git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx#c4d859cca232e6c9d88ca12048df3bc26e1ed4ad"
 dependencies = [
- "ring 0.16.15",
+ "ring 0.16.19",
+ "sgx_tstd",
  "untrusted",
 ]
 
@@ -4236,18 +4236,18 @@ dependencies = [
 [[package]]
 name = "serde"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx.git#db0226f1d5d70fca6b96af2c285851502204e21c"
+source = "git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
- "serde_derive 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git)",
+ "serde_derive 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3)",
  "sgx_tstd",
 ]
 
 [[package]]
 name = "serde"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
+source = "git+https://github.com/mesalock-linux/serde-sgx.git#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
- "serde_derive 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3)",
+ "serde_derive 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx.git)",
  "sgx_tstd",
 ]
 
@@ -4302,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "serde_derive"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx.git#db0226f1d5d70fca6b96af2c285851502204e21c"
+source = "git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "serde_derive"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx.git?rev=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
+source = "git+https://github.com/mesalock-linux/serde-sgx.git#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4734,7 +4734,8 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 [[package]]
 name = "stream-cipher"
 version = "0.3.2"
-source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
 dependencies = [
  "generic-array 0.12.3",
 ]
@@ -4742,8 +4743,7 @@ dependencies = [
 [[package]]
 name = "stream-cipher"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
 dependencies = [
  "generic-array 0.12.3",
 ]
@@ -5475,18 +5475,18 @@ dependencies = [
 [[package]]
 name = "unicase"
 version = "2.6.0"
-source = "git+https://github.com/mesalock-linux/unicase-sgx#0b0519348572927118af47af3da4da9ffdca8ec6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "sgx_tstd",
  "version_check",
 ]
 
 [[package]]
 name = "unicase"
 version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+source = "git+https://github.com/mesalock-linux/unicase-sgx#0b0519348572927118af47af3da4da9ffdca8ec6"
 dependencies = [
+ "sgx_tstd",
  "version_check",
 ]
 
@@ -5853,16 +5853,6 @@ dependencies = [
 [[package]]
 name = "x25519-dalek"
 version = "1.1.0"
-source = "git+https://github.com/cipepser/x25519-dalek?branch=feature/my-rand_core#448b56e5178ea0d4e755b2aaacdac8c9dba27e02"
-dependencies = [
- "curve25519-dalek 3.0.0",
- "rand_core 0.5.1 (git+https://github.com/cipepser/rand?branch=feature/only-trait)",
- "zeroize 1.2.0",
-]
-
-[[package]]
-name = "x25519-dalek"
-version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
@@ -5872,15 +5862,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "xsalsa20poly1305"
-version = "0.6.0"
-source = "git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core#1c35142b1f204cd5b59527767736b7cdc2e93420"
+name = "x25519-dalek"
+version = "1.1.0"
+source = "git+https://github.com/cipepser/x25519-dalek?branch=feature/my-rand_core#448b56e5178ea0d4e755b2aaacdac8c9dba27e02"
 dependencies = [
- "aead",
- "poly1305 0.7.0-pre",
+ "curve25519-dalek 3.0.0",
  "rand_core 0.5.1 (git+https://github.com/cipepser/rand?branch=feature/only-trait)",
- "salsa20",
- "subtle 2.3.0",
  "zeroize 1.2.0",
 ]
 
@@ -5893,6 +5880,19 @@ dependencies = [
  "aead",
  "poly1305 0.6.2",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "salsa20",
+ "subtle 2.3.0",
+ "zeroize 1.2.0",
+]
+
+[[package]]
+name = "xsalsa20poly1305"
+version = "0.6.0"
+source = "git+https://github.com/cipepser/AEADs.git?branch=feature/no-default-feature-in-rand-core#1c35142b1f204cd5b59527767736b7cdc2e93420"
+dependencies = [
+ "aead",
+ "poly1305 0.7.0-pre",
+ "rand_core 0.5.1 (git+https://github.com/cipepser/rand?branch=feature/only-trait)",
  "salsa20",
  "subtle 2.3.0",
  "zeroize 1.2.0",

--- a/contracts/Anonify.sol
+++ b/contracts/Anonify.sol
@@ -17,11 +17,8 @@ contract Anonify is ReportHandle {
     // Mapping of a sender and roster index
     mapping(address => uint32) private _senderToRosterIdx;
 
-    event StoreCiphertext(
-        bytes indexed ciphertext,
-        uint256 indexed stateCounter
-    );
-    event StoreHandshake(bytes indexed handshake, uint256 indexed stateCounter);
+    event StoreCiphertext(bytes ciphertext, uint256 stateCounter);
+    event StoreHandshake(bytes handshake, uint256 stateCounter);
     event UpdateMrenclaveVer(uint32 newVersion);
 
     constructor(

--- a/contracts/Anonify.sol
+++ b/contracts/Anonify.sol
@@ -111,8 +111,9 @@ contract Anonify is ReportHandle {
             "Invalid enclave signature."
         );
 
-        _stateCounter.add(1);
-        emit StoreCiphertext(_newCiphertext, _stateCounter);
+        uint256 incremented_state_counter = _stateCounter.add(1);
+        _stateCounter = incremented_state_counter;
+        emit StoreCiphertext(_newCiphertext, incremented_state_counter);
     }
 
     function handshake(
@@ -142,7 +143,8 @@ contract Anonify is ReportHandle {
     }
 
     function storeHandshake(bytes memory _handshake) private {
-        _stateCounter.add(1);
-        emit StoreHandshake(_handshake, _stateCounter);
+        uint256 incremented_state_counter = _stateCounter.add(1);
+        _stateCounter = incremented_state_counter;
+        emit StoreHandshake(_handshake, incremented_state_counter);
     }
 }

--- a/contracts/Anonify.sol
+++ b/contracts/Anonify.sol
@@ -12,11 +12,13 @@ contract Anonify is ReportHandle {
 
     // An counter of registered roster index
     uint32 private _rosterIdxCounter;
+    // Counter for enforcing the order of state transitions
+    uint256 private _stateCounter;
     // Mapping of a sender and roster index
     mapping(address => uint32) private _senderToRosterIdx;
 
-    event StoreCiphertext(bytes ciphertext);
-    event StoreHandshake(bytes handshake);
+    event StoreCiphertext(bytes ciphertext, uint256 stateCounter);
+    event StoreHandshake(bytes handshake, uint256 stateCounter);
     event UpdateMrenclaveVer(uint32 newVersion);
 
     constructor(
@@ -33,7 +35,7 @@ contract Anonify is ReportHandle {
         _mrenclaveVer = mrenclaveVer;
         _senderToRosterIdx[msg.sender] = rosterIdx;
         _rosterIdxCounter = rosterIdx;
-        handshake_wo_sig(_handshake);
+        storeHandshake(_handshake);
     }
 
     modifier onlyOwner() {
@@ -62,7 +64,7 @@ contract Anonify is ReportHandle {
         handleReport(_report, _reportSig);
         _senderToRosterIdx[msg.sender] = _rosterIdx;
         _rosterIdxCounter = _rosterIdx;
-        handshake_wo_sig(_handshake);
+        storeHandshake(_handshake);
     }
 
     // a recovered TEE node registers the report
@@ -89,8 +91,8 @@ contract Anonify is ReportHandle {
         require(_rosterIdx == 0, "Only owner can update mrenclave");
 
         updateMrenclaveInner(_report, _reportSig);
-        handshake_wo_sig(_handshake);
         _mrenclaveVer = _newVersion;
+        storeHandshake(_handshake);
         emit UpdateMrenclaveVer(_newVersion);
     }
 
@@ -98,10 +100,8 @@ contract Anonify is ReportHandle {
     function storeCommand(bytes memory _newCiphertext, bytes memory _enclaveSig)
         public
     {
-        address verifyingKey = Secp256k1.recover(
-            sha256(_newCiphertext),
-            _enclaveSig
-        );
+        address verifyingKey =
+            Secp256k1.recover(sha256(_newCiphertext), _enclaveSig);
         require(
             verifyingKey != address(0),
             "recovered verifyingKey was address(0)"
@@ -111,7 +111,8 @@ contract Anonify is ReportHandle {
             "Invalid enclave signature."
         );
 
-        emit StoreCiphertext(_newCiphertext);
+        _stateCounter.add(1);
+        emit StoreCiphertext(_newCiphertext, _stateCounter);
     }
 
     function handshake(
@@ -123,10 +124,11 @@ contract Anonify is ReportHandle {
             _senderToRosterIdx[msg.sender] == _rosterIdx,
             "The roster index must be same as the registered one"
         );
-        address verifyingKey = Secp256k1.recover(
-            sha256(abi.encodePacked(_handshake, _rosterIdx)),
-            _enclaveSig
-        );
+        address verifyingKey =
+            Secp256k1.recover(
+                sha256(abi.encodePacked(_handshake, _rosterIdx)),
+                _enclaveSig
+            );
         require(
             verifyingKey != address(0),
             "recovered verifyingKey was address(0)"
@@ -136,10 +138,11 @@ contract Anonify is ReportHandle {
             "Invalid enclave signature."
         );
 
-        emit StoreHandshake(_handshake);
+        storeHandshake(_handshake);
     }
 
-    function handshake_wo_sig(bytes memory _handshake) private {
-        emit StoreHandshake(_handshake);
+    function storeHandshake(bytes memory _handshake) private {
+        _stateCounter.add(1);
+        emit StoreHandshake(_handshake, _stateCounter);
     }
 }

--- a/contracts/Anonify.sol
+++ b/contracts/Anonify.sol
@@ -17,8 +17,11 @@ contract Anonify is ReportHandle {
     // Mapping of a sender and roster index
     mapping(address => uint32) private _senderToRosterIdx;
 
-    event StoreCiphertext(bytes ciphertext, uint256 stateCounter);
-    event StoreHandshake(bytes handshake, uint256 stateCounter);
+    event StoreCiphertext(
+        bytes indexed ciphertext,
+        uint256 indexed stateCounter
+    );
+    event StoreHandshake(bytes indexed handshake, uint256 indexed stateCounter);
     event UpdateMrenclaveVer(uint32 newVersion);
 
     constructor(

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -125,10 +125,6 @@ impl StateCounter {
     }
 
     pub fn is_increment(self, other: StateCounter) -> bool {
-        if self.increment() == other {
-            true
-        } else {
-            false
-        }
+        self.increment() == other
     }
 }

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -44,7 +44,9 @@ impl From<AccountId> for StateType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(crate = "crate::serde")]
 pub enum ReturnState<S: State> {
-    Updated(#[serde(bound(deserialize = "S: State"))] (Vec<UpdatedState<S>>, Vec<Option<NotifyState>>)),
+    Updated(
+        #[serde(bound(deserialize = "S: State"))] (Vec<UpdatedState<S>>, Vec<Option<NotifyState>>),
+    ),
     Get(#[serde(bound(deserialize = "S: State"))] S),
 }
 
@@ -103,5 +105,18 @@ impl MemId {
 
     pub fn from_raw(u: u32) -> Self {
         MemId(u)
+    }
+}
+
+/// Counter for enforcing the order of state transitions
+#[derive(
+    Serialize, Deserialize, Debug, Clone, Copy, PartialOrd, PartialEq, Default, Eq, Ord, Hash,
+)]
+#[serde(crate = "crate::serde")]
+pub struct StateCounter(u32);
+
+impl StateCounter {
+    pub fn new(counter: u32) -> Self {
+        Self(counter)
     }
 }

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -119,4 +119,16 @@ impl StateCounter {
     pub fn new(counter: u32) -> Self {
         Self(counter)
     }
+
+    pub fn increment(self) -> Self {
+        StateCounter(self.0 + 1) // overflow should be ignored
+    }
+
+    pub fn is_increment(self, other: StateCounter) -> bool {
+        if self.increment() == other {
+            true
+        } else {
+            false
+        }
+    }
 }

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -7,7 +7,7 @@ use crate::localstd::{
 use crate::serde::{de::DeserializeOwned, Serialize};
 use frame_common::{
     crypto::{AccountId, BackupPathSecret, Ciphertext, RecoverAllRequest, RecoveredPathSecret},
-    state_types::{MemId, NotifyState, ReturnState, UpdatedState},
+    state_types::{MemId, NotifyState, ReturnState, StateCounter, UpdatedState},
     traits::*,
 };
 use frame_sodium::{SodiumCiphertext, SodiumPubKey};
@@ -100,6 +100,8 @@ pub trait StateOps {
         updated_state_iter: impl Iterator<Item = UpdatedState<Self::S>>,
         notify_state_iter: impl Iterator<Item = Option<NotifyState>>,
     ) -> Option<NotifyState>;
+
+    fn verify_state_counter_increment(&self, received_state_counter: StateCounter) -> Result<()>;
 }
 
 pub trait GroupKeyGetter {

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -13,7 +13,7 @@ use crate::serde_bytes;
 use crate::serde_json;
 use frame_common::{
     crypto::{Ciphertext, ExportHandshake},
-    state_types::StateType,
+    state_types::{StateCounter, StateType},
     traits::AccessPolicy,
     EcallInput, EcallOutput,
 };
@@ -73,17 +73,25 @@ pub mod input {
     #[serde(crate = "crate::serde")]
     pub struct InsertCiphertext {
         ciphertext: Ciphertext,
+        state_counter: StateCounter,
     }
 
     impl EcallInput for InsertCiphertext {}
 
     impl InsertCiphertext {
-        pub fn new(ciphertext: Ciphertext) -> Self {
-            InsertCiphertext { ciphertext }
+        pub fn new(ciphertext: Ciphertext, state_counter: StateCounter) -> Self {
+            InsertCiphertext {
+                ciphertext,
+                state_counter,
+            }
         }
 
         pub fn ciphertext(&self) -> &Ciphertext {
             &self.ciphertext
+        }
+
+        pub fn state_counter(&self) -> StateCounter {
+            self.state_counter
         }
     }
 
@@ -91,17 +99,25 @@ pub mod input {
     #[serde(crate = "crate::serde")]
     pub struct InsertHandshake {
         handshake: ExportHandshake,
+        state_counter: StateCounter,
     }
 
     impl EcallInput for InsertHandshake {}
 
     impl InsertHandshake {
-        pub fn new(handshake: ExportHandshake) -> Self {
-            InsertHandshake { handshake }
+        pub fn new(handshake: ExportHandshake, state_counter: StateCounter) -> Self {
+            InsertHandshake {
+                handshake,
+                state_counter,
+            }
         }
 
         pub fn handshake(&self) -> &ExportHandshake {
             &self.handshake
+        }
+
+        pub fn state_counter(&self) -> StateCounter {
+            self.state_counter
         }
     }
 
@@ -320,7 +336,9 @@ pub mod output {
 
     impl ReturnEncryptionKey {
         pub fn new(enclave_encryption_key: SodiumPubKey) -> Self {
-            ReturnEncryptionKey { enclave_encryption_key }
+            ReturnEncryptionKey {
+                enclave_encryption_key,
+            }
         }
 
         pub fn enclave_encryption_key(self) -> SodiumPubKey {

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -94,6 +94,9 @@ where
         let roster_idx = self.ecall_input.ciphertext().roster_idx() as usize;
         let msg_gen = self.ecall_input.ciphertext().generation();
 
+        // Even if group_key's ratchet operations and state transitions fail, state_counter must be incremented so it doesn't get stuck.
+        enclave_context.verify_state_counter_increment(self.ecall_input.state_counter())?;
+
         // Since the sender's keychain has already ratcheted,
         // even if an error occurs in the state transition, the receiver's keychain also ratchet.
         // `receiver_ratchet` fails if

--- a/modules/anonify-enclave/src/handshake.rs
+++ b/modules/anonify-enclave/src/handshake.rs
@@ -133,7 +133,8 @@ impl EnclaveEngine for HandshakeReceiver {
         let handshake = HandshakeParams::decode(&self.ecall_input.handshake().handshake()[..])
             .map_err(|_| anyhow!("HandshakeParams::decode Error"))?;
 
-        
+        // Even if `process_handshake` fails, state_counter must be incremented so it doesn't get stuck.
+        enclave_context.verify_state_counter_increment(self.ecall_input.state_counter())?;
         group_key.process_handshake(
             enclave_context.store_path_secrets(),
             &handshake,

--- a/modules/anonify-enclave/src/handshake.rs
+++ b/modules/anonify-enclave/src/handshake.rs
@@ -133,6 +133,7 @@ impl EnclaveEngine for HandshakeReceiver {
         let handshake = HandshakeParams::decode(&self.ecall_input.handshake().handshake()[..])
             .map_err(|_| anyhow!("HandshakeParams::decode Error"))?;
 
+        
         group_key.process_handshake(
             enclave_context.store_path_secrets(),
             &handshake,

--- a/modules/anonify-eth-driver/src/cache.rs
+++ b/modules/anonify-eth-driver/src/cache.rs
@@ -257,20 +257,21 @@ impl InnerEventCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use frame_common::state_types::StateCounter;
 
     #[test]
     fn test_correct_order_diff_roster_idx() {
         let dummy_payloads1 = vec![
-            PayloadType::new(0, 0, 1, Default::default()),
-            PayloadType::new(0, 0, 2, Default::default()),
-            PayloadType::new(1, 0, 1, Default::default()),
-            PayloadType::new(1, 0, 2, Default::default()),
-            PayloadType::new(1, 0, 3, Default::default()),
+            PayloadType::new(0, 0, 1, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 2, Default::default(), StateCounter::default()),
+            PayloadType::new(1, 0, 1, Default::default(), StateCounter::default()),
+            PayloadType::new(1, 0, 2, Default::default(), StateCounter::default()),
+            PayloadType::new(1, 0, 3, Default::default(), StateCounter::default()),
         ];
 
         let dummy_payloads2 = vec![
-            PayloadType::new(1, 0, 4, Default::default()),
-            PayloadType::new(2, 0, 1, Default::default()),
+            PayloadType::new(1, 0, 4, Default::default(), StateCounter::default()),
+            PayloadType::new(2, 0, 1, Default::default(), StateCounter::default()),
         ];
 
         let mut cache = InnerEventCache::default();
@@ -279,11 +280,11 @@ mod tests {
         assert_eq!(
             res1,
             vec![
-                PayloadType::new(0, 0, 1, Default::default()),
-                PayloadType::new(0, 0, 2, Default::default()),
-                PayloadType::new(1, 0, 1, Default::default()),
-                PayloadType::new(1, 0, 2, Default::default()),
-                PayloadType::new(1, 0, 3, Default::default()),
+                PayloadType::new(0, 0, 1, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 2, Default::default(), StateCounter::default()),
+                PayloadType::new(1, 0, 1, Default::default(), StateCounter::default()),
+                PayloadType::new(1, 0, 2, Default::default(), StateCounter::default()),
+                PayloadType::new(1, 0, 3, Default::default(), StateCounter::default()),
             ]
         );
 
@@ -292,8 +293,8 @@ mod tests {
         assert_eq!(
             res2,
             vec![
-                PayloadType::new(1, 0, 4, Default::default()),
-                PayloadType::new(2, 0, 1, Default::default()),
+                PayloadType::new(1, 0, 4, Default::default(), StateCounter::default()),
+                PayloadType::new(2, 0, 1, Default::default(), StateCounter::default()),
             ]
         );
     }
@@ -301,16 +302,16 @@ mod tests {
     #[test]
     fn test_fix_reorder_using_cache() {
         let dummy_payloads1 = vec![
-            PayloadType::new(0, 0, 1, Default::default()),
-            PayloadType::new(0, 0, 2, Default::default()),
-            PayloadType::new(0, 0, 4, Default::default()),
-            PayloadType::new(0, 0, 5, Default::default()),
+            PayloadType::new(0, 0, 1, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 2, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 4, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 5, Default::default(), StateCounter::default()),
         ];
 
         let dummy_payloads2 = vec![
-            PayloadType::new(0, 0, 3, Default::default()),
-            PayloadType::new(0, 0, 6, Default::default()),
-            PayloadType::new(0, 0, 7, Default::default()),
+            PayloadType::new(0, 0, 3, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 6, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 7, Default::default(), StateCounter::default()),
         ];
 
         let mut cache = InnerEventCache::default();
@@ -319,8 +320,8 @@ mod tests {
         assert_eq!(
             res1,
             vec![
-                PayloadType::new(0, 0, 1, Default::default()),
-                PayloadType::new(0, 0, 2, Default::default()),
+                PayloadType::new(0, 0, 1, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 2, Default::default(), StateCounter::default()),
             ]
         );
 
@@ -329,11 +330,11 @@ mod tests {
         assert_eq!(
             res2,
             vec![
-                PayloadType::new(0, 0, 3, Default::default()),
-                PayloadType::new(0, 0, 4, Default::default()),
-                PayloadType::new(0, 0, 5, Default::default()),
-                PayloadType::new(0, 0, 6, Default::default()),
-                PayloadType::new(0, 0, 7, Default::default()),
+                PayloadType::new(0, 0, 3, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 4, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 5, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 6, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 7, Default::default(), StateCounter::default()),
             ]
         );
     }
@@ -341,16 +342,16 @@ mod tests {
     #[test]
     fn test_fix_order_handshake() {
         let dummy_payloads1 = vec![
-            PayloadType::new(0, 0, 1, Default::default()),
-            PayloadType::new(0, 0, 2, Default::default()),
-            PayloadType::new(0, 1, 1, Default::default()),
-            PayloadType::new(0, 0, u32::MAX, Default::default()),
+            PayloadType::new(0, 0, 1, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 2, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 1, 1, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, u32::MAX, Default::default(), StateCounter::default()),
         ];
 
         let dummy_payloads2 = vec![
-            PayloadType::new(0, 1, 2, Default::default()),
-            PayloadType::new(0, 1, 3, Default::default()),
-            PayloadType::new(0, 1, 4, Default::default()),
+            PayloadType::new(0, 1, 2, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 1, 3, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 1, 4, Default::default(), StateCounter::default()),
         ];
 
         let mut cache = InnerEventCache::default();
@@ -359,10 +360,10 @@ mod tests {
         assert_eq!(
             res1,
             vec![
-                PayloadType::new(0, 0, 1, Default::default()),
-                PayloadType::new(0, 0, 2, Default::default()),
-                PayloadType::new(0, 1, 1, Default::default()),
-                PayloadType::new(0, 0, u32::MAX, Default::default()),
+                PayloadType::new(0, 0, 1, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 2, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 1, 1, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, u32::MAX, Default::default(), StateCounter::default()),
             ]
         );
 
@@ -371,9 +372,9 @@ mod tests {
         assert_eq!(
             res2,
             vec![
-                PayloadType::new(0, 1, 2, Default::default()),
-                PayloadType::new(0, 1, 3, Default::default()),
-                PayloadType::new(0, 1, 4, Default::default()),
+                PayloadType::new(0, 1, 2, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 1, 3, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 1, 4, Default::default(), StateCounter::default()),
             ]
         );
     }
@@ -381,16 +382,16 @@ mod tests {
     #[test]
     fn test_over_max_trials_num() {
         let dummy_payloads1 = vec![
-            PayloadType::new(0, 0, 1, Default::default()),
-            PayloadType::new(0, 0, 2, Default::default()),
-            PayloadType::new(0, 0, 4, Default::default()),
-            PayloadType::new(0, 0, 5, Default::default()),
+            PayloadType::new(0, 0, 1, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 2, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 4, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 5, Default::default(), StateCounter::default()),
         ];
 
         let dummy_payloads2 = vec![
-            PayloadType::new(0, 0, 3, Default::default()),
-            PayloadType::new(0, 0, 6, Default::default()),
-            PayloadType::new(0, 0, 7, Default::default()),
+            PayloadType::new(0, 0, 3, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 6, Default::default(), StateCounter::default()),
+            PayloadType::new(0, 0, 7, Default::default(), StateCounter::default()),
         ];
 
         let mut cache = InnerEventCache::default();
@@ -398,10 +399,10 @@ mod tests {
         assert_eq!(
             res1,
             vec![
-                PayloadType::new(0, 0, 1, Default::default()),
-                PayloadType::new(0, 0, 2, Default::default()),
-                PayloadType::new(0, 0, 5, Default::default()),
-                PayloadType::new(0, 0, 4, Default::default()),
+                PayloadType::new(0, 0, 1, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 2, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 5, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 4, Default::default(), StateCounter::default()),
             ]
         );
 
@@ -409,9 +410,9 @@ mod tests {
         assert_eq!(
             res2,
             vec![
-                PayloadType::new(0, 0, 3, Default::default()),
-                PayloadType::new(0, 0, 6, Default::default()),
-                PayloadType::new(0, 0, 7, Default::default()),
+                PayloadType::new(0, 0, 3, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 6, Default::default(), StateCounter::default()),
+                PayloadType::new(0, 0, 7, Default::default(), StateCounter::default()),
             ]
         );
     }

--- a/modules/anonify-eth-driver/src/error.rs
+++ b/modules/anonify-eth-driver/src/error.rs
@@ -14,6 +14,10 @@ pub enum HostError {
     EcallOutputNotSet,
     #[error("Failed unlock the account")]
     UnlockError,
+    #[error("Decoded EthLogToken to invalid TokenType")]
+    InvalidEthLogToken,
+    #[error("The number of EthLogTokens should be {0}")]
+    InvalidNumberOfEthLogToken(usize),
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
     #[error("Web3 error: {0}")]

--- a/modules/anonify-eth-driver/src/workflow.rs
+++ b/modules/anonify-eth-driver/src/workflow.rs
@@ -1,5 +1,8 @@
 use anonify_ecall_types::*;
-use frame_common::crypto::{Ciphertext, ExportHandshake};
+use frame_common::{
+    crypto::{Ciphertext, ExportHandshake},
+    state_types::StateCounter,
+};
 use frame_host::engine::*;
 use frame_sodium::SodiumCiphertext;
 use web3::types::Address;
@@ -306,13 +309,15 @@ pub mod host_input {
 
     pub struct InsertCiphertext {
         ciphertext: Ciphertext,
+        state_counter: StateCounter,
         ecall_cmd: u32,
     }
 
     impl InsertCiphertext {
-        pub fn new(ciphertext: Ciphertext, ecall_cmd: u32) -> Self {
+        pub fn new(ciphertext: Ciphertext, state_counter: StateCounter, ecall_cmd: u32) -> Self {
             InsertCiphertext {
                 ciphertext,
+                state_counter,
                 ecall_cmd,
             }
         }
@@ -323,7 +328,7 @@ pub mod host_input {
         type HostOutput = host_output::InsertCiphertext;
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
-            let ecall_input = Self::EcallInput::new(self.ciphertext);
+            let ecall_input = Self::EcallInput::new(self.ciphertext, self.state_counter);
 
             Ok((ecall_input, Self::HostOutput::new()))
         }
@@ -335,13 +340,15 @@ pub mod host_input {
 
     pub struct InsertHandshake {
         handshake: ExportHandshake,
+        state_counter: StateCounter,
         ecall_cmd: u32,
     }
 
     impl InsertHandshake {
-        pub fn new(handshake: ExportHandshake, ecall_cmd: u32) -> Self {
+        pub fn new(handshake: ExportHandshake, state_counter: StateCounter, ecall_cmd: u32) -> Self {
             InsertHandshake {
                 handshake,
+                state_counter,
                 ecall_cmd,
             }
         }
@@ -352,7 +359,7 @@ pub mod host_input {
         type HostOutput = host_output::InsertHandshake;
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
-            let ecall_input = Self::EcallInput::new(self.handshake);
+            let ecall_input = Self::EcallInput::new(self.handshake, self.state_counter);
 
             Ok((ecall_input, Self::HostOutput::default()))
         }


### PR DESCRIPTION
* コントラクトでstate counterをインクリメント・イベント発火して、TEEノードでインクリメント検証

以下のケースで順序変わりうる可能性
* state-runtimeノードが受け取ってから状態に反映するまで（現状シングルスレッドなのでmaliciousな場合のみ）（merkle検証がないとstatecounterは改ざんできうる）