### PR TITLE
結合テスト実装の`anonify_ecall_types::input::Command` をjsonで表現

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,7 +2700,6 @@ version = "0.5.4"
 dependencies = [
  "actix-rt",
  "actix-web",
- "anonify-ecall-types",
  "anonify-eth-driver",
  "anyhow 1.0.34",
  "eth-deployer",
@@ -2708,7 +2707,6 @@ dependencies = [
  "frame-common",
  "frame-config",
  "frame-host",
- "frame-runtime",
  "frame-sodium",
  "key-vault-ecall-types",
  "key-vault-host",

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -1,9 +1,5 @@
 use crate::bincode;
-use crate::localstd::{
-    fmt, str,
-    string::{String, ToString},
-    vec::Vec,
-};
+use crate::localstd::{fmt, str, string::String, vec::Vec};
 use crate::serde::{
     de::{self, Error, SeqAccess},
     ser::SerializeSeq,
@@ -21,61 +17,6 @@ use frame_sodium::SodiumPubKey;
 
 pub mod input {
     use super::*;
-
-    #[derive(Debug, Clone, Deserialize, Serialize)]
-    #[serde(crate = "crate::serde")]
-    pub struct Command<AP: AccessPolicy> {
-        #[serde(deserialize_with = "AP::deserialize")]
-        pub access_policy: AP,
-        pub runtime_params: serde_json::Value,
-        pub cmd_name: String,
-        pub counter: UserCounter,
-    }
-
-    impl<AP> Default for Command<AP>
-    where
-        AP: AccessPolicy,
-    {
-        fn default() -> Self {
-            Self {
-                access_policy: AP::default(),
-                runtime_params: serde_json::Value::Null,
-                cmd_name: String::default(),
-                counter: UserCounter::default(),
-            }
-        }
-    }
-
-    impl<AP> Command<AP>
-    where
-        AP: AccessPolicy,
-    {
-        pub fn new(
-            access_policy: AP,
-            runtime_params: serde_json::Value,
-            cmd_name: impl ToString,
-            counter: UserCounter,
-        ) -> Self {
-            Command {
-                access_policy,
-                runtime_params,
-                cmd_name: cmd_name.to_string(),
-                counter,
-            }
-        }
-
-        pub fn access_policy(&self) -> &AP {
-            &self.access_policy
-        }
-
-        pub fn cmd_name(&self) -> &str {
-            &self.cmd_name
-        }
-
-        pub fn counter(&self) -> UserCounter {
-            self.counter
-        }
-    }
 
     #[derive(Serialize, Deserialize, Debug, Clone, Default)]
     #[serde(crate = "crate::serde")]

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -10,12 +10,16 @@ use frame_enclave::EnclaveEngine;
 use frame_runtime::traits::*;
 use frame_sodium::SodiumCiphertext;
 use serde::{Deserialize, Serialize};
-use std::{marker::PhantomData, vec::Vec};
+use std::{
+    marker::PhantomData,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 /// A message sender that encrypts commands
 #[derive(Debug, Clone, Default)]
 pub struct CmdSender<AP: AccessPolicy> {
-    ecall_input: input::Command<AP>,
+    command_plaintext: CommandPlaintext<AP>,
 }
 
 impl<AP> EnclaveEngine for CmdSender<AP>
@@ -30,12 +34,12 @@ where
         C: ContextOps<S = StateType> + Clone,
     {
         let buf = enclave_context.decrypt(ciphertext)?;
-        let ecall_input = serde_json::from_slice(&buf[..])?;
-        Ok(Self { ecall_input })
+        let command_plaintext = serde_json::from_slice(&buf[..])?;
+        Ok(Self { command_plaintext })
     }
 
     fn eval_policy(&self) -> anyhow::Result<()> {
-        self.ecall_input.access_policy().verify()
+        self.command_plaintext.access_policy().verify()
     }
 
     fn handle<R, C>(self, enclave_context: &C, max_mem_size: usize) -> anyhow::Result<Self::EO>
@@ -48,8 +52,8 @@ where
         // ratchet sender's app keychain per tx.
         group_key.sender_ratchet(roster_idx as usize)?;
 
-        let my_account_id = self.ecall_input.access_policy().into_account_id();
-        let ciphertext = Commands::<R, C, AP>::new(my_account_id, self.ecall_input)?
+        let my_account_id = self.command_plaintext.access_policy().into_account_id();
+        let ciphertext = CommandExecutor::<R, C, AP>::new(my_account_id, self.command_plaintext)?
             .encrypt(group_key, max_mem_size)?;
 
         let msg = Sha256::hash_for_attested_tx(
@@ -62,6 +66,60 @@ where
         let command_output = output::Command::new(ciphertext, enclave_sig.0, enclave_sig.1);
 
         Ok(command_output)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CommandPlaintext<AP: AccessPolicy> {
+    #[serde(deserialize_with = "AP::deserialize")]
+    pub access_policy: AP,
+    pub runtime_params: serde_json::Value,
+    pub cmd_name: String,
+    pub counter: UserCounter,
+}
+
+impl<AP> Default for CommandPlaintext<AP>
+where
+    AP: AccessPolicy,
+{
+    fn default() -> Self {
+        Self {
+            access_policy: AP::default(),
+            runtime_params: serde_json::Value::Null,
+            cmd_name: String::default(),
+            counter: UserCounter::default(),
+        }
+    }
+}
+
+impl<AP> CommandPlaintext<AP>
+where
+    AP: AccessPolicy,
+{
+    pub fn new(
+        access_policy: AP,
+        runtime_params: serde_json::Value,
+        cmd_name: impl ToString,
+        counter: UserCounter,
+    ) -> Self {
+        CommandPlaintext {
+            access_policy,
+            runtime_params,
+            cmd_name: cmd_name.to_string(),
+            counter,
+        }
+    }
+
+    pub fn access_policy(&self) -> &AP {
+        &self.access_policy
+    }
+
+    pub fn cmd_name(&self) -> &str {
+        &self.cmd_name
+    }
+
+    pub fn counter(&self) -> UserCounter {
+        self.counter
     }
 }
 
@@ -120,7 +178,7 @@ where
 
         let mut output = output::ReturnNotifyState::default();
         let decrypted_cmds =
-            Commands::<R, C, AP>::decrypt(self.ecall_input.ciphertext(), group_key)?;
+            CommandExecutor::<R, C, AP>::decrypt(self.ecall_input.ciphertext(), group_key)?;
         if let Some(cmds) = decrypted_cmds {
             // Since the command data is valid for the error at the time of state transition,
             // `user_counter` must be verified and incremented before the state transition.
@@ -141,7 +199,7 @@ where
 
 /// Command data which make state update
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Commands<R: RuntimeExecutor<CTX>, CTX: ContextOps<S = StateType>, AP> {
+pub struct CommandExecutor<R: RuntimeExecutor<CTX>, CTX: ContextOps<S = StateType>, AP> {
     my_account_id: AccountId,
     #[serde(deserialize_with = "R::C::deserialize")]
     call_kind: R::C,
@@ -150,19 +208,22 @@ pub struct Commands<R: RuntimeExecutor<CTX>, CTX: ContextOps<S = StateType>, AP>
     ap: PhantomData<AP>,
 }
 
-impl<R, CTX, AP> Commands<R, CTX, AP>
+impl<R, CTX, AP> CommandExecutor<R, CTX, AP>
 where
     R: RuntimeExecutor<CTX, S = StateType>,
     CTX: ContextOps<S = StateType>,
     AP: AccessPolicy,
 {
-    pub fn new(my_account_id: AccountId, ecall_input: input::Command<AP>) -> Result<Self> {
-        let call_kind = R::C::new(ecall_input.cmd_name(), ecall_input.runtime_params.clone())?;
+    pub fn new(my_account_id: AccountId, command_plaintext: CommandPlaintext<AP>) -> Result<Self> {
+        let call_kind = R::C::new(
+            command_plaintext.cmd_name(),
+            command_plaintext.runtime_params.clone(),
+        )?;
 
-        Ok(Commands {
+        Ok(CommandExecutor {
             my_account_id,
             call_kind,
-            counter: ecall_input.counter(),
+            counter: command_plaintext.counter(),
             phantom: PhantomData,
             ap: PhantomData,
         })
@@ -202,7 +263,7 @@ where
 
     fn decrypt<GK: GroupKeyOps>(ciphertext: &Ciphertext, key: &mut GK) -> Result<Option<Self>> {
         match key.decrypt(ciphertext)? {
-            Some(plaintext) => Commands::decode(&plaintext[..]).map(Some),
+            Some(plaintext) => CommandExecutor::decode(&plaintext[..]).map(Some),
             None => Ok(None),
         }
     }

--- a/nodes/key-vault/Cargo.toml
+++ b/nodes/key-vault/Cargo.toml
@@ -24,10 +24,8 @@ once_cell = "1.5.2"
 eth-deployer = { path = "../../ethereum/deployer"}
 frame-config = { path = "../../frame/config" }
 frame-common = { path = "../../frame/common" }
-frame-runtime = { path = "../../frame/runtime" }
 frame-sodium = { path = "../../frame/sodium" }
 anonify-eth-driver = { path = "../../modules/anonify-eth-driver" }
-anonify-ecall-types = { path = "../../modules/anonify-ecall-types"}
 state-runtime-node-server = { path = "../../nodes/state-runtime/server" }
 state-runtime-node-api = { path = "../../nodes/state-runtime/api" }
 web3 = "0.14"

--- a/nodes/key-vault/src/tests.rs
+++ b/nodes/key-vault/src/tests.rs
@@ -1,13 +1,11 @@
 use crate::{handlers::*, Server as KeyVaultServer};
 use actix_web::{test, web, App};
-use anonify_ecall_types::input;
 use anonify_eth_driver::eth::{EthSender, EventWatcher};
 use eth_deployer::EthDeployer;
 use ethabi::Contract as ContractABI;
 use frame_common::crypto::Ed25519ChallengeResponse;
 use frame_config::{ANONIFY_ABI_PATH, ANONIFY_BIN_PATH, PJ_ROOT_DIR};
 use frame_host::EnclaveDir;
-use frame_runtime::primitives::U64;
 use frame_sodium::{SodiumCiphertext, SodiumPubKey};
 use once_cell::sync::Lazy;
 use rand_core::{CryptoRng, RngCore};
@@ -916,10 +914,16 @@ where
         3, 101, 33, 155, 58, 175, 168, 63, 73, 125, 205, 225,
     ];
     let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
-    let init_100 = json!({
-        "total_supply": U64::from_raw(100),
+
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_params": {
+            "total_supply": 100,
+        },
+        "cmd_name": "construct",
+        "counter": counter,
     });
-    let req = input::Command::new(access_policy, init_100, "construct", counter.into());
+
     let ciphertext =
         SodiumCiphertext::encrypt(csprng, &enc_key, serde_json::to_vec(&req).unwrap()).unwrap();
 

--- a/nodes/state-runtime/server/Cargo.toml
+++ b/nodes/state-runtime/server/Cargo.toml
@@ -28,7 +28,6 @@ integration-tests = { path = "../../../tests/integration" }
 eth-deployer = { path = "../../../ethereum/deployer"}
 frame-runtime = { path = "../../../frame/runtime" }
 frame-sodium = { path = "../../../frame/sodium" }
-anonify-ecall-types = { path = "../../../modules/anonify-ecall-types"}
 ethabi = "12.0.0"
 rand_core = "0.5"
 rand = "0.7"

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -1,6 +1,5 @@
 use crate::{handlers::*, Server};
 use actix_web::{test, web, App};
-use anonify_ecall_types::input;
 use anonify_eth_driver::eth::*;
 use eth_deployer::EthDeployer;
 use ethabi::Contract as ContractABI;
@@ -1052,10 +1051,15 @@ where
         3, 101, 33, 155, 58, 175, 168, 63, 73, 125, 205, 225,
     ];
     let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
-    let init_100 = json!({
-        "total_supply": U64::from_raw(100),
+
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_params": {
+            "total_supply": 100,
+        },
+        "cmd_name": "construct",
+        "counter": counter,
     });
-    let req = input::Command::new(access_policy, init_100, "construct", counter.into());
     let ciphertext =
         SodiumCiphertext::encrypt(csprng, &enc_key, serde_json::to_vec(&req).unwrap()).unwrap();
 
@@ -1086,14 +1090,19 @@ where
         186, 25, 30, 135, 114, 237, 169, 138, 122, 81, 61, 43, 183,
     ];
     let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
-    let transfer_10 = json!({
-        "amount": U64::from_raw(10),
-        "recipient": AccountId([
-            236, 126, 92, 200, 50, 125, 9, 112, 74, 58, 35, 60, 181, 105, 198, 107, 62, 111, 168,
-            118,
-        ])
+
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_params": {
+            "amount": 10,
+            "recipient": AccountId([
+                236, 126, 92, 200, 50, 125, 9, 112, 74, 58, 35, 60, 181, 105, 198, 107, 62, 111, 168,
+                118,
+            ])
+        },
+        "cmd_name": "transfer",
+        "counter": counter,
     });
-    let req = input::Command::new(access_policy, transfer_10, "transfer", counter.into());
     let ciphertext =
         SodiumCiphertext::encrypt(csprng, &enc_key, serde_json::to_vec(&req).unwrap()).unwrap();
 
@@ -1124,14 +1133,19 @@ where
         186, 25, 30, 135, 114, 237, 169, 138, 122, 81, 61, 43, 183,
     ];
     let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
-    let transfer_10 = json!({
-        "amount": U64::from_raw(110),
-        "recipient": AccountId([
-            236, 126, 92, 200, 50, 125, 9, 112, 74, 58, 35, 60, 181, 105, 198, 107, 62, 111, 168,
-            118,
-        ])
+
+    let req = json!({
+        "access_policy": access_policy,
+        "runtime_params": {
+            "amount": 110,
+            "recipient": AccountId([
+                236, 126, 92, 200, 50, 125, 9, 112, 74, 58, 35, 60, 181, 105, 198, 107, 62, 111, 168,
+                118,
+            ])
+        },
+        "cmd_name": "transfer",
+        "counter": counter,
     });
-    let req = input::Command::new(access_policy, transfer_10, "transfer", counter.into());
     let ciphertext =
         SodiumCiphertext::encrypt(csprng, &enc_key, serde_json::to_vec(&req).unwrap()).unwrap();
 


### PR DESCRIPTION
* 現状の `anonify_ecall_types::input::Command` をenclave専用型 `CommandPlaintext` にし、metafield含めた新たな型を共有型として使うために、結合テストで使用している `anonify_ecall_types::input::Command` をjsonで表現するよう修正

TODO
* 暗号文とメタデータinput用の型をecall-typesに定義
* 状態遷移API修正