### PR TITLE
サーバー初期化重複解消

### DIFF
--- a/example/erc20/server/src/main.rs
+++ b/example/erc20/server/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> io::Result<()> {
 
     HttpServer::new(move || {
         App::new()
-            .data(server.clone())
+            .app_data(server.clone())
             .route(
                 "/api/v1/update_mrenclave",
                 web::post().to(handle_update_mrenclave),

--- a/example/erc20/server/src/main.rs
+++ b/example/erc20/server/src/main.rs
@@ -1,7 +1,7 @@
 use actix_web::{web, App, HttpServer};
 use frame_host::EnclaveDir;
 use state_runtime_node_server::{handlers::*, Server};
-use std::{env, io, sync::Arc};
+use std::{env, io};
 
 #[actix_web::main]
 async fn main() -> io::Result<()> {
@@ -17,10 +17,7 @@ async fn main() -> io::Result<()> {
         .init_enclave(true)
         .expect("Failed to initialize enclave.");
     let eid = enclave.geteid();
-
-    // TODO: Dupulicated Server initialization
-    Server::new(eid).await.run().await;
-    let server = Arc::new(Server::new(eid).await);
+    let server = Server::new(eid).await.run().await;
 
     HttpServer::new(move || {
         App::new()

--- a/example/erc20/server/src/main.rs
+++ b/example/erc20/server/src/main.rs
@@ -1,7 +1,7 @@
 use actix_web::{web, App, HttpServer};
 use frame_host::EnclaveDir;
 use state_runtime_node_server::{handlers::*, Server};
-use std::{env, io};
+use std::{env, io, sync::Arc};
 
 #[actix_web::main]
 async fn main() -> io::Result<()> {

--- a/example/erc20/server/src/main.rs
+++ b/example/erc20/server/src/main.rs
@@ -18,10 +18,11 @@ async fn main() -> io::Result<()> {
         .expect("Failed to initialize enclave.");
     let eid = enclave.geteid();
     let server = Server::new(eid).await.run().await;
+    let server = Arc::new(server);
 
     HttpServer::new(move || {
         App::new()
-            .app_data(server.clone())
+            .data(server.clone())
             .route(
                 "/api/v1/update_mrenclave",
                 web::post().to(handle_update_mrenclave),

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -13,7 +13,7 @@ use frame_host::engine::HostEngine;
 use frame_sodium::{SodiumCiphertext, SodiumPubKey};
 use parking_lot::RwLock;
 use sgx_types::sgx_enclave_id_t;
-use std::{fmt::Debug, path::Path, time};
+use std::{fmt::Debug, path::Path, sync::Arc, time};
 use tracing::{error, info};
 use web3::{
     contract::Options,
@@ -21,9 +21,9 @@ use web3::{
 };
 
 /// This dispatcher communicates with a blockchain node.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Dispatcher {
-    inner: RwLock<InnerDispatcher>,
+    inner: Arc<RwLock<InnerDispatcher>>,
 }
 
 #[derive(Debug)]
@@ -39,7 +39,7 @@ struct InnerDispatcher {
 
 impl Dispatcher {
     pub fn new(enclave_id: sgx_enclave_id_t, node_url: &str, cache: EventCache) -> Self {
-        let inner = RwLock::new(InnerDispatcher {
+        let inner = Arc::new(RwLock::new(InnerDispatcher {
             enclave_id,
             node_url: node_url.to_string(),
             cache,
@@ -47,7 +47,7 @@ impl Dispatcher {
             watcher: None,
             #[cfg(feature = "backup-enable")]
             backup: SecretBackup::default(),
-        });
+        }));
 
         Dispatcher { inner }
     }
@@ -98,7 +98,9 @@ impl Dispatcher {
 
     /// - Starting syncing with the blockchain node.
     /// - Joining as the state runtime node.
-    pub async fn run(self, sync_time: u64, signer: Address, gas: u64) -> Result<()> {
+    /// These operations are not mutable so just returning self data type.
+    pub async fn run(self, sync_time: u64, signer: Address, gas: u64) -> Result<Self> {
+        let this = self.clone();
         let tx_hash = self.join_group(signer, gas).await?;
         info!("A transaction hash of join_group: {:?}", tx_hash);
 
@@ -115,7 +117,7 @@ impl Dispatcher {
             });
         });
 
-        Ok(())
+        Ok(this)
     }
 
     pub async fn fetch_events(&self) -> Result<Option<Vec<serde_json::Value>>> {

--- a/nodes/key-vault/src/tests.rs
+++ b/nodes/key-vault/src/tests.rs
@@ -50,9 +50,7 @@ async fn test_backup_path_secret() {
     // just for testing
     let mut csprng = rand::thread_rng();
 
-    // TODO: Dupulicated Server initialization
-    ERC20Server::new(app_eid).await.run().await;
-    let erc20_server = Arc::new(ERC20Server::new(app_eid).await);
+    let erc20_server = ERC20Server::new(app_eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
@@ -185,9 +183,7 @@ async fn test_recover_without_key_vault() {
     // just for testing
     let mut csprng = rand::thread_rng();
 
-    // TODO: Dupulicated Server initialization
-    ERC20Server::new(app_eid).await.run().await;
-    let erc20_server = Arc::new(ERC20Server::new(app_eid).await);
+    let erc20_server = ERC20Server::new(app_eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
@@ -314,9 +310,7 @@ async fn test_manually_backup_all() {
     // just for testing
     let mut csprng = rand::thread_rng();
 
-    // TODO: Dupulicated Server initialization
-    ERC20Server::new(app_eid).await.run().await;
-    let erc20_server = Arc::new(ERC20Server::new(app_eid).await);
+    let erc20_server = ERC20Server::new(app_eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
@@ -457,9 +451,7 @@ async fn test_manually_recover_all() {
     // just for testing
     let mut csprng = rand::thread_rng();
 
-    // TODO: Dupulicated Server initialization
-    ERC20Server::new(app_eid).await.run().await;
-    let erc20_server = Arc::new(ERC20Server::new(app_eid).await);
+   let erc20_server = ERC20Server::new(app_eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())

--- a/nodes/key-vault/src/tests.rs
+++ b/nodes/key-vault/src/tests.rs
@@ -51,6 +51,7 @@ async fn test_backup_path_secret() {
     let mut csprng = rand::thread_rng();
 
     let erc20_server = ERC20Server::new(app_eid).await.run().await;
+    let erc20_server = Arc::new(erc20_server);
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
@@ -184,6 +185,7 @@ async fn test_recover_without_key_vault() {
     let mut csprng = rand::thread_rng();
 
     let erc20_server = ERC20Server::new(app_eid).await.run().await;
+    let erc20_server = Arc::new(erc20_server);
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
@@ -311,6 +313,7 @@ async fn test_manually_backup_all() {
     let mut csprng = rand::thread_rng();
 
     let erc20_server = ERC20Server::new(app_eid).await.run().await;
+    let erc20_server = Arc::new(erc20_server);
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())
@@ -452,6 +455,7 @@ async fn test_manually_recover_all() {
     let mut csprng = rand::thread_rng();
 
    let erc20_server = ERC20Server::new(app_eid).await.run().await;
+   let erc20_server = Arc::new(erc20_server);
     let mut app = test::init_service(
         App::new()
             .data(erc20_server.clone())

--- a/nodes/state-runtime/server/src/lib.rs
+++ b/nodes/state-runtime/server/src/lib.rs
@@ -1,7 +1,7 @@
 use anonify_eth_driver::{Dispatcher, EventCache};
 use frame_config::{ANONIFY_ABI_PATH, ANONIFY_BIN_PATH, FACTORY_ABI_PATH};
 use sgx_types::sgx_enclave_id_t;
-use std::{env, str::FromStr};
+use std::{env, str::FromStr, sync::Arc};
 use web3::types::Address;
 
 mod error;
@@ -11,7 +11,7 @@ mod tests;
 
 const DEFAULT_GAS: u64 = 5_000_000;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Server {
     pub eid: sgx_enclave_id_t,
     pub eth_url: String,
@@ -65,15 +65,18 @@ impl Server {
         }
     }
 
-    pub async fn run(self) {
+    pub async fn run(mut self) -> Self {
         let sync_time: u64 = env::var("SYNC_BC_TIME")
             .unwrap_or_else(|_| "1000".to_string())
             .parse()
             .expect("Failed to parse SYNC_BC_TIME to u64");
 
-        self.dispatcher
+        let dispatcher = self.dispatcher
             .run(sync_time, self.sender_address, DEFAULT_GAS)
             .await
             .unwrap();
+
+        self.dispatcher = dispatcher;
+        self
     }
 }

--- a/nodes/state-runtime/server/src/lib.rs
+++ b/nodes/state-runtime/server/src/lib.rs
@@ -1,7 +1,7 @@
 use anonify_eth_driver::{Dispatcher, EventCache};
 use frame_config::{ANONIFY_ABI_PATH, ANONIFY_BIN_PATH, FACTORY_ABI_PATH};
 use sgx_types::sgx_enclave_id_t;
-use std::{env, str::FromStr, sync::Arc};
+use std::{env, str::FromStr};
 use web3::types::Address;
 
 mod error;
@@ -71,7 +71,8 @@ impl Server {
             .parse()
             .expect("Failed to parse SYNC_BC_TIME to u64");
 
-        let dispatcher = self.dispatcher
+        let dispatcher = self
+            .dispatcher
             .run(sync_time, self.sender_address, DEFAULT_GAS)
             .await
             .unwrap();

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -27,9 +27,8 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
-    // TODO: Dupulicated Server initialization
-    Server::new(eid).await.run().await;
-    let server = Arc::new(Server::new(eid).await);
+
+    let server = Server::new(eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
@@ -131,9 +130,8 @@ async fn test_multiple_messages() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
-    // TODO: Dupulicated Server initialization
-    Server::new(eid).await.run().await;
-    let server = Arc::new(Server::new(eid).await);
+
+    let server = Server::new(eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
@@ -220,9 +218,8 @@ async fn test_skip_invalid_event() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
-    // TODO: Dupulicated Server initialization
-    Server::new(eid).await.run().await;
-    let server = Arc::new(Server::new(eid).await);
+
+    let server = Server::new(eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
@@ -324,9 +321,8 @@ async fn test_node_recovery() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
-    // TODO: Dupulicated Server initialization
-    Server::new(eid).await.run().await;
-    let server = Arc::new(Server::new(eid).await);
+
+    let server = Server::new(eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
@@ -486,10 +482,8 @@ async fn test_join_group_then_handshake() {
     let eid1 = enclave1.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
-    // TODO: Dupulicated Server initialization
-    Server::new(eid1).await.run().await;
-    let server1 = Arc::new(Server::new(eid1).await);
 
+    let server1 = Server::new(eid1).await.run().await;
     let mut app1 = test::init_service(
         App::new()
             .data(server1.clone())
@@ -505,10 +499,7 @@ async fn test_join_group_then_handshake() {
         .init_enclave(true)
         .expect("Failed to initialize enclave.");
     let eid2 = enclave2.geteid();
-    // TODO: Dupulicated Server initialization
-    Server::new(eid2).await.run().await;
-    let server2 = Arc::new(Server::new(eid2).await);
-
+    let server2 = Server::new(eid2).await.run().await;
     let mut app2 = test::init_service(
         App::new()
             .data(server2.clone())
@@ -648,9 +639,8 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
     let eid = enclave.geteid();
     // just for testing
     let mut csprng = rand::thread_rng();
-    // TODO: Dupulicated Server initialization
-    Server::new(eid).await.run().await;
-    let server = Arc::new(Server::new(eid).await);
+
+    let server = Server::new(eid).await.run().await;
     let mut app = test::init_service(
         App::new()
             .data(server.clone())

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -133,6 +133,7 @@ async fn test_multiple_messages() {
     let mut csprng = rand::thread_rng();
 
     let server = Server::new(eid).await.run().await;
+    let server = Arc::new(server);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
@@ -221,6 +222,7 @@ async fn test_skip_invalid_event() {
     let mut csprng = rand::thread_rng();
 
     let server = Server::new(eid).await.run().await;
+    let server = Arc::new(server);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
@@ -324,6 +326,7 @@ async fn test_node_recovery() {
     let mut csprng = rand::thread_rng();
 
     let server = Server::new(eid).await.run().await;
+    let server = Arc::new(server);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())
@@ -343,6 +346,7 @@ async fn test_node_recovery() {
 
     // Do not run
     let recovered_server = Arc::new(Server::new(recovered_eid).await);
+    let recovered_server = Arc::new(recovered_server);
 
     let mut recovered_app = test::init_service(
         App::new()
@@ -485,6 +489,7 @@ async fn test_join_group_then_handshake() {
     let mut csprng = rand::thread_rng();
 
     let server1 = Server::new(eid1).await.run().await;
+    let server1 = Arc::new(server1);
     let mut app1 = test::init_service(
         App::new()
             .data(server1.clone())
@@ -501,6 +506,7 @@ async fn test_join_group_then_handshake() {
         .expect("Failed to initialize enclave.");
     let eid2 = enclave2.geteid();
     let server2 = Server::new(eid2).await.run().await;
+    let server2 = Arc::new(server2);
     let mut app2 = test::init_service(
         App::new()
             .data(server2.clone())
@@ -642,6 +648,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
     let mut csprng = rand::thread_rng();
 
     let server = Server::new(eid).await.run().await;
+    let server = Arc::new(server);
     let mut app = test::init_service(
         App::new()
             .data(server.clone())

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -29,9 +29,10 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     let mut csprng = rand::thread_rng();
 
     let server = Server::new(eid).await.run().await;
+    let server = Arc::new(server);
     let mut app = test::init_service(
         App::new()
-            .app_data(server.clone())
+            .data(server.clone())
             .route("/api/v1/state", web::post().to(handle_send_command))
             .route("/api/v1/state", web::get().to(handle_get_state))
             .route(

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -346,7 +346,6 @@ async fn test_node_recovery() {
 
     // Do not run
     let recovered_server = Arc::new(Server::new(recovered_eid).await);
-    let recovered_server = Arc::new(recovered_server);
 
     let mut recovered_app = test::init_service(
         App::new()

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -31,7 +31,7 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     let server = Server::new(eid).await.run().await;
     let mut app = test::init_service(
         App::new()
-            .data(server.clone())
+            .app_data(server.clone())
             .route("/api/v1/state", web::post().to(handle_send_command))
             .route("/api/v1/state", web::get().to(handle_get_state))
             .route(


### PR DESCRIPTION
* `Dispatcher`内を `Arc`で持たせてcloneできるようにし、 `run()`時に 別スレッドにDispatcherがmoveしてしまうかつ `fetch_events`と`join_group`はimmutableなので、move前にclone()し返り値はselfを返す
* actix-webで `data()` に渡す引数は`Arc<>`である必要


fixed: https://github.com/LayerXcom/anonify/issues/513