### PR TITLE
fix key vault tests

### DIFF
--- a/nodes/key-vault/server/src/tests.rs
+++ b/nodes/key-vault/server/src/tests.rs
@@ -407,9 +407,6 @@ async fn test_manually_backup_all() {
     )
     .await;
 
-    let path_secrets_dir =
-        PJ_ROOT_DIR.join(&env::var("PATH_SECRETS_DIR").expect("PATH_SECRETS_DIR is not set"));
-
     // Deploy
     let req = test::TestRequest::post().uri("/api/v1/deploy").to_request();
     let resp = test::call_service(&mut app, req).await;
@@ -486,9 +483,10 @@ async fn test_manually_backup_all() {
 
     clear_remote_path_secrets(env::var("MY_ROSTER_IDX").unwrap().to_string());
     // ensure clearing remote path_secrets
-    assert!(!path_secrets_dir
-        .join(env::var("MY_ROSTER_IDX").unwrap().as_str())
-        .exists());
+    assert_eq!(
+        get_remote_ids(env::var("MY_ROSTER_IDX").unwrap().to_string()).len(),
+        0
+    );
 
     // backup all path_secrets to key-vault server
     let req = test::TestRequest::post()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -58,7 +58,11 @@ make DEBUG=1 ENCLAVE_DIR=example/erc20/enclave
 cd ${ANONIFY_ROOT}/nodes/key-vault/server
 RUST_BACKTRACE=1 RUST_LOG=debug cargo test test_backup_path_secret -- --nocapture
 sleep 1
-RUST_BACKTRACE=1 RUST_LOG=debug cargo test test_lost_path_secret -- --nocapture
+RUST_BACKTRACE=1 RUST_LOG=debug cargo test test_recover_without_key_vault -- --nocapture
+sleep 1
+RUST_BACKTRACE=1 RUST_LOG=debug cargo test test_manually_backup_all -- --nocapture
+sleep 1
+RUST_BACKTRACE=1 RUST_LOG=debug cargo test test_manually_recover_all -- --nocapture
 
 #
 # Unit Tests


### PR DESCRIPTION
- tests.shからkey-vaultのテストが一部しか実行されていなかったので、すべて実行されるように修正
- remoteの`path_secrets`は`clear_remote_path_secrets`によってファイルのみ削除される（ディレクトリは残る）ので、削除されたことのチェックロジックを変更