### PR TITLE
[命令暗号方式抽象化] ホストレイヤ実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,6 +2526,7 @@ name = "integration-tests"
 version = "0.5.4"
 dependencies = [
  "actix-rt",
+ "anonify-ecall-types",
  "anonify-eth-driver",
  "eth-deployer",
  "ethabi",

--- a/ethereum/contracts/Anonify.sol
+++ b/ethereum/contracts/Anonify.sol
@@ -25,8 +25,8 @@ contract Anonify is ReportHandle {
     // Counter for enforcing the order of state transitions
     mapping(uint32 => GroupKeyCounter) private _groupKeyCounter;
 
-    event StoreCiphertext(bytes ciphertext, uint256 stateCounter);
-    event StoreHandshake(bytes handshake, uint256 stateCounter);
+    event StoreTreeKemCiphertext(bytes ciphertext, uint256 stateCounter);
+    event StoreTreeKemHandshake(bytes handshake, uint256 stateCounter);
     event UpdateMrenclaveVer(uint32 newVersion);
 
     constructor() {

--- a/modules/anonify-ecall-types/src/lib.rs
+++ b/modules/anonify-ecall-types/src/lib.rs
@@ -26,3 +26,18 @@ use serde_std as serde;
 pub mod cmd;
 pub mod types;
 pub use crate::types::*;
+
+use crate::serde::{Deserialize, Serialize};
+use frame_common::TreeKemCiphertext;
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[serde(crate = "crate::serde")]
+pub enum CommandCiphertext {
+    TreeKem(TreeKemCiphertext),
+}
+
+impl Default for CommandCiphertext {
+    fn default() -> Self {
+        CommandCiphertext::TreeKem(Default::default())
+    }
+}

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -392,22 +392,36 @@ pub mod output {
         #[serde(with = "serde_bytes")]
         report_sig: Vec<u8>,
         #[serde(with = "serde_bytes")]
-        handshake: Vec<u8>,
+        handshake: Option<Vec<u8>>,
         mrenclave_ver: u32,
         roster_idx: u32,
     }
 
     impl fmt::Debug for ReturnJoinGroup {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(
-                f,
-                "ReturnJoinGroup {{ report: 0x{}, report_sig: 0x{}, handshake: 0x{}, mrenclave_ver: {:?}, roster_idx: {:?} }}",
-                hex::encode(&self.report()),
-                hex::encode(&self.report_sig()),
-                hex::encode(&self.handshake),
-                self.mrenclave_ver,
-                self.roster_idx
-            )
+            match self.handshake() {
+                Some(handshake) => {
+                    write!(
+                        f,
+                        "ReturnJoinGroup {{ report: 0x{}, report_sig: 0x{}, handshake: 0x{}, mrenclave_ver: {:?}, roster_idx: {:?} }}",
+                        hex::encode(&self.report()),
+                        hex::encode(&self.report_sig()),
+                        hex::encode(&handshake),
+                        self.mrenclave_ver,
+                        self.roster_idx
+                    )
+                }
+                None => {
+                    write!(
+                        f,
+                        "ReturnJoinGroup {{ report: 0x{}, report_sig: 0x{}, mrenclave_ver: {:?}, roster_idx: {:?} }}",
+                        hex::encode(&self.report()),
+                        hex::encode(&self.report_sig()),
+                        self.mrenclave_ver,
+                        self.roster_idx
+                    )
+                }
+            }
         }
     }
 
@@ -417,7 +431,7 @@ pub mod output {
         pub fn new(
             report: Vec<u8>,
             report_sig: Vec<u8>,
-            handshake: Vec<u8>,
+            handshake: Option<Vec<u8>>,
             mrenclave_ver: usize,
             roster_idx: u32,
         ) -> Self {
@@ -438,8 +452,8 @@ pub mod output {
             &self.report_sig[..]
         }
 
-        pub fn handshake(&self) -> &[u8] {
-            &self.handshake[..]
+        pub fn handshake(&self) -> Option<&[u8]> {
+            self.handshake.as_deref()
         }
 
         pub fn mrenclave_ver(&self) -> u32 {

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -7,11 +7,12 @@ use crate::serde::{
 };
 use crate::serde_bytes;
 use crate::serde_json;
+use crate::CommandCiphertext;
 use frame_common::{
     crypto::{AccountId, ExportHandshake},
     state_types::{StateCounter, StateType, UserCounter},
     traits::AccessPolicy,
-    EcallInput, EcallOutput, TreeKemCiphertext,
+    EcallInput, EcallOutput,
 };
 use frame_sodium::{SodiumCiphertext, SodiumPubKey};
 
@@ -46,22 +47,22 @@ pub mod input {
 
     #[derive(Serialize, Deserialize, Debug, Clone, Default)]
     #[serde(crate = "crate::serde")]
-    pub struct InsertCiphertextByTreeKem {
-        ciphertext: TreeKemCiphertext,
+    pub struct InsertCiphertext {
+        ciphertext: CommandCiphertext,
         state_counter: StateCounter,
     }
 
-    impl EcallInput for InsertCiphertextByTreeKem {}
+    impl EcallInput for InsertCiphertext {}
 
-    impl InsertCiphertextByTreeKem {
-        pub fn new(ciphertext: TreeKemCiphertext, state_counter: StateCounter) -> Self {
-            InsertCiphertextByTreeKem {
+    impl InsertCiphertext {
+        pub fn new(ciphertext: CommandCiphertext, state_counter: StateCounter) -> Self {
+            InsertCiphertext {
                 ciphertext,
                 state_counter,
             }
         }
 
-        pub fn ciphertext(&self) -> &TreeKemCiphertext {
+        pub fn ciphertext(&self) -> &CommandCiphertext {
             &self.ciphertext
         }
 
@@ -202,27 +203,27 @@ pub mod output {
     use super::*;
 
     #[derive(Debug, Clone)]
-    pub struct CommandByTreeKem {
+    pub struct Command {
         enclave_sig: secp256k1::Signature,
-        ciphertext: TreeKemCiphertext,
+        ciphertext: CommandCiphertext,
         recovery_id: secp256k1::RecoveryId,
     }
 
-    impl Default for CommandByTreeKem {
+    impl Default for Command {
         fn default() -> Self {
             let enclave_sig = secp256k1::Signature::parse(&[0u8; 64]);
             let recovery_id = secp256k1::RecoveryId::parse(0).unwrap();
             Self {
                 enclave_sig,
-                ciphertext: TreeKemCiphertext::default(),
+                ciphertext: CommandCiphertext::default(),
                 recovery_id,
             }
         }
     }
 
-    impl EcallOutput for CommandByTreeKem {}
+    impl EcallOutput for Command {}
 
-    impl Serialize for CommandByTreeKem {
+    impl Serialize for Command {
         // not for human readable, used for binary encoding
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -236,7 +237,7 @@ pub mod output {
         }
     }
 
-    impl<'de> Deserialize<'de> for CommandByTreeKem {
+    impl<'de> Deserialize<'de> for Command {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: de::Deserializer<'de>,
@@ -244,13 +245,13 @@ pub mod output {
             struct CommandVisitor;
 
             impl<'de> de::Visitor<'de> for CommandVisitor {
-                type Value = CommandByTreeKem;
+                type Value = Command;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                     formatter.write_str("ecall output command")
                 }
 
-                fn visit_seq<V>(self, mut seq: V) -> Result<CommandByTreeKem, V::Error>
+                fn visit_seq<V>(self, mut seq: V) -> Result<Command, V::Error>
                 where
                     V: SeqAccess<'de>,
                 {
@@ -271,7 +272,7 @@ pub mod output {
                     let ciphertext = bincode::deserialize(&ciphertext_v[..])
                         .map_err(|_e| V::Error::custom("InvalidCiphertext"))?;
 
-                    Ok(CommandByTreeKem::new(ciphertext, enclave_sig, recovery_id))
+                    Ok(Command::new(ciphertext, enclave_sig, recovery_id))
                 }
             }
 
@@ -279,20 +280,20 @@ pub mod output {
         }
     }
 
-    impl CommandByTreeKem {
+    impl Command {
         pub fn new(
-            ciphertext: TreeKemCiphertext,
+            ciphertext: CommandCiphertext,
             enclave_sig: secp256k1::Signature,
             recovery_id: secp256k1::RecoveryId,
         ) -> Self {
-            CommandByTreeKem {
+            Command {
                 enclave_sig,
                 ciphertext,
                 recovery_id,
             }
         }
 
-        pub fn ciphertext(&self) -> &TreeKemCiphertext {
+        pub fn ciphertext(&self) -> &CommandCiphertext {
             &self.ciphertext
         }
 

--- a/modules/anonify-ecall-types/src/types.rs
+++ b/modules/anonify-ecall-types/src/types.rs
@@ -391,7 +391,7 @@ pub mod output {
         report: Vec<u8>,
         #[serde(with = "serde_bytes")]
         report_sig: Vec<u8>,
-        #[serde(with = "serde_bytes")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         handshake: Option<Vec<u8>>,
         mrenclave_ver: u32,
         roster_idx: u32,

--- a/modules/anonify-enclave/src/handshake.rs
+++ b/modules/anonify-enclave/src/handshake.rs
@@ -49,7 +49,7 @@ impl EnclaveEngine for JoinGroupSender {
         Ok(output::ReturnJoinGroup::new(
             attested_report.report().to_vec(),
             attested_report.report_sig().to_vec(),
-            export_handshake.encode(),
+            Some(export_handshake.encode()),
             enclave_context.mrenclave_ver(),
             export_handshake.roster_idx(),
         ))

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -105,7 +105,6 @@ impl Dispatcher {
         Ok(address)
     }
 
-    // TODO: treekem
     /// - Starting syncing with the blockchain node.
     /// - Joining as the state runtime node.
     /// These operations are not mutable so just returning self data type.

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -109,16 +109,27 @@ impl Dispatcher {
     /// - Starting syncing with the blockchain node.
     /// - Joining as the state runtime node.
     /// These operations are not mutable so just returning self data type.
-    pub async fn run(self, sync_time: u64, signer: Address, gas: u64) -> Result<Self> {
+    pub async fn run(
+        self,
+        sync_time: u64,
+        signer: Address,
+        gas: u64,
+        fetch_ciphertext_ecall_cmd: u32,
+        fetch_handshake_ecalll_cmd: u32,
+        join_group_ecall_cmd: u32,
+    ) -> Result<Self> {
         let this = self.clone();
-        let receipt = self.join_group(signer, gas).await?;
+        let receipt = self.join_group(signer, gas, join_group_ecall_cmd).await?;
         info!("A transaction hash of join_group: {:?}", receipt);
 
         // it spawns a new OS thread, and hosts an event loop.
         actix_rt::Arbiter::new().exec_fn(move || {
             actix_rt::spawn(async move {
                 loop {
-                    match self.fetch_events().await {
+                    match self
+                        .fetch_events(fetch_ciphertext_ecall_cmd, fetch_handshake_ecalll_cmd)
+                        .await
+                    {
                         Ok(updated_states) => info!("State updated: {:?}", updated_states),
                         Err(err) => error!("event fetched error: {:?}", err),
                     };
@@ -139,28 +150,31 @@ impl Dispatcher {
         self.inner.read().is_healthy
     }
 
-    // TODO: treekem
-    pub async fn fetch_events(&self) -> Result<Option<Vec<serde_json::Value>>> {
+    pub async fn fetch_events(
+        &self,
+        fetch_ciphertext_ecall_cmd: u32,
+        getch_handshake_ecall_cmd: u32,
+    ) -> Result<Option<Vec<serde_json::Value>>> {
         let inner = self.inner.read();
         let eid = inner.enclave_id;
         inner
             .watcher
             .as_ref()
             .ok_or(HostError::EventWatcherNotSet)?
-            .fetch_events(
-                eid,
-                FETCH_CIPHERTEXT_TREEKEM_CMD,
-                FETCH_HANDSHAKE_TREEKEM_CMD,
-            )
+            .fetch_events(eid, fetch_ciphertext_ecall_cmd, getch_handshake_ecall_cmd)
             .await
     }
 
-    // TODO: treekem
-    pub async fn join_group(&self, signer: Address, gas: u64) -> Result<TransactionReceipt> {
-        self.send_report_handshake(signer, gas, "joinGroup").await
+    pub async fn join_group(
+        &self,
+        signer: Address,
+        gas: u64,
+        ecall_cmd: u32,
+    ) -> Result<TransactionReceipt> {
+        self.send_report_handshake(signer, gas, "joinGroup", ecall_cmd)
+            .await
     }
 
-    // TODO: treekem
     pub async fn register_report(&self, signer: Address, gas: u64) -> Result<H256> {
         let inner = self.inner.read();
         let eid = inner.enclave_id;
@@ -177,22 +191,26 @@ impl Dispatcher {
         Ok(tx_hash)
     }
 
-    // TODO: treekem
-    pub async fn update_mrenclave(&self, signer: Address, gas: u64) -> Result<TransactionReceipt> {
-        self.send_report_handshake(signer, gas, "updateMrenclave")
+    pub async fn update_mrenclave(
+        &self,
+        signer: Address,
+        gas: u64,
+        ecall_cmd: u32,
+    ) -> Result<TransactionReceipt> {
+        self.send_report_handshake(signer, gas, "updateMrenclave", ecall_cmd)
             .await
     }
 
-    // TODO: treekem
     async fn send_report_handshake(
         &self,
         signer: Address,
         gas: u64,
         method: &str,
+        ecall_cmd: u32,
     ) -> Result<TransactionReceipt> {
         let inner = self.inner.read();
         let eid = inner.enclave_id;
-        let input = host_input::JoinGroup::new(signer, gas, JOIN_GROUP_TREEKEM_CMD);
+        let input = host_input::JoinGroup::new(signer, gas, ecall_cmd);
         let host_output = JoinGroupWorkflow::exec(input, eid)?;
 
         let receipt = inner
@@ -205,24 +223,18 @@ impl Dispatcher {
         Ok(receipt)
     }
 
-    // TODO: treekem
     pub async fn send_command(
         &self,
         ciphertext: SodiumCiphertext,
         user_id: Option<AccountId>,
         signer: Address,
         gas: u64,
+        ecall_cmd: u32,
     ) -> Result<H256> {
         let inner = self.inner.read();
-        let input = host_input::CommandByTreeKem::new(
-            ciphertext,
-            user_id,
-            signer,
-            gas,
-            SEND_COMMAND_TREEKEM_CMD,
-        );
+        let input = host_input::Command::new(ciphertext, user_id, signer, gas, ecall_cmd);
         let eid = inner.enclave_id;
-        let host_output = CommandByTreeKemWorkflow::exec(input, eid)?;
+        let host_output = CommandWorkflow::exec(input, eid)?;
 
         match &inner.sender {
             Some(s) => s.send_command(&host_output).await,
@@ -251,7 +263,6 @@ impl Dispatcher {
         serde_json::to_value(user_counter.user_counter).map_err(Into::into)
     }
 
-    // TODO: treekem
     pub async fn handshake(&self, signer: Address, gas: u64) -> Result<H256> {
         let inner = self.inner.read();
         let input = host_input::Handshake::new(signer, gas, SEND_HANDSHAKE_TREEKEM_CMD);

--- a/modules/anonify-eth-driver/src/error.rs
+++ b/modules/anonify-eth-driver/src/error.rs
@@ -16,6 +16,8 @@ pub enum HostError {
     UnlockError,
     #[error("Decoded EthLogToken to invalid TokenType")]
     InvalidEthLogToken,
+    #[error("Invalid ciphertext")]
+    InvalidCiphertextError,
     #[error("The number of EthLogTokens should be {0}")]
     InvalidNumberOfEthLogToken(usize),
     #[error("IO error: {0}")]

--- a/modules/anonify-eth-driver/src/eth/sender.rs
+++ b/modules/anonify-eth-driver/src/eth/sender.rs
@@ -79,7 +79,7 @@ impl EthSender {
         .await
     }
 
-    pub async fn send_command(&self, host_output: &host_output::CommandByTreeKem) -> Result<H256> {
+    pub async fn send_command(&self, host_output: &host_output::Command) -> Result<H256> {
         info!("Sending a command to blockchain: {:?}", host_output);
         Retry::new(
             "send_command",

--- a/modules/anonify-eth-driver/src/workflow.rs
+++ b/modules/anonify-eth-driver/src/workflow.rs
@@ -2,7 +2,6 @@ use anonify_ecall_types::*;
 use frame_common::{
     crypto::{AccountId, ExportHandshake},
     state_types::StateCounter,
-    TreeKemCiphertext,
 };
 use frame_host::engine::*;
 use frame_sodium::SodiumCiphertext;
@@ -10,13 +9,13 @@ use web3::types::Address;
 
 pub const OUTPUT_MAX_LEN: usize = 2048;
 
-pub struct CommandByTreeKemWorkflow;
+pub struct CommandWorkflow;
 
-impl HostEngine for CommandByTreeKemWorkflow {
-    type HI = host_input::CommandByTreeKem;
+impl HostEngine for CommandWorkflow {
+    type HI = host_input::Command;
     type EI = input::Command;
-    type EO = output::CommandByTreeKem;
-    type HO = host_output::CommandByTreeKem;
+    type EO = output::Command;
+    type HO = host_output::Command;
     const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
 }
 
@@ -70,11 +69,11 @@ impl HostEngine for GetStateWorkflow {
     const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
 }
 
-pub struct InsertCiphertextByTreeKemWorkflow;
+pub struct InsertCiphertextWorkflow;
 
-impl HostEngine for InsertCiphertextByTreeKemWorkflow {
-    type HI = host_input::InsertCiphertextByTreeKem;
-    type EI = input::InsertCiphertextByTreeKem;
+impl HostEngine for InsertCiphertextWorkflow {
+    type HI = host_input::InsertCiphertext;
+    type EI = input::InsertCiphertext;
     type EO = output::ReturnNotifyState;
     type HO = host_output::InsertCiphertext;
     const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
@@ -133,7 +132,7 @@ impl HostEngine for GetUserCounterWorkflow {
 pub mod host_input {
     use super::*;
 
-    pub struct CommandByTreeKem {
+    pub struct Command {
         ciphertext: SodiumCiphertext,
         user_id: Option<AccountId>,
         signer: Address,
@@ -141,7 +140,7 @@ pub mod host_input {
         ecall_cmd: u32,
     }
 
-    impl CommandByTreeKem {
+    impl Command {
         pub fn new(
             ciphertext: SodiumCiphertext,
             user_id: Option<AccountId>,
@@ -149,7 +148,7 @@ pub mod host_input {
             gas: u64,
             ecall_cmd: u32,
         ) -> Self {
-            CommandByTreeKem {
+            Command {
                 ciphertext,
                 user_id,
                 signer,
@@ -159,12 +158,12 @@ pub mod host_input {
         }
     }
 
-    impl HostInput for CommandByTreeKem {
+    impl HostInput for Command {
         type EcallInput = input::Command;
-        type HostOutput = host_output::CommandByTreeKem;
+        type HostOutput = host_output::Command;
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
-            let host_output = host_output::CommandByTreeKem::new(self.signer, self.gas);
+            let host_output = host_output::Command::new(self.signer, self.gas);
             let ecall_input = input::Command::new(self.ciphertext, self.user_id);
 
             Ok((ecall_input, host_output))
@@ -349,19 +348,19 @@ pub mod host_input {
         }
     }
 
-    pub struct InsertCiphertextByTreeKem {
-        ciphertext: TreeKemCiphertext,
+    pub struct InsertCiphertext {
+        ciphertext: CommandCiphertext,
         state_counter: StateCounter,
         ecall_cmd: u32,
     }
 
-    impl InsertCiphertextByTreeKem {
+    impl InsertCiphertext {
         pub fn new(
-            ciphertext: TreeKemCiphertext,
+            ciphertext: CommandCiphertext,
             state_counter: StateCounter,
             ecall_cmd: u32,
         ) -> Self {
-            InsertCiphertextByTreeKem {
+            InsertCiphertext {
                 ciphertext,
                 state_counter,
                 ecall_cmd,
@@ -369,8 +368,8 @@ pub mod host_input {
         }
     }
 
-    impl HostInput for InsertCiphertextByTreeKem {
-        type EcallInput = input::InsertCiphertextByTreeKem;
+    impl HostInput for InsertCiphertext {
+        type EcallInput = input::InsertCiphertext;
         type HostOutput = host_output::InsertCiphertext;
 
         fn apply(self) -> anyhow::Result<(Self::EcallInput, Self::HostOutput)> {
@@ -493,14 +492,14 @@ pub mod host_output {
     use super::*;
 
     #[derive(Debug, Clone)]
-    pub struct CommandByTreeKem {
+    pub struct Command {
         pub signer: Address,
         pub gas: u64,
-        pub ecall_output: Option<output::CommandByTreeKem>,
+        pub ecall_output: Option<output::Command>,
     }
 
-    impl HostOutput for CommandByTreeKem {
-        type EcallOutput = output::CommandByTreeKem;
+    impl HostOutput for Command {
+        type EcallOutput = output::Command;
 
         fn set_ecall_output(mut self, output: Self::EcallOutput) -> anyhow::Result<Self> {
             self.ecall_output = Some(output);
@@ -509,9 +508,9 @@ pub mod host_output {
         }
     }
 
-    impl CommandByTreeKem {
+    impl Command {
         pub fn new(signer: Address, gas: u64) -> Self {
-            CommandByTreeKem {
+            Command {
                 signer,
                 gas,
                 ecall_output: None,

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -13,6 +13,7 @@ frame-runtime = { path = "../../frame/runtime" }
 frame-config = { path = "../../frame/config" }
 frame-host = { path = "../../frame/host" }
 anonify-eth-driver = { path = "../../modules/anonify-eth-driver" }
+anonify-ecall-types = { path = "../../modules/anonify-ecall-types" }
 actix-rt = "1.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate lazy_static;
+use anonify_ecall_types::cmd::*;
 use anonify_eth_driver::{dispatcher::*, eth::*, EventCache};
 use eth_deployer::EthDeployer;
 use ethabi::Contract as ContractABI;
@@ -113,10 +114,16 @@ async fn test_integration_eth_construct() {
     println!("factory contract address: {}", factory_contract_addr);
     println!("anonify contract address: {}", anonify_contract_addr);
 
-    dispatcher.join_group(deployer_addr, gas).await.unwrap();
+    dispatcher
+        .join_group(deployer_addr, gas, JOIN_GROUP_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Init state
     let total_supply: u64 = 100;
@@ -132,14 +139,23 @@ async fn test_integration_eth_construct() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
 
     println!("init state receipt: {:?}", receipt);
 
     // Get logs from contract and update state inside enclave.
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     let req = json!({
         "access_policy": COMMON_ACCESS_POLICY.clone(),
@@ -231,10 +247,16 @@ async fn test_auto_notification() {
     println!("factory contract address: {}", factory_contract_addr);
     println!("anonify contract address: {}", anonify_contract_addr);
 
-    dispatcher.join_group(deployer_addr, gas).await.unwrap();
+    dispatcher
+        .join_group(deployer_addr, gas, JOIN_GROUP_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Init state
     let pubkey = get_enclave_encryption_key(anonify_contract_addr, &dispatcher).await;
@@ -250,7 +272,13 @@ async fn test_auto_notification() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
 
@@ -262,7 +290,11 @@ async fn test_auto_notification() {
     dispatcher.register_notification(encrypted_req).unwrap();
 
     // Get logs from contract and update state inside enclave.
-    let updated_state = dispatcher.fetch_events().await.unwrap().unwrap();
+    let updated_state = dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap()
+        .unwrap();
     let notified_state: Vec<NotifyState> = updated_state
         .into_iter()
         .map(|e| serde_json::from_value(e).unwrap())
@@ -294,13 +326,23 @@ async fn test_auto_notification() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr, gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
 
     // Update state inside enclave
-    let updated_state = dispatcher.fetch_events().await.unwrap().unwrap();
+    let updated_state = dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap()
+        .unwrap();
     let notified_state: Vec<NotifyState> = updated_state
         .into_iter()
         .map(|e| serde_json::from_value(e).unwrap())
@@ -373,10 +415,16 @@ async fn test_integration_eth_transfer() {
     println!("factory contract address: {}", factory_contract_addr);
     println!("anonify contract address: {}", anonify_contract_addr);
 
-    dispatcher.join_group(deployer_addr, gas).await.unwrap();
+    dispatcher
+        .join_group(deployer_addr, gas, JOIN_GROUP_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Init state
     let total_supply: u64 = 100;
@@ -393,14 +441,23 @@ async fn test_integration_eth_transfer() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
 
     println!("init state receipt: {:?}", receipt);
 
     // Get logs from contract and update state inside enclave.
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get state from enclave
     let req = json!({
@@ -448,13 +505,22 @@ async fn test_integration_eth_transfer() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr, gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
 
     // Update state inside enclave
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Check the updated states
     let req = json!({
@@ -544,10 +610,16 @@ async fn test_key_rotation() {
     println!("factory contract address: {}", factory_contract_addr);
     println!("anonify contract address: {}", anonify_contract_addr);
 
-    dispatcher.join_group(deployer_addr, gas).await.unwrap();
+    dispatcher
+        .join_group(deployer_addr, gas, JOIN_GROUP_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Send handshake
     let receipt = dispatcher
@@ -557,7 +629,10 @@ async fn test_key_rotation() {
     println!("handshake receipt: {:?}", receipt);
 
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // init state
     let total_supply: u64 = 100;
@@ -573,13 +648,22 @@ async fn test_key_rotation() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
     println!("init state receipt: {:?}", receipt);
 
     // Get logs from contract and update state inside enclave.
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get state from enclave
     let req = json!({
@@ -667,9 +751,15 @@ async fn test_integration_eth_approve() {
     println!("factory contract address: {}", factory_contract_addr);
     println!("anonify contract address: {}", anonify_contract_addr);
 
-    dispatcher.join_group(deployer_addr, gas).await.unwrap();
+    dispatcher
+        .join_group(deployer_addr, gas, JOIN_GROUP_TREEKEM_CMD)
+        .await
+        .unwrap();
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Init state
     let total_supply = 100;
@@ -685,14 +775,23 @@ async fn test_integration_eth_approve() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
 
     println!("init state receipt: {:?}", receipt);
 
     // Get logs from contract and update state inside enclave.
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     let spender = other_access_policy.into_account_id();
     // Get state from enclave
@@ -734,13 +833,22 @@ async fn test_integration_eth_approve() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr, gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
 
     // Update state inside enclave
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Check the updated states
     let req = json!({
@@ -824,10 +932,16 @@ async fn test_integration_eth_transfer_from() {
     println!("factory contract address: {}", factory_contract_addr);
     println!("anonify contract address: {}", anonify_contract_addr);
 
-    dispatcher.join_group(deployer_addr, gas).await.unwrap();
+    dispatcher
+        .join_group(deployer_addr, gas, JOIN_GROUP_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Init state
     let total_supply: u64 = 100;
@@ -843,14 +957,23 @@ async fn test_integration_eth_transfer_from() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
 
     println!("init state receipt: {:?}", receipt);
 
     // Get logs from contract and update state inside enclave.
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get initial state from enclave
     let req = json!({
@@ -934,13 +1057,22 @@ async fn test_integration_eth_transfer_from() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
 
     // Update state inside enclave
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Check the updated states
     let req = json!({
@@ -1027,13 +1159,22 @@ async fn test_integration_eth_transfer_from() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr, gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
 
     // Update state inside enclave
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Check the final states
     let req = json!({
@@ -1158,10 +1299,16 @@ async fn test_integration_eth_mint() {
     println!("factory contract address: {}", factory_contract_addr);
     println!("anonify contract address: {}", anonify_contract_addr);
 
-    dispatcher.join_group(deployer_addr, gas).await.unwrap();
+    dispatcher
+        .join_group(deployer_addr, gas, JOIN_GROUP_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Init state
     let total_supply = 100;
@@ -1177,14 +1324,23 @@ async fn test_integration_eth_mint() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
 
     println!("init state receipt: {:?}", receipt);
 
     // Get logs from contract and update state inside enclave.
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // transit state
     let amount = 50;
@@ -1201,14 +1357,23 @@ async fn test_integration_eth_mint() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr, gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
 
     println!("minted state receipt: {:?}", receipt);
 
     // Update state inside enclave
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     let req = json!({
         "access_policy": COMMON_ACCESS_POLICY.clone(),
@@ -1296,10 +1461,16 @@ async fn test_integration_eth_burn() {
     println!("factory contract address: {}", factory_contract_addr);
     println!("anonify contract address: {}", anonify_contract_addr);
 
-    dispatcher.join_group(deployer_addr, gas).await.unwrap();
+    dispatcher
+        .join_group(deployer_addr, gas, JOIN_GROUP_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Get handshake from contract
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Init state
     let total_supply = 100;
@@ -1315,14 +1486,23 @@ async fn test_integration_eth_burn() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
 
     println!("init state receipt: {:?}", receipt);
 
     // Get logs from contract and update state inside enclave.
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Send a transaction to contract
     let amount = 30;
@@ -1339,13 +1519,22 @@ async fn test_integration_eth_burn() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr.clone(), gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr.clone(),
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
 
     // Update state inside enclave
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     // Send a transaction to contract
     let amount = 20;
@@ -1360,13 +1549,22 @@ async fn test_integration_eth_burn() {
     let encrypted_command =
         SodiumCiphertext::encrypt(&mut csprng, &pubkey, serde_json::to_vec(&req).unwrap()).unwrap();
     let receipt = dispatcher
-        .send_command(encrypted_command, None, deployer_addr, gas)
+        .send_command(
+            encrypted_command,
+            None,
+            deployer_addr,
+            gas,
+            SEND_COMMAND_TREEKEM_CMD,
+        )
         .await
         .unwrap();
     println!("receipt: {:?}", receipt);
 
     // Update state inside enclave
-    dispatcher.fetch_events().await.unwrap();
+    dispatcher
+        .fetch_events(FETCH_CIPHERTEXT_TREEKEM_CMD, FETCH_HANDSHAKE_TREEKEM_CMD)
+        .await
+        .unwrap();
 
     let req = json!({
         "access_policy": COMMON_ACCESS_POLICY.clone(),


### PR DESCRIPTION
* dispatcherなどホストレイヤ共通化実装（enum使う）
* join_groupもenumで実装

TODO
* EnclaveKey用のコマンド追加（Enclave側）

文脈
* dispatcherレイヤは内部でenum使うなどで同じ型・同じmethodを利用
* 一番下層のconnectionレイヤでロジック分ける
* ハンドラは全てロジック実装しておいて、server mainレイヤで使うハンドラを分ける（treekemはhandshakeハンドラ使うけど、enclave keyでは使わない、など）