### PR TITLE
POST: state APIにおけるユーザID一致検証によるアクセスポリシー評価実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4546,6 +4546,7 @@ dependencies = [
 name = "state-runtime-node-api"
 version = "0.5.4"
 dependencies = [
+ "frame-common",
  "frame-sodium",
  "serde 1.0.117",
  "serde_json 1.0.59",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,6 @@ dependencies = [
  "frame-common",
  "frame-config",
  "frame-host",
- "frame-runtime",
  "frame-sodium",
  "hex",
  "integration-tests",

--- a/frame/runtime/src/traits.rs
+++ b/frame/runtime/src/traits.rs
@@ -145,7 +145,7 @@ pub trait NotificationOps {
 pub trait EnclaveKeyOps {
     fn sign(&self, msg: &[u8]) -> Result<(secp256k1::Signature, secp256k1::RecoveryId)>;
 
-    fn decrypt(&self, ciphertext: SodiumCiphertext) -> Result<Vec<u8>>;
+    fn decrypt(&self, ciphertext: &SodiumCiphertext) -> Result<Vec<u8>>;
 
     fn enclave_encryption_key(&self) -> Result<SodiumPubKey>;
 }

--- a/frame/sodium/src/crypto.rs
+++ b/frame/sodium/src/crypto.rs
@@ -339,7 +339,7 @@ impl SodiumCiphertext {
     }
 
     #[cfg(any(all(feature = "std", test), feature = "sgx"))]
-    pub fn decrypt(self, my_priv_key: &SodiumPrivateKey) -> Result<Vec<u8>> {
+    pub fn decrypt(&self, my_priv_key: &SodiumPrivateKey) -> Result<Vec<u8>> {
         let cbox = CryptoBox::new(&self.ephemeral_public_key.0, &my_priv_key.0);
         let plaintext = cbox
             .decrypt(&self.nonce.0, &self.ciphertext[..])

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -18,7 +18,7 @@ use frame_sodium::{SodiumCiphertext, SodiumPubKey};
 pub mod input {
     use super::*;
 
-    #[derive(Debug, Clone, Deserialize, Serialize)]
+    #[derive(Debug, Clone, Deserialize, Serialize, Default)]
     #[serde(crate = "crate::serde")]
     pub struct Command {
         ciphertext: SodiumCiphertext,

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -8,15 +8,41 @@ use crate::serde::{
 use crate::serde_bytes;
 use crate::serde_json;
 use frame_common::{
-    crypto::{Ciphertext, ExportHandshake},
+    crypto::{AccountId, Ciphertext, ExportHandshake},
     state_types::{StateCounter, StateType, UserCounter},
     traits::AccessPolicy,
     EcallInput, EcallOutput,
 };
-use frame_sodium::SodiumPubKey;
+use frame_sodium::{SodiumCiphertext, SodiumPubKey};
 
 pub mod input {
     use super::*;
+
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    #[serde(crate = "crate::serde")]
+    pub struct Command {
+        ciphertext: SodiumCiphertext,
+        user_id: Option<AccountId>,
+    }
+
+    impl EcallInput for Command {}
+
+    impl Command {
+        pub fn new(ciphertext: SodiumCiphertext, user_id: Option<AccountId>) -> Self {
+            Self {
+                ciphertext,
+                user_id,
+            }
+        }
+
+        pub fn ciphertext(&self) -> &SodiumCiphertext {
+            &self.ciphertext
+        }
+
+        pub fn user_id(&self) -> Option<AccountId> {
+            self.user_id
+        }
+    }
 
     #[derive(Serialize, Deserialize, Debug, Clone, Default)]
     #[serde(crate = "crate::serde")]

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -20,26 +20,42 @@ use std::{
 #[derive(Debug, Clone, Default)]
 pub struct CmdSender<AP: AccessPolicy> {
     command_plaintext: CommandPlaintext<AP>,
+    user_id: Option<AccountId>,
 }
 
 impl<AP> EnclaveEngine for CmdSender<AP>
 where
     AP: AccessPolicy,
 {
-    type EI = SodiumCiphertext;
+    type EI = input::Command;
     type EO = output::Command;
 
-    fn decrypt<C>(ciphertext: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
+    fn decrypt<C>(ecall_input: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        let buf = enclave_context.decrypt(ciphertext)?;
+        let buf = enclave_context.decrypt(ecall_input.ciphertext())?;
         let command_plaintext = serde_json::from_slice(&buf[..])?;
-        Ok(Self { command_plaintext })
+
+        Ok(Self {
+            command_plaintext,
+            user_id: ecall_input.user_id(),
+        })
     }
 
     fn eval_policy(&self) -> anyhow::Result<()> {
-        self.command_plaintext.access_policy().verify()
+        if self.command_plaintext.access_policy().verify().is_err() {
+            return Err(anyhow!("Failed to verify access policy"));
+        }
+
+        if let Some(user_id_for_verify) = self.user_id {
+            let user_id = self.command_plaintext.access_policy().into_account_id();
+            return (user_id == user_id_for_verify)
+                .then()
+                .ok_or_else(|_| anyhow!("Invalid user_id. user_id in the ciphertext: {:?}, user_id for verification: {:?}", user_id, user_id_for_verify));
+        }
+
+        Ok(())
     }
 
     fn handle<R, C>(self, enclave_context: &C, max_mem_size: usize) -> anyhow::Result<Self::EO>

--- a/modules/anonify-enclave/src/commands.rs
+++ b/modules/anonify-enclave/src/commands.rs
@@ -8,7 +8,6 @@ use frame_common::{
 };
 use frame_enclave::EnclaveEngine;
 use frame_runtime::traits::*;
-use frame_sodium::SodiumCiphertext;
 use serde::{Deserialize, Serialize};
 use std::{
     marker::PhantomData,
@@ -50,9 +49,13 @@ where
 
         if let Some(user_id_for_verify) = self.user_id {
             let user_id = self.command_plaintext.access_policy().into_account_id();
-            return (user_id == user_id_for_verify)
-                .then()
-                .ok_or_else(|_| anyhow!("Invalid user_id. user_id in the ciphertext: {:?}, user_id for verification: {:?}", user_id, user_id_for_verify));
+            if user_id != user_id_for_verify {
+                return Err(anyhow!(
+                    "Invalid user_id. user_id in the ciphertext: {:?}, user_id for verification: {:?}",
+                    user_id,
+                    user_id_for_verify
+                ));
+            }
         }
 
         Ok(())

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -435,7 +435,7 @@ impl<AP: AccessPolicy> EnclaveEngine for GetState<AP> {
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        let buf = enclave_context.decrypt(ciphertext)?;
+        let buf = enclave_context.decrypt(&ciphertext)?;
         let ecall_input = serde_json::from_slice(&buf[..])?;
 
         Ok(Self { ecall_input })
@@ -479,7 +479,7 @@ impl<AP: AccessPolicy> EnclaveEngine for GetUserCounter<AP> {
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        let buf = enclave_context.decrypt(ciphertext)?;
+        let buf = enclave_context.decrypt(&ciphertext)?;
         let ecall_input = serde_json::from_slice(&buf[..])?;
 
         Ok(Self { ecall_input })

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -224,7 +224,7 @@ impl EnclaveKeyOps for AnonifyEnclaveContext {
         self.enclave_key.sign(msg).map_err(Into::into)
     }
 
-    fn decrypt(&self, ciphertext: SodiumCiphertext) -> anyhow::Result<Vec<u8>> {
+    fn decrypt(&self, ciphertext: &SodiumCiphertext) -> anyhow::Result<Vec<u8>> {
         self.enclave_key.decrypt(ciphertext).map_err(Into::into)
     }
 

--- a/modules/anonify-enclave/src/enclave_key.rs
+++ b/modules/anonify-enclave/src/enclave_key.rs
@@ -150,7 +150,7 @@ impl EnclaveKey {
         Ok(sig)
     }
 
-    pub fn decrypt(&self, ciphertext: SodiumCiphertext) -> Result<Vec<u8>> {
+    pub fn decrypt(&self, ciphertext: &SodiumCiphertext) -> Result<Vec<u8>> {
         let dec_key = self
             .decryption_privkey
             .as_ref()

--- a/modules/anonify-enclave/src/notify.rs
+++ b/modules/anonify-enclave/src/notify.rs
@@ -44,7 +44,7 @@ impl<AP: AccessPolicy> EnclaveEngine for RegisterNotification<AP> {
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        let buf = enclave_context.decrypt(ciphertext)?;
+        let buf = enclave_context.decrypt(&ciphertext)?;
         let ecall_input = serde_json::from_slice(&buf[..])?;
         Ok(Self { ecall_input })
     }

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -181,12 +181,13 @@ where
     pub async fn send_command(
         &self,
         ciphertext: SodiumCiphertext,
+        user_id: Option<AccountId>,
         signer: Address,
         gas: u64,
         ecall_cmd: u32,
     ) -> Result<H256> {
         let inner = self.inner.read();
-        let input = host_input::Command::new(ciphertext, signer, gas, ecall_cmd);
+        let input = host_input::Command::new(ciphertext, user_id, signer, gas, ecall_cmd);
         let eid = inner.enclave_id;
         let host_output = CommandWorkflow::exec(input, eid)?;
 

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -9,6 +9,7 @@ use crate::{
     workflow::host_input,
 };
 use anyhow::anyhow;
+use frame_common::crypto::AccountId;
 use frame_host::engine::HostEngine;
 use frame_sodium::{SodiumCiphertext, SodiumPubKey};
 use parking_lot::RwLock;

--- a/modules/anonify-eth-driver/src/workflow.rs
+++ b/modules/anonify-eth-driver/src/workflow.rs
@@ -134,6 +134,7 @@ pub mod host_input {
 
     pub struct Command {
         ciphertext: SodiumCiphertext,
+        user_id: Option<AccountId>,
         signer: Address,
         gas: u64,
         ecall_cmd: u32,
@@ -142,6 +143,7 @@ pub mod host_input {
     impl Command {
         pub fn new(
             ciphertext: SodiumCiphertext,
+            user_id: Option<AccountId>,
             signer: Address,
             gas: u64,
             ecall_cmd: u32,
@@ -156,13 +158,14 @@ pub mod host_input {
     }
 
     impl HostInput for Command {
-        type EcallInput = SodiumCiphertext;
+        type EcallInput = input::Command;
         type HostOutput = host_output::Command;
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
             let host_output = host_output::Command::new(self.signer, self.gas);
+            let ecall_input = input::Command::new(self.ciphertext, self.user_id);
 
-            Ok((self.ciphertext, host_output))
+            Ok((ecall_input, host_output))
         }
 
         fn ecall_cmd(&self) -> u32 {

--- a/modules/anonify-eth-driver/src/workflow.rs
+++ b/modules/anonify-eth-driver/src/workflow.rs
@@ -1,6 +1,6 @@
 use anonify_ecall_types::*;
 use frame_common::{
-    crypto::{Ciphertext, ExportHandshake},
+    crypto::{AccountId, Ciphertext, ExportHandshake},
     state_types::StateCounter,
 };
 use frame_host::engine::*;
@@ -13,7 +13,7 @@ pub struct CommandWorkflow;
 
 impl HostEngine for CommandWorkflow {
     type HI = host_input::Command;
-    type EI = SodiumCiphertext;
+    type EI = input::Command;
     type EO = output::Command;
     type HO = host_output::Command;
     const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
@@ -150,6 +150,7 @@ pub mod host_input {
         ) -> Self {
             Command {
                 ciphertext,
+                user_id,
                 signer,
                 gas,
                 ecall_cmd,

--- a/nodes/key-vault/src/tests.rs
+++ b/nodes/key-vault/src/tests.rs
@@ -927,7 +927,10 @@ where
     let ciphertext =
         SodiumCiphertext::encrypt(csprng, &enc_key, serde_json::to_vec(&req).unwrap()).unwrap();
 
-    state_runtime_node_api::state::post::Request { ciphertext }
+    state_runtime_node_api::state::post::Request {
+        ciphertext,
+        user_id: None,
+    }
 }
 
 fn balance_of_req<CR>(

--- a/nodes/state-runtime/api/Cargo.toml
+++ b/nodes/state-runtime/api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 frame-sodium = { path = "../../../frame/sodium" }
+frame-common = { path = "../../../frame/common" }
 serde = { version = "1", features = ["derive"] }
 web3 = "0.14"
 serde_json = "1.0"

--- a/nodes/state-runtime/api/src/lib.rs
+++ b/nodes/state-runtime/api/src/lib.rs
@@ -1,3 +1,4 @@
+use frame_common::crypto::AccountId;
 use frame_sodium::{SodiumCiphertext, SodiumPubKey};
 use serde::{Deserialize, Serialize};
 use web3::types::H256;

--- a/nodes/state-runtime/api/src/lib.rs
+++ b/nodes/state-runtime/api/src/lib.rs
@@ -34,12 +34,17 @@ pub mod state {
 
         #[derive(Debug, Clone, Deserialize, Serialize)]
         pub struct Request {
+            #[serde(flatten)]
             pub ciphertext: SodiumCiphertext,
+            pub user_id: Option<AccountId>,
         }
 
         impl Request {
             pub fn new(ciphertext: SodiumCiphertext) -> Self {
-                Request { ciphertext }
+                Request {
+                    ciphertext,
+                    user_id: None,
+                }
             }
         }
 

--- a/nodes/state-runtime/server/Cargo.toml
+++ b/nodes/state-runtime/server/Cargo.toml
@@ -26,7 +26,6 @@ thiserror = "1.0"
 [dev-dependencies]
 integration-tests = { path = "../../../tests/integration" }
 eth-deployer = { path = "../../../ethereum/deployer"}
-frame-runtime = { path = "../../../frame/runtime" }
 frame-sodium = { path = "../../../frame/sodium" }
 ethabi = "12.0.0"
 rand_core = "0.5"

--- a/nodes/state-runtime/server/src/handlers.rs
+++ b/nodes/state-runtime/server/src/handlers.rs
@@ -88,6 +88,7 @@ where
         .dispatcher
         .send_command(
             req.ciphertext.clone(),
+            req.user_id,
             sender_address,
             DEFAULT_GAS,
             SEND_COMMAND_CMD,

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -155,7 +155,7 @@ async fn test_evaluate_access_policy_by_user_id_field() {
         .set_json(&transfer_10_req_json)
         .to_request();
     let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
+    assert!(resp.status().is_server_error(), "response: {:?}", resp);
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,6 +38,8 @@ RUST_BACKTRACE=1 RUST_LOG=debug cargo test -- --nocapture
 # ERC20 Application Tests
 
 cd ${ANONIFY_ROOT}/nodes/state-runtime/server
+RUST_BACKTRACE=1 RUST_LOG=debug cargo test test_evaluate_access_policy_by_user_id_field -- --nocapture
+sleep 1
 RUST_BACKTRACE=1 RUST_LOG=debug cargo test test_multiple_messages -- --nocapture
 sleep 1
 RUST_BACKTRACE=1 RUST_LOG=debug cargo test test_skip_invalid_event -- --nocapture

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -133,6 +133,7 @@ async fn test_integration_eth_construct() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -254,6 +255,7 @@ async fn test_auto_notification() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -307,7 +309,13 @@ async fn test_auto_notification() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, deployer_addr, gas, SEND_COMMAND_CMD)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
@@ -407,6 +415,7 @@ async fn test_integration_eth_transfer() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -468,7 +477,13 @@ async fn test_integration_eth_transfer() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, deployer_addr, gas, SEND_COMMAND_CMD)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
@@ -596,6 +611,7 @@ async fn test_key_rotation() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -712,6 +728,7 @@ async fn test_integration_eth_approve() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -767,7 +784,13 @@ async fn test_integration_eth_approve() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, deployer_addr, gas, SEND_COMMAND_CMD)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
@@ -876,6 +899,7 @@ async fn test_integration_eth_transfer_from() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -975,6 +999,7 @@ async fn test_integration_eth_transfer_from() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -1074,7 +1099,13 @@ async fn test_integration_eth_transfer_from() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, deployer_addr, gas, SEND_COMMAND_CMD)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
@@ -1223,6 +1254,7 @@ async fn test_integration_eth_mint() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -1253,7 +1285,13 @@ async fn test_integration_eth_mint() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, deployer_addr, gas, SEND_COMMAND_CMD)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_CMD,
+        )
         .await
         .unwrap();
 
@@ -1367,6 +1405,7 @@ async fn test_integration_eth_burn() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -1399,6 +1438,7 @@ async fn test_integration_eth_burn() {
     let receipt = dispatcher
         .send_command(
             encrypted_command,
+            None,
             deployer_addr.clone(),
             gas,
             SEND_COMMAND_CMD,
@@ -1426,7 +1466,13 @@ async fn test_integration_eth_burn() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, deployer_addr, gas, SEND_COMMAND_CMD)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);


### PR DESCRIPTION
POST: /state のリクエストボディを以下のように修正。（フラット化、user_idフィールド追加）
```
{ 	
		"ciphertext": String
		"ephemeral_public_key": String
		"nonce": String
 	        "user_id": String // optional
 }
```

user_idフィールドが存在する場合は、`ciphertext` での平文jsonの `access_policy` から得られる `user_id` と一致しなければアクセスポリシー評価で失敗する。
user_idフィールドは存在しなくてもOK。