### PR TITLE
BC同期、join_group自動化実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
 name = "anonify-eth-driver"
 version = "0.5.4"
 dependencies = [
+ "actix-rt",
  "anonify-ecall-types",
  "anyhow 1.0.34",
  "async-trait",

--- a/example/erc20/cli/src/commands.rs
+++ b/example/erc20/cli/src/commands.rs
@@ -15,26 +15,6 @@ use reqwest::Client;
 use serde_json::json;
 use std::path::PathBuf;
 
-pub(crate) fn deploy(state_runtime_url: String) -> Result<()> {
-    let res = Client::new()
-        .post(&format!("{}/api/v1/deploy", &state_runtime_url))
-        .send()?
-        .text()?;
-
-    println!("Deployed Contract address: {}", res);
-    Ok(())
-}
-
-pub(crate) fn join_group(state_runtime_url: String) -> Result<()> {
-    let res = Client::new()
-        .post(&format!("{}/api/v1/join_group", &state_runtime_url))
-        .send()?
-        .text()?;
-
-    println!("Transaction hash: {:?}", res);
-    Ok(())
-}
-
 pub(crate) fn register_report(state_runtime_url: String) -> Result<()> {
     let res = Client::new()
         .post(&format!("{}/api/v1/register_report", &state_runtime_url))
@@ -426,15 +406,6 @@ where
         .text()?;
 
     println!("Current State: {:?}", res);
-    Ok(())
-}
-
-pub(crate) fn start_sync_bc(state_runtime_url: String) -> Result<()> {
-    Client::new()
-        .get(&format!("{}/api/v1/start_sync_bc", &state_runtime_url))
-        .send()?
-        .text()?;
-
     Ok(())
 }
 

--- a/example/erc20/cli/src/main.rs
+++ b/example/erc20/cli/src/main.rs
@@ -72,12 +72,6 @@ fn subcommand_anonify<R, CR>(
     CR: RngCore + CryptoRng,
 {
     match matches.subcommand() {
-        ("deploy", Some(_)) => {
-            commands::deploy(state_runtime_url).expect("Failed to deploy command");
-        }
-        ("join_group", Some(_)) => {
-            commands::join_group(state_runtime_url).expect("Failed to join_group command");
-        }
         ("register_report", Some(_)) => {
             commands::register_report(state_runtime_url)
                 .expect("Failed to register_report command");
@@ -351,9 +345,6 @@ fn subcommand_anonify<R, CR>(
             )
             .expect("Failed balance_of command");
         }
-        ("start_sync_bc", Some(_)) => {
-            commands::start_sync_bc(state_runtime_url).expect("Failed to start_sync_bc command");
-        }
         ("get_enclave_encryption_key", Some(_)) => {
             let enclave_encryption_key =
                 commands::get_enclave_encryption_key(state_runtime_url.clone())
@@ -371,13 +362,6 @@ fn subcommand_anonify<R, CR>(
 fn anonify_commands_definition<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name(ANONIFY_COMMAND)
         .about("Anonify operations")
-        .subcommand(
-            SubCommand::with_name("deploy").about("Deploy a contract from anonify services."),
-        )
-        .subcommand(
-            SubCommand::with_name("join_group")
-                .about("join group a contract from anonify services."),
-        )
         .subcommand(
             SubCommand::with_name("register_report").about("register a report to the blockchain"),
         )
@@ -606,9 +590,6 @@ fn anonify_commands_definition<'a, 'b>() -> App<'a, 'b> {
                         .takes_value(true)
                         .required(true),
                 ),
-        )
-        .subcommand(
-            SubCommand::with_name("start_sync_bc").about("Get state from anonify services."),
         )
         .subcommand(
             SubCommand::with_name("get_enclave_encryption_key")

--- a/example/erc20/server/src/main.rs
+++ b/example/erc20/server/src/main.rs
@@ -18,15 +18,17 @@ async fn main() -> io::Result<()> {
         .init_enclave(true)
         .expect("Failed to initialize enclave.");
     let eid = enclave.geteid();
+
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(eid)
+        .await
+        .run()
+        .await;
     let server = Arc::new(Server::<EthSender, EventWatcher>::new(eid).await);
 
     HttpServer::new(move || {
         App::new()
             .data(server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/update_mrenclave",
                 web::post().to(handle_update_mrenclave::<EthSender, EventWatcher>),
@@ -46,10 +48,6 @@ async fn main() -> io::Result<()> {
             .route(
                 "/api/v1/key_rotation",
                 web::post().to(handle_key_rotation::<EthSender, EventWatcher>),
-            )
-            .route(
-                "/api/v1/start_sync_bc",
-                web::get().to(handle_start_sync_bc::<EthSender, EventWatcher>),
             )
             .route(
                 "/api/v1/register_notification",

--- a/modules/anonify-eth-driver/Cargo.toml
+++ b/modules/anonify-eth-driver/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = "0.1"
 tracing = "0.1"
 serde_json = "1.0"
 bincode = "1.3"
+actix-rt = "1.1"
 
 [features]
 default = ["backup-enable"]

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -102,14 +102,7 @@ where
 
     /// - Starting syncing with the blockchain node.
     /// - Joining as the state runtime node.
-    pub async fn run(
-        self,
-        sync_time: u64,
-        signer: Address,
-        gas: u64,
-    ) -> Result<()>
-    {
-
+    pub async fn run(self, sync_time: u64, signer: Address, gas: u64) -> Result<()> {
         let tx_hash = self.join_group(signer, gas, JOIN_GROUP_CMD).await?;
         info!("A transaction hash of join_group: {:?}", tx_hash);
 

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -8,6 +8,7 @@ use crate::{
     utils::*,
     workflow::host_input,
 };
+use anonify_ecall_types::cmd::*;
 use frame_common::crypto::AccountId;
 use frame_host::engine::HostEngine;
 use frame_sodium::{SodiumCiphertext, SodiumPubKey};
@@ -100,8 +101,50 @@ where
 
     /// - Starting syncing with the blockchain node.
     /// - Joining as the state runtime node.
-    pub fn run(self) -> Result<Self> {
+    pub async fn run(
+        self,
+        sync_time: u64,
+        index: usize,
+        password: Option<&str>,
+        gas: u64,
+    ) -> Result<Self> {
+        let signer = self.get_account(index, password).await?;
+
+        // it spawns a new OS thread, and hosts an event loop.
+        actix_rt::Arbiter::new().exec_fn(move || {
+            actix_rt::spawn(async move {
+                loop {
+                    match self
+                        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+                        .await
+                    {
+                        Ok(updated_states) => info!("State updated: {:?}", updated_states),
+                        Err(err) => error!("event fetched error: {:?}", err),
+                    };
+                    actix_rt::time::delay_for(time::Duration::from_millis(sync_time)).await;
+                }
+            });
+        });
+
+        let tx_hash = self.join_group(signer, gas, JOIN_GROUP_CMD)?;
+        info!("A transaction hash of join_group: {:?}", tx_hash);
+
         Ok(self)
+    }
+
+    pub async fn fetch_events(
+        &self,
+        fetch_ciphertext_cmd: u32,
+        fetch_handshake_cmd: u32,
+    ) -> Result<Option<Vec<serde_json::Value>>> {
+        let inner = self.inner.read();
+        let eid = inner.enclave_id;
+        inner
+            .watcher
+            .as_ref()
+            .ok_or(HostError::EventWatcherNotSet)?
+            .fetch_events(eid, fetch_ciphertext_cmd, fetch_handshake_cmd)
+            .await
     }
 
     pub async fn join_group(&self, signer: Address, gas: u64, ecall_cmd: u32) -> Result<H256> {
@@ -219,21 +262,6 @@ where
             .await?;
 
         Ok(tx_hash)
-    }
-
-    pub async fn fetch_events(
-        &self,
-        fetch_ciphertext_cmd: u32,
-        fetch_handshake_cmd: u32,
-    ) -> Result<Option<Vec<serde_json::Value>>> {
-        let inner = self.inner.read();
-        let eid = inner.enclave_id;
-        inner
-            .watcher
-            .as_ref()
-            .ok_or(HostError::EventWatcherNotSet)?
-            .fetch_events(eid, fetch_ciphertext_cmd, fetch_handshake_cmd)
-            .await
     }
 
     pub async fn get_account(&self, index: usize, password: Option<&str>) -> Result<Address> {

--- a/modules/anonify-eth-driver/src/traits.rs
+++ b/modules/anonify-eth-driver/src/traits.rs
@@ -10,7 +10,7 @@ use web3::types::{Address, H256};
 
 /// A trait for sending transactions to blockchain nodes
 #[async_trait]
-pub trait Sender: Sized {
+pub trait Sender: Sized + Send + Sync + 'static {
     fn new(
         enclave_id: sgx_enclave_id_t,
         node_url: &str,
@@ -40,7 +40,7 @@ pub trait Sender: Sized {
 
 /// A trait of fetching event from blockchian nodes
 #[async_trait]
-pub trait Watcher: Sized {
+pub trait Watcher: Sized + Send + Sync + 'static {
     fn new(node_url: &str, contract_info: ContractInfo, cache: EventCache) -> Result<Self>;
 
     /// Blocking event fetch from blockchain nodes.

--- a/nodes/key-vault/src/tests.rs
+++ b/nodes/key-vault/src/tests.rs
@@ -12,10 +12,8 @@ use once_cell::sync::Lazy;
 use rand_core::{CryptoRng, RngCore};
 use serde_json::json;
 use state_runtime_node_server::{handlers::*, Server as ERC20Server};
-use std::{env, fs, path::Path, str::FromStr, sync::Arc, time};
+use std::{env, fs, path::Path, str::FromStr, sync::Arc};
 use web3::{contract::Options, types::Address};
-
-const SYNC_TIME: u64 = 1500;
 
 #[actix_rt::test]
 async fn test_backup_path_secret() {
@@ -55,14 +53,15 @@ async fn test_backup_path_secret() {
     // just for testing
     let mut csprng = rand::thread_rng();
 
+    // TODO: Dupulicated Server initialization
+    ERC20Server::<EthSender, EventWatcher>::new(app_eid)
+        .await
+        .run()
+        .await;
     let erc20_server = Arc::new(ERC20Server::<EthSender, EventWatcher>::new(app_eid).await);
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -84,13 +83,6 @@ async fn test_backup_path_secret() {
 
     let path_secrets_dir =
         PJ_ROOT_DIR.join(&env::var("PATH_SECRETS_DIR").expect("PATH_SECRETS_DIR is not set"));
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -208,14 +200,15 @@ async fn test_recover_without_key_vault() {
     // just for testing
     let mut csprng = rand::thread_rng();
 
+    // TODO: Dupulicated Server initialization
+    ERC20Server::<EthSender, EventWatcher>::new(app_eid)
+        .await
+        .run()
+        .await;
     let erc20_server = Arc::new(ERC20Server::<EthSender, EventWatcher>::new(app_eid).await);
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -237,13 +230,6 @@ async fn test_recover_without_key_vault() {
 
     let path_secrets_dir =
         PJ_ROOT_DIR.join(&env::var("PATH_SECRETS_DIR").expect("PATH_SECRETS_DIR is not set"));
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -355,14 +341,15 @@ async fn test_manually_backup_all() {
     // just for testing
     let mut csprng = rand::thread_rng();
 
+    // TODO: Dupulicated Server initialization
+    ERC20Server::<EthSender, EventWatcher>::new(app_eid)
+        .await
+        .run()
+        .await;
     let erc20_server = Arc::new(ERC20Server::<EthSender, EventWatcher>::new(app_eid).await);
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -385,13 +372,6 @@ async fn test_manually_backup_all() {
             ),
     )
     .await;
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -516,14 +496,15 @@ async fn test_manually_recover_all() {
     // just for testing
     let mut csprng = rand::thread_rng();
 
+    // TODO: Dupulicated Server initialization
+    ERC20Server::<EthSender, EventWatcher>::new(app_eid)
+        .await
+        .run()
+        .await;
     let erc20_server = Arc::new(ERC20Server::<EthSender, EventWatcher>::new(app_eid).await);
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -546,13 +527,6 @@ async fn test_manually_recover_all() {
             ),
     )
     .await;
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")

--- a/nodes/state-runtime/api/src/lib.rs
+++ b/nodes/state-runtime/api/src/lib.rs
@@ -76,17 +76,6 @@ pub mod state {
     }
 }
 
-pub mod join_group {
-    pub mod post {
-        use super::super::*;
-
-        #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
-        pub struct Response {
-            pub tx_hash: H256,
-        }
-    }
-}
-
 pub mod update_mrenclave {
     pub mod post {
         use super::super::*;

--- a/nodes/state-runtime/server/src/handlers.rs
+++ b/nodes/state-runtime/server/src/handlers.rs
@@ -3,8 +3,7 @@ use crate::{Server, DEFAULT_GAS};
 use actix_web::{web, HttpResponse, Responder};
 use anonify_ecall_types::cmd::*;
 use anonify_eth_driver::traits::*;
-use std::{sync::Arc, time};
-use tracing::{error, info};
+use std::sync::Arc;
 
 pub async fn handle_health_check() -> impl Responder {
     HttpResponse::Ok().finish()

--- a/nodes/state-runtime/server/src/handlers.rs
+++ b/nodes/state-runtime/server/src/handlers.rs
@@ -1,35 +1,13 @@
 use crate::error::{Result, ServerError};
-use crate::Server;
+use crate::{Server, DEFAULT_GAS};
 use actix_web::{web, HttpResponse, Responder};
 use anonify_ecall_types::cmd::*;
 use anonify_eth_driver::traits::*;
 use std::{sync::Arc, time};
 use tracing::{error, info};
 
-const DEFAULT_GAS: u64 = 5_000_000;
-
 pub async fn handle_health_check() -> impl Responder {
     HttpResponse::Ok().finish()
-}
-
-pub async fn handle_join_group<S, W>(server: web::Data<Arc<Server<S, W>>>) -> Result<HttpResponse>
-where
-    S: Sender,
-    W: Watcher,
-{
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, server.password.as_deref())
-        .await
-        .map_err(|e| ServerError::from(e))?;
-    let tx_hash = server
-        .dispatcher
-        .join_group(sender_address, DEFAULT_GAS, JOIN_GROUP_CMD)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
-    Ok(HttpResponse::Accepted()
-        .json(state_runtime_node_api::join_group::post::Response { tx_hash }))
 }
 
 pub async fn handle_update_mrenclave<S, W>(
@@ -39,14 +17,9 @@ where
     S: Sender,
     W: Watcher,
 {
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, server.password.as_deref())
-        .await
-        .map_err(|e| ServerError::from(e))?;
     let tx_hash = server
         .dispatcher
-        .update_mrenclave(sender_address, DEFAULT_GAS, JOIN_GROUP_CMD)
+        .update_mrenclave(server.sender_address, DEFAULT_GAS, JOIN_GROUP_CMD)
         .await
         .map_err(|e| ServerError::from(e))?;
 
@@ -62,18 +35,12 @@ where
     S: Sender,
     W: Watcher,
 {
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, server.password.as_deref())
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
     let tx_hash = server
         .dispatcher
         .send_command(
             req.ciphertext.clone(),
             req.user_id,
-            sender_address,
+            server.sender_address,
             DEFAULT_GAS,
             SEND_COMMAND_CMD,
         )
@@ -88,14 +55,9 @@ where
     S: Sender,
     W: Watcher,
 {
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, server.password.as_deref())
-        .await
-        .map_err(|e| ServerError::from(e))?;
     let tx_hash = server
         .dispatcher
-        .handshake(sender_address, DEFAULT_GAS, SEND_HANDSHAKE_CMD)
+        .handshake(server.sender_address, DEFAULT_GAS, SEND_HANDSHAKE_CMD)
         .await
         .map_err(|e| ServerError::from(e))?;
 
@@ -169,33 +131,6 @@ where
     ))
 }
 
-pub async fn handle_start_sync_bc<S, W>(
-    server: web::Data<Arc<Server<S, W>>>,
-) -> Result<HttpResponse>
-where
-    S: Sender + Send + Sync + 'static,
-    W: Watcher + Send + Sync + 'static,
-{
-    // it spawns a new OS thread, and hosts an event loop.
-    actix_rt::Arbiter::new().exec_fn(move || {
-        actix_rt::spawn(async move {
-            loop {
-                match server
-                    .dispatcher
-                    .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
-                    .await
-                {
-                    Ok(updated_states) => info!("State updated: {:?}", updated_states),
-                    Err(err) => error!("event fetched error: {:?}", err),
-                };
-                actix_rt::time::delay_for(time::Duration::from_millis(server.sync_time)).await;
-            }
-        });
-    });
-
-    Ok(HttpResponse::Ok().finish())
-}
-
 pub async fn handle_register_notification<S, W>(
     server: web::Data<Arc<Server<S, W>>>,
     req: web::Json<state_runtime_node_api::register_notification::post::Request>,
@@ -219,14 +154,9 @@ where
     S: Sender,
     W: Watcher,
 {
-    let sender_address = server
-        .dispatcher
-        .get_account(server.account_index, server.password.as_deref())
-        .await
-        .map_err(|e| ServerError::from(e))?;
     let tx_hash = server
         .dispatcher
-        .register_report(sender_address, DEFAULT_GAS, SEND_REGISTER_REPORT_CMD)
+        .register_report(server.sender_address, DEFAULT_GAS, SEND_REGISTER_REPORT_CMD)
         .await
         .map_err(|e| ServerError::from(e))?;
 

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -27,14 +27,15 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(eid)
+        .await
+        .run()
+        .await;
     let server = Arc::new(Server::<EthSender, EventWatcher>::new(eid).await);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -50,12 +51,6 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     )
     .await;
 
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
         .to_request();
@@ -145,14 +140,15 @@ async fn test_multiple_messages() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(eid)
+        .await
+        .run()
+        .await;
     let server = Arc::new(Server::<EthSender, EventWatcher>::new(eid).await);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -167,13 +163,6 @@ async fn test_multiple_messages() {
             ),
     )
     .await;
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -249,14 +238,15 @@ async fn test_skip_invalid_event() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(eid)
+        .await
+        .run()
+        .await;
     let server = Arc::new(Server::<EthSender, EventWatcher>::new(eid).await);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -271,13 +261,6 @@ async fn test_skip_invalid_event() {
             ),
     )
     .await;
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -368,14 +351,15 @@ async fn test_node_recovery() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(eid)
+        .await
+        .run()
+        .await;
     let server = Arc::new(Server::<EthSender, EventWatcher>::new(eid).await);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -395,6 +379,11 @@ async fn test_node_recovery() {
         .init_enclave(true)
         .expect("Failed to initialize enclave.");
     let recovered_eid = recovered_enclave.geteid();
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(recovered_eid)
+        .await
+        .run()
+        .await;
     let recovered_server = Arc::new(Server::<EthSender, EventWatcher>::new(recovered_eid).await);
 
     let mut recovered_app = test::init_service(
@@ -418,13 +407,6 @@ async fn test_node_recovery() {
             ),
     )
     .await;
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -549,15 +531,16 @@ async fn test_join_group_then_handshake() {
     let eid1 = enclave1.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(eid1)
+        .await
+        .run()
+        .await;
     let server1 = Arc::new(Server::<EthSender, EventWatcher>::new(eid1).await);
 
     let mut app1 = test::init_service(
         App::new()
             .data(server1.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::get().to(handle_get_state::<EthSender, EventWatcher>),
@@ -573,15 +556,16 @@ async fn test_join_group_then_handshake() {
         .init_enclave(true)
         .expect("Failed to initialize enclave.");
     let eid2 = enclave2.geteid();
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(eid2)
+        .await
+        .run()
+        .await;
     let server2 = Arc::new(Server::<EthSender, EventWatcher>::new(eid2).await);
 
     let mut app2 = test::init_service(
         App::new()
             .data(server2.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -741,14 +725,15 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
+    // TODO: Dupulicated Server initialization
+    Server::<EthSender, EventWatcher>::new(eid)
+        .await
+        .run()
+        .await;
     let server = Arc::new(Server::<EthSender, EventWatcher>::new(eid).await);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
-            .route(
-                "/api/v1/join_group",
-                web::post().to(handle_join_group::<EthSender, EventWatcher>),
-            )
             .route(
                 "/api/v1/state",
                 web::post().to(handle_send_command::<EthSender, EventWatcher>),
@@ -767,13 +752,6 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
             ),
     )
     .await;
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -584,13 +584,6 @@ async fn test_join_group_then_handshake() {
 
     // Party 1
 
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app1, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
-
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
         .to_request();
@@ -627,13 +620,6 @@ async fn test_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp); // return 200 OK: becuse allowed same enclave encryption key
-
-    let req = test::TestRequest::post()
-        .uri("/api/v1/join_group")
-        .to_request();
-    let resp = test::call_service(&mut app2, req).await;
-    assert!(resp.status().is_success(), "response: {:?}", resp);
-    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -379,11 +379,8 @@ async fn test_node_recovery() {
         .init_enclave(true)
         .expect("Failed to initialize enclave.");
     let recovered_eid = recovered_enclave.geteid();
-    // TODO: Dupulicated Server initialization
-    Server::<EthSender, EventWatcher>::new(recovered_eid)
-        .await
-        .run()
-        .await;
+
+    // Do not run
     let recovered_server = Arc::new(Server::<EthSender, EventWatcher>::new(recovered_eid).await);
 
     let mut recovered_app = test::init_service(


### PR DESCRIPTION
StateRuntimeノード起動時にBCの同期とjoin_groupトランザクションの送信。

TODO
* `'static` 、Server初期化重複は https://github.com/LayerXcom/anonify/issues/508 対応後外す
* healthcheck修正（https://github.com/LayerXcom/anonify/issues/510）
* https://github.com/LayerXcom/anonify/issues/509