### PR TITLE
fix joinGroup and update CI

### DIFF
--- a/ethereum/contracts/AnonifyWithTreeKem.sol
+++ b/ethereum/contracts/AnonifyWithTreeKem.sol
@@ -51,9 +51,9 @@ contract AnonifyWithTreeKem is ReportHandle {
         handleReport(_report, _reportSig);
         // It is assumed that the nodes participate in the order of roster index,
         // and all the nodes finish participating before the state transition.
-        for (int i = 0; i < _rosterIdx; i++) {
-            uint32 _generation = _groupKeyCounter[uint32(i)].generation;
-            _groupKeyCounter[uint32(i)] = GroupKeyCounter(_generation, _rosterIdx + 1);
+        for (uint32 i = 0; i < _rosterIdx; i++) {
+            uint32 _generation = _groupKeyCounter[i].generation;
+            _groupKeyCounter[i] = GroupKeyCounter(_generation, _rosterIdx + 1);
         }
         _groupKeyCounter[_rosterIdx] = GroupKeyCounter(0, _rosterIdx + 1);
         storeTreeKemHandshake(_handshake);
@@ -164,8 +164,8 @@ contract AnonifyWithTreeKem is ReportHandle {
             "epoch must be bigger than the counter"
         );
 
-        for (int i = 0; i < _rosterIdx + 1; i++) {
-            _groupKeyCounter[uint32(i)] = GroupKeyCounter(_generation, _epoch);
+        for (uint32 i = 0; i < _rosterIdx + 1; i++) {
+            _groupKeyCounter[i] = GroupKeyCounter(_generation, _epoch);
         }
         storeTreeKemHandshake(_handshake);
     }

--- a/ethereum/contracts/AnonifyWithTreeKem.sol
+++ b/ethereum/contracts/AnonifyWithTreeKem.sol
@@ -51,7 +51,7 @@ contract AnonifyWithTreeKem is ReportHandle {
         handleReport(_report, _reportSig);
         // It is assumed that the nodes participate in the order of roster index,
         // and all the nodes finish participating before the state transition.
-        for (int i = 0; i < _rosterIdx; i++) {
+        for (int i = 0; i < _rosterIdx + 1; i++) {
             _groupKeyCounter[uint32(i)] = GroupKeyCounter(0, _rosterIdx + 1);
         }
         storeTreeKemHandshake(_handshake);

--- a/ethereum/contracts/AnonifyWithTreeKem.sol
+++ b/ethereum/contracts/AnonifyWithTreeKem.sol
@@ -51,9 +51,11 @@ contract AnonifyWithTreeKem is ReportHandle {
         handleReport(_report, _reportSig);
         // It is assumed that the nodes participate in the order of roster index,
         // and all the nodes finish participating before the state transition.
-        for (int i = 0; i < _rosterIdx + 1; i++) {
-            _groupKeyCounter[uint32(i)] = GroupKeyCounter(0, _rosterIdx + 1);
+        for (int i = 0; i < _rosterIdx; i++) {
+            uint32 _generation = _groupKeyCounter[uint32(i)].generation;
+            _groupKeyCounter[uint32(i)] = GroupKeyCounter(_generation, _rosterIdx + 1);
         }
+        _groupKeyCounter[_rosterIdx] = GroupKeyCounter(0, _rosterIdx + 1);
         storeTreeKemHandshake(_handshake);
     }
 
@@ -162,7 +164,9 @@ contract AnonifyWithTreeKem is ReportHandle {
             "epoch must be bigger than the counter"
         );
 
-        _groupKeyCounter[_rosterIdx] = GroupKeyCounter(_generation, _epoch);
+        for (int i = 0; i < _rosterIdx + 1; i++) {
+            _groupKeyCounter[uint32(i)] = GroupKeyCounter(_generation, _epoch);
+        }
         storeTreeKemHandshake(_handshake);
     }
 

--- a/ethereum/contracts/AnonifyWithTreeKem.sol
+++ b/ethereum/contracts/AnonifyWithTreeKem.sol
@@ -51,7 +51,9 @@ contract AnonifyWithTreeKem is ReportHandle {
         handleReport(_report, _reportSig);
         // It is assumed that the nodes participate in the order of roster index,
         // and all the nodes finish participating before the state transition.
-        _groupKeyCounter[_rosterIdx] = GroupKeyCounter(0, _rosterIdx + 1);
+        for (int i = 0; i < _rosterIdx; i++) {
+            _groupKeyCounter[uint32(i)] = GroupKeyCounter(0, _rosterIdx + 1);
+        }
         storeTreeKemHandshake(_handshake);
     }
 

--- a/example/erc20/enclave/src/state_transition.rs
+++ b/example/erc20/enclave/src/state_transition.rs
@@ -31,7 +31,7 @@ impl_runtime! {
         let sender_balance = self.get_map::<U64>(sender, "Balance")?;
         let recipient_balance = self.get_map::<U64>(recipient, "Balance")?;
 
-        ensure!(sender_balance > amount, "transfer amount ({:?}) exceeds balance ({:?}).", amount, sender_balance);
+        ensure!(sender_balance >= amount, "transfer amount ({:?}) exceeds balance ({:?}).", amount, sender_balance);
 
         let sender_update = update!(sender, "Balance", sender_balance - amount, U64);
         let recipient_update = update!(recipient, "Balance", recipient_balance + amount, U64);

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -156,7 +156,7 @@ impl Dispatcher {
     pub async fn fetch_events(
         &self,
         fetch_ciphertext_ecall_cmd: u32,
-        getch_handshake_ecall_cmd: u32,
+        fetch_handshake_ecall_cmd: u32,
     ) -> Result<Option<Vec<serde_json::Value>>> {
         let inner = self.inner.read();
         let eid = inner.enclave_id;
@@ -164,7 +164,7 @@ impl Dispatcher {
             .watcher
             .as_ref()
             .ok_or(HostError::EventWatcherNotSet)?
-            .fetch_events(eid, fetch_ciphertext_ecall_cmd, getch_handshake_ecall_cmd)
+            .fetch_events(eid, fetch_ciphertext_ecall_cmd, fetch_handshake_ecall_cmd)
             .await
     }
 

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -99,7 +99,12 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 0);
 
-    let init_100_req = init_100_req_fn(&mut csprng, &enc_key, 1, Some(valid_user_id()));
+    let init_100_req = init_100_req_fn(
+        &mut csprng,
+        &enc_key,
+        1,
+        Some(valid_user_id().into_account_id()),
+    );
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&init_100_req)
@@ -117,7 +122,12 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     assert_eq!(balance.state, 100);
 
     // Sending valid user_id, so this request should be successful
-    let transfer_10_req_json = transfer_10_req_fn(&mut csprng, &enc_key, 2, Some(valid_user_id()));
+    let transfer_10_req_json = transfer_10_req_fn(
+        &mut csprng,
+        &enc_key,
+        2,
+        Some(valid_user_id().into_account_id()),
+    );
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_10_req_json)
@@ -1008,7 +1018,7 @@ fn valid_other_user_id() -> Ed25519ChallengeResponse {
         196, 164, 228, 172, 9, 251, 94, 245, 43, 74, 182, 98, 47, 59, 145, 40, 28, 65, 122, 189,
         150, 211, 16, 29, 204, 200, 52, 116, 106, 234, 138, 139,
     ];
-    Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challeng)
+    Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge)
 }
 
 // to me

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -617,6 +617,7 @@ async fn test_join_group_then_handshake() {
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 0);
 
+    // Requests from party 2
     let init_100_req = init_100_req(&mut csprng, &enc_key, 1, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
@@ -666,6 +667,64 @@ async fn test_join_group_then_handshake() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 90);
+
+    // Request from other via state-runtime 1
+    let transfer_other_5_req = transfer_other_5_req(&mut csprng, &enc_key, 1, None);
+    let req = test::TestRequest::post()
+        .uri("/api/v1/state")
+        .set_json(&transfer_other_5_req)
+        .to_request();
+    let resp = test::call_service(&mut app1, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+
+    // check the result of state transition in state-runtime 1
+    let req = test::TestRequest::get()
+        .uri("/api/v1/state")
+        .set_json(&balance_of_other_req(&mut csprng, &enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app1, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 5);
+
+    // check the result of state transition in state-runtime 2
+    let req = test::TestRequest::get()
+        .uri("/api/v1/state")
+        .set_json(&balance_of_other_req(&mut csprng, &enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app2, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 5);
+
+    // Request from other via state-runtime 2
+    let transfer_other_5_req = transfer_other_5_req(&mut csprng, &enc_key, 2, None);
+    let req = test::TestRequest::post()
+        .uri("/api/v1/state")
+        .set_json(&transfer_other_5_req)
+        .to_request();
+    let resp = test::call_service(&mut app2, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+
+    // check the result of state transition in state-runtime 1
+    let req = test::TestRequest::get()
+        .uri("/api/v1/state")
+        .set_json(&balance_of_other_req(&mut csprng, &enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app1, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 0);
+
+    // check the result of state transition in state-runtime 2
+    let req = test::TestRequest::get()
+        .uri("/api/v1/state")
+        .set_json(&balance_of_other_req(&mut csprng, &enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app2, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 0);
 }
 
 #[actix_rt::test]
@@ -934,6 +993,24 @@ fn valid_user_id() -> AccountId {
     Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge).into_account_id()
 }
 
+fn valid_other_user_id() -> AccountId {
+    let sig = [
+        227, 214, 246, 7, 62, 33, 159, 246, 238, 120, 63, 85, 220, 132, 207, 133, 93, 74, 35, 180,
+        99, 85, 57, 254, 2, 205, 175, 221, 61, 86, 246, 86, 229, 86, 19, 47, 46, 46, 66, 4, 186,
+        245, 251, 191, 16, 3, 40, 107, 179, 53, 172, 131, 113, 117, 2, 65, 119, 174, 54, 248, 146,
+        13, 20, 13,
+    ];
+    let pubkey = [
+        123, 153, 87, 235, 253, 48, 23, 28, 250, 137, 255, 93, 230, 42, 139, 136, 203, 222, 179,
+        160, 141, 51, 10, 36, 197, 59, 62, 211, 95, 25, 255, 111,
+    ];
+    let challenge = [
+        196, 164, 228, 172, 9, 251, 94, 245, 43, 74, 182, 98, 47, 59, 145, 40, 28, 65, 122, 189,
+        150, 211, 16, 29, 204, 200, 52, 116, 106, 234, 138, 139,
+    ];
+    Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge).into_account_id()
+}
+
 // to me
 fn init_100_req<CR>(
     csprng: &mut CR,
@@ -944,24 +1021,8 @@ fn init_100_req<CR>(
 where
     CR: RngCore + CryptoRng,
 {
-    let sig = [
-        236, 103, 17, 252, 166, 199, 9, 46, 200, 107, 188, 0, 37, 111, 83, 105, 175, 81, 231, 14,
-        81, 100, 221, 89, 102, 172, 30, 96, 15, 128, 117, 146, 181, 221, 149, 206, 163, 208, 113,
-        198, 241, 16, 150, 248, 99, 170, 85, 122, 165, 197, 14, 120, 110, 37, 69, 32, 36, 218, 100,
-        64, 224, 226, 99, 2,
-    ];
-    let pubkey = [
-        164, 189, 195, 42, 48, 163, 27, 74, 84, 147, 25, 254, 16, 14, 206, 134, 153, 148, 33, 189,
-        55, 149, 7, 15, 11, 101, 106, 28, 48, 130, 133, 143,
-    ];
-    let challenge = [
-        244, 158, 183, 202, 237, 236, 27, 67, 39, 95, 178, 136, 235, 162, 188, 106, 52, 56, 6, 245,
-        3, 101, 33, 155, 58, 175, 168, 63, 73, 125, 205, 225,
-    ];
-    let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
-
     let req = json!({
-        "access_policy": access_policy,
+        "access_policy": valid_user_id(),
         "runtime_params": {
             "total_supply": 100,
         },
@@ -987,30 +1048,39 @@ fn transfer_10_req<CR>(
 where
     CR: RngCore + CryptoRng,
 {
-    let sig = [
-        227, 77, 52, 167, 149, 64, 24, 23, 103, 227, 13, 120, 90, 186, 1, 62, 110, 60, 186, 247,
-        143, 247, 19, 71, 85, 191, 224, 5, 38, 219, 96, 44, 196, 154, 181, 50, 99, 58, 20, 125,
-        244, 172, 212, 166, 234, 203, 208, 77, 9, 232, 77, 248, 152, 81, 106, 49, 120, 34, 212, 89,
-        92, 100, 221, 14,
-    ];
-    let pubkey = [
-        164, 189, 195, 42, 48, 163, 27, 74, 84, 147, 25, 254, 16, 14, 206, 134, 153, 148, 33, 189,
-        55, 149, 7, 15, 11, 101, 106, 28, 48, 130, 133, 143,
-    ];
-    let challenge = [
-        157, 61, 16, 189, 40, 124, 88, 101, 19, 36, 155, 229, 245, 123, 189, 124, 222, 114, 215,
-        186, 25, 30, 135, 114, 237, 169, 138, 122, 81, 61, 43, 183,
-    ];
-    let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
-
     let req = json!({
-        "access_policy": access_policy,
+        "access_policy": valid_user_id(),
         "runtime_params": {
             "amount": 10,
-            "recipient": AccountId([
-                236, 126, 92, 200, 50, 125, 9, 112, 74, 58, 35, 60, 181, 105, 198, 107, 62, 111, 168,
-                118,
-            ])
+            "recipient": valid_other_user_id(),
+        },
+        "cmd_name": "transfer",
+        "counter": counter,
+    });
+    let ciphertext =
+        SodiumCiphertext::encrypt(csprng, &enc_key, &serde_json::to_vec(&req).unwrap()).unwrap();
+
+    state_runtime_node_api::state::post::Request {
+        ciphertext,
+        user_id,
+    }
+}
+
+// from other to me
+fn transfer_other_5_req<CR>(
+    csprng: &mut CR,
+    enc_key: &SodiumPubKey,
+    counter: u32,
+    user_id: Option<AccountId>,
+) -> state_runtime_node_api::state::post::Request
+where
+    CR: RngCore + CryptoRng,
+{
+    let req = json!({
+        "access_policy": valid_other_user_id(),
+        "runtime_params": {
+            "amount": 5,
+            "recipient": valid_user_id(),
         },
         "cmd_name": "transfer",
         "counter": counter,
@@ -1034,30 +1104,11 @@ fn transfer_110_req<CR>(
 where
     CR: RngCore + CryptoRng,
 {
-    let sig = [
-        227, 77, 52, 167, 149, 64, 24, 23, 103, 227, 13, 120, 90, 186, 1, 62, 110, 60, 186, 247,
-        143, 247, 19, 71, 85, 191, 224, 5, 38, 219, 96, 44, 196, 154, 181, 50, 99, 58, 20, 125,
-        244, 172, 212, 166, 234, 203, 208, 77, 9, 232, 77, 248, 152, 81, 106, 49, 120, 34, 212, 89,
-        92, 100, 221, 14,
-    ];
-    let pubkey = [
-        164, 189, 195, 42, 48, 163, 27, 74, 84, 147, 25, 254, 16, 14, 206, 134, 153, 148, 33, 189,
-        55, 149, 7, 15, 11, 101, 106, 28, 48, 130, 133, 143,
-    ];
-    let challenge = [
-        157, 61, 16, 189, 40, 124, 88, 101, 19, 36, 155, 229, 245, 123, 189, 124, 222, 114, 215,
-        186, 25, 30, 135, 114, 237, 169, 138, 122, 81, 61, 43, 183,
-    ];
-    let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
-
     let req = json!({
-        "access_policy": access_policy,
+        "access_policy": valid_user_id(),
         "runtime_params": {
             "amount": 110,
-            "recipient": AccountId([
-                236, 126, 92, 200, 50, 125, 9, 112, 74, 58, 35, 60, 181, 105, 198, 107, 62, 111, 168,
-                118,
-            ])
+            "recipient": valid_other_user_id(),
         },
         "cmd_name": "transfer",
         "counter": counter,
@@ -1078,23 +1129,26 @@ fn balance_of_req<CR>(
 where
     CR: RngCore + CryptoRng,
 {
-    let sig = [
-        21, 54, 136, 84, 150, 59, 196, 71, 164, 136, 222, 128, 100, 84, 208, 219, 84, 7, 61, 11,
-        230, 220, 25, 138, 67, 247, 95, 97, 30, 76, 120, 160, 73, 48, 110, 43, 94, 79, 192, 195,
-        82, 199, 73, 80, 48, 148, 233, 143, 87, 237, 159, 97, 252, 226, 68, 160, 137, 127, 195,
-        116, 128, 181, 47, 2,
-    ];
-    let pubkey = [
-        164, 189, 195, 42, 48, 163, 27, 74, 84, 147, 25, 254, 16, 14, 206, 134, 153, 148, 33, 189,
-        55, 149, 7, 15, 11, 101, 106, 28, 48, 130, 133, 143,
-    ];
-    let challenge = [
-        119, 177, 182, 220, 100, 44, 96, 179, 173, 47, 220, 49, 105, 204, 132, 230, 211, 24, 166,
-        219, 82, 76, 27, 205, 211, 232, 142, 98, 66, 130, 150, 202,
-    ];
-    let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
     let req = json!({
-        "access_policy": access_policy,
+        "access_policy": valid_user_id(),
+        "runtime_params": {},
+        "state_name": "balance_of",
+    });
+    let ciphertext =
+        SodiumCiphertext::encrypt(csprng, &enc_key, &serde_json::to_vec(&req).unwrap()).unwrap();
+
+    state_runtime_node_api::state::get::Request { ciphertext }
+}
+
+fn balance_of_other_req<CR>(
+    csprng: &mut CR,
+    enc_key: &SodiumPubKey,
+) -> state_runtime_node_api::state::get::Request
+where
+    CR: RngCore + CryptoRng,
+{
+    let req = json!({
+        "access_policy": valid_other_user_id(),
         "runtime_params": {},
         "state_name": "balance_of",
     });
@@ -1111,23 +1165,8 @@ fn user_counter_req<CR>(
 where
     CR: RngCore + CryptoRng,
 {
-    let sig = [
-        21, 54, 136, 84, 150, 59, 196, 71, 164, 136, 222, 128, 100, 84, 208, 219, 84, 7, 61, 11,
-        230, 220, 25, 138, 67, 247, 95, 97, 30, 76, 120, 160, 73, 48, 110, 43, 94, 79, 192, 195,
-        82, 199, 73, 80, 48, 148, 233, 143, 87, 237, 159, 97, 252, 226, 68, 160, 137, 127, 195,
-        116, 128, 181, 47, 2,
-    ];
-    let pubkey = [
-        164, 189, 195, 42, 48, 163, 27, 74, 84, 147, 25, 254, 16, 14, 206, 134, 153, 148, 33, 189,
-        55, 149, 7, 15, 11, 101, 106, 28, 48, 130, 133, 143,
-    ];
-    let challenge = [
-        119, 177, 182, 220, 100, 44, 96, 179, 173, 47, 220, 49, 105, 204, 132, 230, 211, 24, 166,
-        219, 82, 76, 27, 205, 211, 232, 142, 98, 66, 130, 150, 202,
-    ];
-    let access_policy = Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge);
     let req = json!({
-        "access_policy": access_policy,
+        "access_policy": valid_user_id(),
     });
     let ciphertext =
         SodiumCiphertext::encrypt(csprng, &enc_key, &serde_json::to_vec(&req).unwrap()).unwrap();

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -975,7 +975,7 @@ const INVALID_USER_ID: AccountId = AccountId([
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 ]);
 
-fn valid_user_id() -> AccountId {
+fn valid_user_id() -> Ed25519ChallengeResponse {
     let sig = [
         236, 103, 17, 252, 166, 199, 9, 46, 200, 107, 188, 0, 37, 111, 83, 105, 175, 81, 231, 14,
         81, 100, 221, 89, 102, 172, 30, 96, 15, 128, 117, 146, 181, 221, 149, 206, 163, 208, 113,
@@ -990,10 +990,10 @@ fn valid_user_id() -> AccountId {
         244, 158, 183, 202, 237, 236, 27, 67, 39, 95, 178, 136, 235, 162, 188, 106, 52, 56, 6, 245,
         3, 101, 33, 155, 58, 175, 168, 63, 73, 125, 205, 225,
     ];
-    Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge).into_account_id()
+    Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge)
 }
 
-fn valid_other_user_id() -> AccountId {
+fn valid_other_user_id() -> Ed25519ChallengeResponse {
     let sig = [
         227, 214, 246, 7, 62, 33, 159, 246, 238, 120, 63, 85, 220, 132, 207, 133, 93, 74, 35, 180,
         99, 85, 57, 254, 2, 205, 175, 221, 61, 86, 246, 86, 229, 86, 19, 47, 46, 46, 66, 4, 186,
@@ -1008,7 +1008,7 @@ fn valid_other_user_id() -> AccountId {
         196, 164, 228, 172, 9, 251, 94, 245, 43, 74, 182, 98, 47, 59, 145, 40, 28, 65, 122, 189,
         150, 211, 16, 29, 204, 200, 52, 116, 106, 234, 138, 139,
     ];
-    Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challenge).into_account_id()
+    Ed25519ChallengeResponse::new_from_bytes(sig, pubkey, challeng)
 }
 
 // to me
@@ -1052,7 +1052,7 @@ where
         "access_policy": valid_user_id(),
         "runtime_params": {
             "amount": 10,
-            "recipient": valid_other_user_id(),
+            "recipient": valid_other_user_id().into_account_id(),
         },
         "cmd_name": "transfer",
         "counter": counter,
@@ -1080,7 +1080,7 @@ where
         "access_policy": valid_other_user_id(),
         "runtime_params": {
             "amount": 5,
-            "recipient": valid_user_id(),
+            "recipient": valid_user_id().into_account_id(),
         },
         "cmd_name": "transfer",
         "counter": counter,
@@ -1108,7 +1108,7 @@ where
         "access_policy": valid_user_id(),
         "runtime_params": {
             "amount": 110,
-            "recipient": valid_other_user_id(),
+            "recipient": valid_other_user_id().into_account_id(),
         },
         "cmd_name": "transfer",
         "counter": counter,

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -535,6 +535,7 @@ async fn test_join_group_then_handshake() {
     let mut app1 = test::init_service(
         App::new()
             .data(server1.clone())
+            .route("/api/v1/state", web::post().to(handle_send_command))
             .route("/api/v1/state", web::get().to(handle_get_state))
             .route(
                 "/api/v1/enclave_encryption_key",

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -679,6 +679,16 @@ async fn test_join_group_then_handshake() {
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 90);
 
+    env::set_var("ACCOUNT_INDEX", "0");
+    let req = test::TestRequest::get()
+        .uri("/api/v1/state")
+        .set_json(&balance_of_other_req_fn(&mut csprng, &enc_key))
+        .to_request();
+    let resp = test::call_service(&mut app1, req).await;
+    assert!(resp.status().is_success(), "response: {:?}", resp);
+    let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
+    assert_eq!(balance.state, 10);
+
     // Request from other via state-runtime 1
     let transfer_other_5_req = transfer_other_5_req_fn(&mut csprng, &enc_key, 1, None);
     let req = test::TestRequest::post()
@@ -699,6 +709,7 @@ async fn test_join_group_then_handshake() {
     assert_eq!(balance.state, 5);
 
     // check the result of state transition in state-runtime 2
+    env::set_var("ACCOUNT_INDEX", "1");
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
         .set_json(&balance_of_other_req_fn(&mut csprng, &enc_key))
@@ -718,6 +729,7 @@ async fn test_join_group_then_handshake() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
 
     // check the result of state transition in state-runtime 1
+    env::set_var("ACCOUNT_INDEX", "0");
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
         .set_json(&balance_of_other_req_fn(&mut csprng, &enc_key))
@@ -728,6 +740,7 @@ async fn test_join_group_then_handshake() {
     assert_eq!(balance.state, 0);
 
     // check the result of state transition in state-runtime 2
+    env::set_var("ACCOUNT_INDEX", "1");
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
         .set_json(&balance_of_other_req_fn(&mut csprng, &enc_key))

--- a/nodes/state-runtime/server/src/tests.rs
+++ b/nodes/state-runtime/server/src/tests.rs
@@ -92,14 +92,14 @@ async fn test_evaluate_access_policy_by_user_id_field() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 0);
 
-    let init_100_req = init_100_req(&mut csprng, &enc_key, 1, Some(valid_user_id()));
+    let init_100_req = init_100_req_fn(&mut csprng, &enc_key, 1, Some(valid_user_id()));
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&init_100_req)
@@ -109,7 +109,7 @@ async fn test_evaluate_access_policy_by_user_id_field() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -117,7 +117,7 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     assert_eq!(balance.state, 100);
 
     // Sending valid user_id, so this request should be successful
-    let transfer_10_req_json = transfer_10_req(&mut csprng, &enc_key, 2, Some(valid_user_id()));
+    let transfer_10_req_json = transfer_10_req_fn(&mut csprng, &enc_key, 2, Some(valid_user_id()));
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_10_req_json)
@@ -127,7 +127,7 @@ async fn test_evaluate_access_policy_by_user_id_field() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -135,7 +135,7 @@ async fn test_evaluate_access_policy_by_user_id_field() {
     assert_eq!(balance.state, 90);
 
     // Sending invalid user_id, so this request should be failed
-    let transfer_10_req_json = transfer_10_req(&mut csprng, &enc_key, 3, Some(INVALID_USER_ID));
+    let transfer_10_req_json = transfer_10_req_fn(&mut csprng, &enc_key, 3, Some(INVALID_USER_ID));
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_10_req_json)
@@ -145,7 +145,7 @@ async fn test_evaluate_access_policy_by_user_id_field() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -196,14 +196,14 @@ async fn test_multiple_messages() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 0);
 
-    let init_100_req = init_100_req(&mut csprng, &enc_key, 1, None);
+    let init_100_req = init_100_req_fn(&mut csprng, &enc_key, 1, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&init_100_req)
@@ -213,7 +213,7 @@ async fn test_multiple_messages() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -222,7 +222,7 @@ async fn test_multiple_messages() {
 
     // Sending five messages before receiving any messages
     for i in 0..5 {
-        let transfer_10_req = transfer_10_req(&mut csprng, &enc_key, 2 + i, None);
+        let transfer_10_req = transfer_10_req_fn(&mut csprng, &enc_key, 2 + i, None);
         let req = test::TestRequest::post()
             .uri("/api/v1/state")
             .set_json(&transfer_10_req)
@@ -233,7 +233,7 @@ async fn test_multiple_messages() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -285,14 +285,14 @@ async fn test_skip_invalid_event() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 0);
 
-    let init_100_req = init_100_req(&mut csprng, &enc_key, 1, None);
+    let init_100_req = init_100_req_fn(&mut csprng, &enc_key, 1, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&init_100_req)
@@ -302,7 +302,7 @@ async fn test_skip_invalid_event() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -310,7 +310,7 @@ async fn test_skip_invalid_event() {
     assert_eq!(balance.state, 100);
 
     // state transition should not be occured by this transaction.
-    let transfer_110_req = transfer_110_req(&mut csprng, &enc_key, 2, None);
+    let transfer_110_req = transfer_110_req_fn(&mut csprng, &enc_key, 2, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_110_req)
@@ -320,14 +320,14 @@ async fn test_skip_invalid_event() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 100);
 
-    let transfer_10_req = transfer_10_req(&mut csprng, &enc_key, 3, None);
+    let transfer_10_req = transfer_10_req_fn(&mut csprng, &enc_key, 3, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_10_req)
@@ -337,7 +337,7 @@ async fn test_skip_invalid_event() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -413,14 +413,14 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 0);
 
-    let init_100_req = init_100_req(&mut csprng, &enc_key, 1, None);
+    let init_100_req = init_100_req_fn(&mut csprng, &enc_key, 1, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&init_100_req)
@@ -430,14 +430,14 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 100);
 
-    let transfer_10_req_ = transfer_10_req(&mut csprng, &enc_key, 2, None);
+    let transfer_10_req_ = transfer_10_req_fn(&mut csprng, &enc_key, 2, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_10_req_)
@@ -447,7 +447,7 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -481,14 +481,14 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 90);
 
-    let transfer_10_req = transfer_10_req(&mut csprng, &enc_key, 3, None);
+    let transfer_10_req = transfer_10_req_fn(&mut csprng, &enc_key, 3, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_10_req)
@@ -498,7 +498,7 @@ async fn test_node_recovery() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -572,7 +572,7 @@ async fn test_join_group_then_handshake() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key1))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key1))
         .to_request();
     let resp = test::call_service(&mut app1, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -587,7 +587,7 @@ async fn test_join_group_then_handshake() {
     // so using app1's key
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key1))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key1))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp); // return 200 OK: becuse allowed same enclave encryption key
@@ -610,7 +610,7 @@ async fn test_join_group_then_handshake() {
     actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME)).await;
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -618,7 +618,7 @@ async fn test_join_group_then_handshake() {
     assert_eq!(balance.state, 0);
 
     // Requests from party 2
-    let init_100_req = init_100_req(&mut csprng, &enc_key, 1, None);
+    let init_100_req = init_100_req_fn(&mut csprng, &enc_key, 1, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&init_100_req)
@@ -628,7 +628,7 @@ async fn test_join_group_then_handshake() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -644,14 +644,14 @@ async fn test_join_group_then_handshake() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 100);
 
-    let transfer_10_req = transfer_10_req(&mut csprng, &enc_key, 2, None);
+    let transfer_10_req = transfer_10_req_fn(&mut csprng, &enc_key, 2, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_10_req)
@@ -661,7 +661,7 @@ async fn test_join_group_then_handshake() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -669,7 +669,7 @@ async fn test_join_group_then_handshake() {
     assert_eq!(balance.state, 90);
 
     // Request from other via state-runtime 1
-    let transfer_other_5_req = transfer_other_5_req(&mut csprng, &enc_key, 1, None);
+    let transfer_other_5_req = transfer_other_5_req_fn(&mut csprng, &enc_key, 1, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_other_5_req)
@@ -680,7 +680,7 @@ async fn test_join_group_then_handshake() {
     // check the result of state transition in state-runtime 1
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_other_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_other_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app1, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -690,7 +690,7 @@ async fn test_join_group_then_handshake() {
     // check the result of state transition in state-runtime 2
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_other_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_other_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -698,7 +698,7 @@ async fn test_join_group_then_handshake() {
     assert_eq!(balance.state, 5);
 
     // Request from other via state-runtime 2
-    let transfer_other_5_req = transfer_other_5_req(&mut csprng, &enc_key, 2, None);
+    let transfer_other_5_req = transfer_other_5_req_fn(&mut csprng, &enc_key, 2, None);
     let req = test::TestRequest::post()
         .uri("/api/v1/state")
         .set_json(&transfer_other_5_req)
@@ -709,7 +709,7 @@ async fn test_join_group_then_handshake() {
     // check the result of state transition in state-runtime 1
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_other_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_other_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app1, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -719,7 +719,7 @@ async fn test_join_group_then_handshake() {
     // check the result of state transition in state-runtime 2
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_other_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_other_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -775,7 +775,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/user_counter")
-        .set_json(&user_counter_req(&mut csprng, &enc_key))
+        .set_json(&user_counter_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -783,7 +783,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
         test::read_body_json(resp).await;
     assert_eq!(user_counter.user_counter, 0);
 
-    let init_100_req = init_100_req(
+    let init_100_req = init_100_req_fn(
         &mut csprng,
         &enc_key,
         user_counter.user_counter.as_u64().unwrap() as u32 + 1,
@@ -798,7 +798,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -807,7 +807,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/user_counter")
-        .set_json(&user_counter_req(&mut csprng, &enc_key))
+        .set_json(&user_counter_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -816,7 +816,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
     assert_eq!(user_counter.user_counter, 1);
 
     // first request
-    let transfer_10 = transfer_10_req(
+    let transfer_10 = transfer_10_req_fn(
         &mut csprng,
         &enc_key,
         user_counter.user_counter.as_u64().unwrap() as u32 + 1,
@@ -831,7 +831,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -840,7 +840,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/user_counter")
-        .set_json(&user_counter_req(&mut csprng, &enc_key))
+        .set_json(&user_counter_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -849,7 +849,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
     assert_eq!(user_counter.user_counter, 2);
 
     // try second duplicated request
-    let transfer_10 = transfer_10_req(
+    let transfer_10 = transfer_10_req_fn(
         &mut csprng,
         &enc_key,
         user_counter.user_counter.as_u64().unwrap() as u32,
@@ -864,7 +864,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -872,7 +872,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
     assert_eq!(balance.state, 90); // failed
 
     // send out of order request
-    let transfer_10 = transfer_10_req(
+    let transfer_10 = transfer_10_req_fn(
         &mut csprng,
         &enc_key,
         user_counter.user_counter.as_u64().unwrap() as u32 + 2, // should be 3
@@ -887,7 +887,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -895,7 +895,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
     assert_eq!(balance.state, 90); // failed
 
     // then, send correct request
-    let transfer_10 = transfer_10_req(
+    let transfer_10 = transfer_10_req_fn(
         &mut csprng,
         &enc_key,
         user_counter.user_counter.as_u64().unwrap() as u32 + 1,
@@ -910,7 +910,7 @@ async fn test_duplicated_out_of_order_request_from_same_user() {
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
-        .set_json(&balance_of_req(&mut csprng, &enc_key))
+        .set_json(&balance_of_req_fn(&mut csprng, &enc_key))
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
@@ -1012,7 +1012,7 @@ fn valid_other_user_id() -> AccountId {
 }
 
 // to me
-fn init_100_req<CR>(
+fn init_100_req_fn<CR>(
     csprng: &mut CR,
     enc_key: &SodiumPubKey,
     counter: u32,
@@ -1039,7 +1039,7 @@ where
 }
 
 // from me to other
-fn transfer_10_req<CR>(
+fn transfer_10_req_fn<CR>(
     csprng: &mut CR,
     enc_key: &SodiumPubKey,
     counter: u32,
@@ -1067,7 +1067,7 @@ where
 }
 
 // from other to me
-fn transfer_other_5_req<CR>(
+fn transfer_other_5_req_fn<CR>(
     csprng: &mut CR,
     enc_key: &SodiumPubKey,
     counter: u32,
@@ -1095,7 +1095,7 @@ where
 }
 
 // from me to other
-fn transfer_110_req<CR>(
+fn transfer_110_req_fn<CR>(
     csprng: &mut CR,
     enc_key: &SodiumPubKey,
     counter: u32,
@@ -1122,7 +1122,7 @@ where
     }
 }
 
-fn balance_of_req<CR>(
+fn balance_of_req_fn<CR>(
     csprng: &mut CR,
     enc_key: &SodiumPubKey,
 ) -> state_runtime_node_api::state::get::Request
@@ -1140,7 +1140,7 @@ where
     state_runtime_node_api::state::get::Request { ciphertext }
 }
 
-fn balance_of_other_req<CR>(
+fn balance_of_other_req_fn<CR>(
     csprng: &mut CR,
     enc_key: &SodiumPubKey,
 ) -> state_runtime_node_api::state::get::Request
@@ -1158,7 +1158,7 @@ where
     state_runtime_node_api::state::get::Request { ciphertext }
 }
 
-fn user_counter_req<CR>(
+fn user_counter_req_fn<CR>(
     csprng: &mut CR,
     enc_key: &SodiumPubKey,
 ) -> state_runtime_node_api::user_counter::get::Request


### PR DESCRIPTION
- joinGroup、handshake時に全state-runtimeの`_groupKeyCounter`を更新するよう修正
- state-runtime1/2両方からの更新/状態取得のテストをCIに追加