### PR TITLE
CMD定数をhandlerからではなくdispatcherから渡す

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,7 +2527,6 @@ name = "integration-tests"
 version = "0.5.4"
 dependencies = [
  "actix-rt",
- "anonify-ecall-types",
  "anonify-eth-driver",
  "eth-deployer",
  "ethabi",

--- a/nodes/state-runtime/server/src/handlers.rs
+++ b/nodes/state-runtime/server/src/handlers.rs
@@ -1,7 +1,6 @@
 use crate::error::{Result, ServerError};
 use crate::{Server, DEFAULT_GAS};
 use actix_web::{web, HttpResponse, Responder};
-use anonify_ecall_types::cmd::*;
 use anonify_eth_driver::traits::*;
 use std::sync::Arc;
 
@@ -18,7 +17,7 @@ where
 {
     let tx_hash = server
         .dispatcher
-        .update_mrenclave(server.sender_address, DEFAULT_GAS, JOIN_GROUP_CMD)
+        .update_mrenclave(server.sender_address, DEFAULT_GAS)
         .await
         .map_err(|e| ServerError::from(e))?;
 
@@ -41,7 +40,6 @@ where
             req.user_id,
             server.sender_address,
             DEFAULT_GAS,
-            SEND_COMMAND_CMD,
         )
         .await
         .map_err(|e| ServerError::from(e))?;
@@ -56,7 +54,7 @@ where
 {
     let tx_hash = server
         .dispatcher
-        .handshake(server.sender_address, DEFAULT_GAS, SEND_HANDSHAKE_CMD)
+        .handshake(server.sender_address, DEFAULT_GAS)
         .await
         .map_err(|e| ServerError::from(e))?;
 
@@ -75,13 +73,13 @@ where
 {
     server
         .dispatcher
-        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events()
         .await
         .map_err(|e| ServerError::from(e))?;
 
     let state = server
         .dispatcher
-        .get_state(req.ciphertext.clone(), GET_STATE_CMD)
+        .get_state(req.ciphertext.clone())
         .map_err(|e| ServerError::from(e))?;
 
     Ok(HttpResponse::Ok().json(state_runtime_node_api::state::get::Response { state }))
@@ -98,13 +96,13 @@ where
 {
     server
         .dispatcher
-        .fetch_events(FETCH_CIPHERTEXT_CMD, FETCH_HANDSHAKE_CMD)
+        .fetch_events()
         .await
         .map_err(|e| ServerError::from(e))?;
 
     let user_counter = server
         .dispatcher
-        .get_user_counter(req.ciphertext.clone(), GET_USER_COUNTER_CMD)
+        .get_user_counter(req.ciphertext.clone())
         .map_err(|e| ServerError::from(e))?;
 
     Ok(HttpResponse::Ok()
@@ -120,7 +118,7 @@ where
 {
     let enclave_encryption_key = server
         .dispatcher
-        .get_enclave_encryption_key(GET_ENCLAVE_ENCRYPTION_KEY_CMD)
+        .get_enclave_encryption_key()
         .map_err(|e| ServerError::from(e))?;
 
     Ok(HttpResponse::Ok().json(
@@ -140,7 +138,7 @@ where
 {
     server
         .dispatcher
-        .register_notification(req.ciphertext.clone(), REGISTER_NOTIFICATION_CMD)
+        .register_notification(req.ciphertext.clone())
         .map_err(|e| ServerError::from(e))?;
 
     Ok(HttpResponse::Ok().finish())
@@ -155,7 +153,7 @@ where
 {
     let tx_hash = server
         .dispatcher
-        .register_report(server.sender_address, DEFAULT_GAS, SEND_REGISTER_REPORT_CMD)
+        .register_report(server.sender_address, DEFAULT_GAS)
         .await
         .map_err(|e| ServerError::from(e))?;
 
@@ -171,9 +169,7 @@ where
     S: Sender,
     W: Watcher,
 {
-    server
-        .dispatcher
-        .all_backup_to(BACKUP_PATH_SECRET_ALL_CMD)?;
+    server.dispatcher.all_backup_to()?;
 
     Ok(HttpResponse::Ok().finish())
 }
@@ -186,9 +182,7 @@ where
     S: Sender,
     W: Watcher,
 {
-    server
-        .dispatcher
-        .all_backup_from(RECOVER_PATH_SECRET_ALL_CMD)?;
+    server.dispatcher.all_backup_from()?;
 
     Ok(HttpResponse::Ok().finish())
 }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -13,7 +13,6 @@ frame-runtime = { path = "../../frame/runtime" }
 frame-config = { path = "../../frame/config" }
 frame-host = { path = "../../frame/host" }
 anonify-eth-driver = { path = "../../modules/anonify-eth-driver" }
-anonify-ecall-types = { path = "../../modules/anonify-ecall-types" }
 actix-rt = "1.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"


### PR DESCRIPTION
CMD定数は moduleレベルの `anonify-ecall-types` で定義されているので。
fixed: https://github.com/LayerXcom/anonify/issues/509