### PR TITLE
エラーログをCIでチェック

### DIFF
--- a/frame/treekem/src/application.rs
+++ b/frame/treekem/src/application.rs
@@ -43,7 +43,7 @@ impl AppKeyChain {
         ))
     }
 
-    /// Decrypt messag with current member's application secret.
+    /// Decrypt message with current member's application secret.
     pub fn decrypt_msg(
         &self,
         app_msg: &TreeKemCiphertext,
@@ -58,7 +58,7 @@ impl AppKeyChain {
             _ => {
                 ensure!(
                     app_msg.epoch() == self.epoch,
-                    "The received messages's epoch ({:?}) differs from the current key_chain's ({:?})",
+                    "The received message's epoch ({:?}) differs from the current key_chain's ({:?})",
                     app_msg.epoch(),
                     self.epoch
                 );
@@ -67,7 +67,7 @@ impl AppKeyChain {
                     self.key_nonce_gen(app_msg.roster_idx() as usize)?;
                 ensure!(
                     app_msg.generation() == generation,
-                    "The received messages's generation ({:?}) differs from the current AppMemberSecret's ({:?})", app_msg.generation(), generation
+                    "The received message's generation ({:?}) differs from the current AppMemberSecret's ({:?})", app_msg.generation(), generation
                 );
 
                 let mut ciphertext = app_msg.encrypted_state_ref().to_vec();

--- a/modules/anonify-eth-driver/src/dispatcher.rs
+++ b/modules/anonify-eth-driver/src/dispatcher.rs
@@ -133,7 +133,7 @@ impl Dispatcher {
                         Ok(updated_states) => debug!("State updated: {:?}", updated_states),
                         Err(err) => error!("event fetched error: {:?}", err),
                     };
-                    actix_rt::time::delay_for(time::Duration::from_millis(2 * sync_time)).await;
+                    actix_rt::time::delay_for(time::Duration::from_millis(sync_time)).await;
                 }
             });
         });

--- a/nodes/key-vault/src/test/enclave_key.rs
+++ b/nodes/key-vault/src/test/enclave_key.rs
@@ -4,6 +4,8 @@ use frame_config::{ANONIFY_ABI_PATH, ANONIFY_PARAMS_DIR, FACTORY_ABI_PATH};
 use frame_host::EnclaveDir;
 use state_runtime_node_server::{handlers::*, Server as ERC20Server};
 use std::{env, sync::Arc};
+#[cfg(test)]
+use test_utils::tracing::logs_contain;
 
 use super::*;
 
@@ -63,4 +65,5 @@ async fn test_enclave_key_backup() {
         .to_path_buf()
         .join(KV_DEC_KEY_FILE_NAME)
         .exists());
+    assert!(!logs_contain("ERROR"));
 }

--- a/nodes/key-vault/src/test/mod.rs
+++ b/nodes/key-vault/src/test/mod.rs
@@ -18,6 +18,9 @@ use web3::{contract::Options, types::Address};
 mod enclave_key;
 mod treekem;
 
+#[cfg(test)]
+const SYNC_TIME: u64 = 1500;
+
 const SR_DEC_KEY_FILE_NAME: &'static str = "sr_enclave_decryption_key";
 const KV_DEC_KEY_FILE_NAME: &'static str = "kv_enclave_decryption_key";
 

--- a/nodes/key-vault/src/test/mod.rs
+++ b/nodes/key-vault/src/test/mod.rs
@@ -11,6 +11,8 @@ use serde_json::json;
 #[cfg(test)]
 use std::str::FromStr;
 use std::{env, fs, path::Path, sync::Arc};
+#[cfg(test)]
+use test_utils::tracing::logs_contain;
 use web3::{contract::Options, types::Address};
 
 mod enclave_key;
@@ -51,12 +53,13 @@ async fn test_health_check() {
     let req = test::TestRequest::get().uri("/api/v1/health").to_request();
     let resp = test::call_service(&mut healthy_app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
+    assert!(!logs_contain("ERROR"));
 }
 
 pub static SUBSCRIBER_INIT: Lazy<()> = Lazy::new(|| {
-    use test_utils::tracing::{GLOBAL_TRACING_BUF, TracingWriter};
-    use tracing_subscriber::util::SubscriberInitExt;
+    use test_utils::tracing::{TracingWriter, GLOBAL_TRACING_BUF};
     use tracing_core::Dispatch;
+    use tracing_subscriber::util::SubscriberInitExt;
 
     let mock_writer = TracingWriter::new(&*GLOBAL_TRACING_BUF);
 

--- a/nodes/key-vault/src/test/treekem.rs
+++ b/nodes/key-vault/src/test/treekem.rs
@@ -2,7 +2,7 @@ use crate::Server as KeyVaultServer;
 use actix_web::{test, web, App};
 use frame_config::{ANONIFY_ABI_PATH, CMD_DEC_SECRET_DIR, FACTORY_ABI_PATH};
 use frame_host::EnclaveDir;
-use state_runtime_node_server::{handlers::*, Server as ERC20Server, SYNC_TIME};
+use state_runtime_node_server::{handlers::*, Server as ERC20Server};
 use std::{env, path::PathBuf, str::FromStr, sync::Arc, time};
 #[cfg(test)]
 use test_utils::tracing::logs_contain;

--- a/nodes/key-vault/src/test/treekem.rs
+++ b/nodes/key-vault/src/test/treekem.rs
@@ -28,7 +28,7 @@ async fn test_treekem_backup_path_secret() {
     let key_vault_server_eid = key_vault_server_enclave.geteid();
     let key_vault_server = Arc::new(KeyVaultServer::new(key_vault_server_eid).run().await);
     let _key_vault_app = test::init_service(App::new().data(key_vault_server.clone())).await;
-    std::thread::sleep(std::time::Duration::from_secs(1));
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // Setup ERC20 application
     env::set_var("ENCLAVE_PKG_NAME", "erc20");
@@ -53,6 +53,7 @@ async fn test_treekem_backup_path_secret() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -154,7 +155,7 @@ async fn test_treekem_recover_without_key_vault() {
     let key_vault_server_eid = key_vault_server_enclave.geteid();
     let key_vault_server = Arc::new(KeyVaultServer::new(key_vault_server_eid).run().await);
     let _key_vault_app = test::init_service(App::new().data(key_vault_server.clone())).await;
-    std::thread::sleep(std::time::Duration::from_secs(1));
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // Setup ERC20 application
     env::set_var("ENCLAVE_PKG_NAME", "erc20");
@@ -179,6 +180,7 @@ async fn test_treekem_recover_without_key_vault() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -271,7 +273,7 @@ async fn test_treekem_manually_backup_all() {
     let key_vault_server_eid = key_vault_server_enclave.geteid();
     let key_vault_server = Arc::new(KeyVaultServer::new(key_vault_server_eid).run().await);
     let _key_vault_app = test::init_service(App::new().data(key_vault_server.clone())).await;
-    std::thread::sleep(std::time::Duration::from_secs(1));
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // Setup ERC20 application
     env::set_var("ENCLAVE_PKG_NAME", "erc20");
@@ -300,6 +302,7 @@ async fn test_treekem_manually_backup_all() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -406,7 +409,7 @@ async fn test_treekem_manually_recover_all() {
     let key_vault_server_eid = key_vault_server_enclave.geteid();
     let key_vault_server = Arc::new(KeyVaultServer::new(key_vault_server_eid).run().await);
     let _key_vault_app = test::init_service(App::new().data(key_vault_server.clone())).await;
-    std::thread::sleep(std::time::Duration::from_secs(1));
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // Setup ERC20 application
     env::set_var("ENCLAVE_PKG_NAME", "erc20");
@@ -435,6 +438,7 @@ async fn test_treekem_manually_recover_all() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")

--- a/nodes/key-vault/src/test/treekem.rs
+++ b/nodes/key-vault/src/test/treekem.rs
@@ -2,8 +2,8 @@ use crate::Server as KeyVaultServer;
 use actix_web::{test, web, App};
 use frame_config::{ANONIFY_ABI_PATH, CMD_DEC_SECRET_DIR, FACTORY_ABI_PATH};
 use frame_host::EnclaveDir;
-use state_runtime_node_server::{handlers::*, Server as ERC20Server};
-use std::{env, path::PathBuf, str::FromStr, sync::Arc};
+use state_runtime_node_server::{handlers::*, Server as ERC20Server, SYNC_TIME};
+use std::{env, path::PathBuf, str::FromStr, sync::Arc, time};
 #[cfg(test)]
 use test_utils::tracing::logs_contain;
 
@@ -97,6 +97,7 @@ async fn test_treekem_backup_path_secret() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -112,6 +113,7 @@ async fn test_treekem_backup_path_secret() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     clear_local_path_secrets();
     // local
@@ -221,6 +223,7 @@ async fn test_treekem_recover_without_key_vault() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -236,6 +239,7 @@ async fn test_treekem_recover_without_key_vault() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // stop key-vault server
     sgx_urts::rsgx_destroy_enclave(key_vault_server_eid).unwrap();
@@ -330,6 +334,7 @@ async fn test_treekem_manually_backup_all() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -345,6 +350,7 @@ async fn test_treekem_manually_backup_all() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -376,6 +382,7 @@ async fn test_treekem_manually_backup_all() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // check recovering remote path_secrets
     let recovered_remote_ids = get_remote_ids(env::var("MY_ROSTER_IDX").unwrap().to_string());
@@ -462,6 +469,7 @@ async fn test_treekem_manually_recover_all() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -477,6 +485,7 @@ async fn test_treekem_manually_recover_all() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -505,6 +514,7 @@ async fn test_treekem_manually_recover_all() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // check recovering local path_secrets
     let recovered_local_ids = get_local_ids();

--- a/nodes/key-vault/src/test/treekem.rs
+++ b/nodes/key-vault/src/test/treekem.rs
@@ -4,6 +4,8 @@ use frame_config::{ANONIFY_ABI_PATH, CMD_DEC_SECRET_DIR, FACTORY_ABI_PATH};
 use frame_host::EnclaveDir;
 use state_runtime_node_server::{handlers::*, Server as ERC20Server};
 use std::{env, path::PathBuf, str::FromStr, sync::Arc};
+#[cfg(test)]
+use test_utils::tracing::logs_contain;
 
 use super::*;
 
@@ -128,6 +130,7 @@ async fn test_treekem_backup_path_secret() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 100);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -245,6 +248,7 @@ async fn test_treekem_recover_without_key_vault() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 100);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -376,6 +380,7 @@ async fn test_treekem_manually_backup_all() {
     // check recovering remote path_secrets
     let recovered_remote_ids = get_remote_ids(env::var("MY_ROSTER_IDX").unwrap().to_string());
     assert_eq!(recovered_remote_ids, remote_ids);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -504,4 +509,5 @@ async fn test_treekem_manually_recover_all() {
     // check recovering local path_secrets
     let recovered_local_ids = get_local_ids();
     assert_eq!(recovered_local_ids, local_ids);
+    assert!(!logs_contain("ERROR"));
 }

--- a/nodes/state-runtime/server/src/handlers.rs
+++ b/nodes/state-runtime/server/src/handlers.rs
@@ -52,14 +52,6 @@ pub async fn handle_get_state(
     server: web::Data<Arc<Server>>,
     req: web::Json<state_runtime_node_api::state::get::Request>,
 ) -> Result<HttpResponse> {
-    let (fetch_ciphertext_ecall_cmd, fetch_handshake_ecall_cmd) = match server.cmd_encryption_algo {
-        CmdEncryptionAlgo::EnclaveKey => (FETCH_CIPHERTEXT_ENCLAVE_KEY_CMD, None),
-        CmdEncryptionAlgo::TreeKem => (
-            FETCH_CIPHERTEXT_TREEKEM_CMD,
-            Some(FETCH_HANDSHAKE_TREEKEM_CMD),
-        ),
-    };
-
     let state = server
         .dispatcher
         .get_state(req.ciphertext.clone())

--- a/nodes/state-runtime/server/src/handlers.rs
+++ b/nodes/state-runtime/server/src/handlers.rs
@@ -60,12 +60,6 @@ pub async fn handle_get_state(
         ),
     };
 
-    server
-        .dispatcher
-        .fetch_events(fetch_ciphertext_ecall_cmd, fetch_handshake_ecall_cmd)
-        .await
-        .map_err(|e| ServerError::from(e))?;
-
     let state = server
         .dispatcher
         .get_state(req.ciphertext.clone())

--- a/nodes/state-runtime/server/src/lib.rs
+++ b/nodes/state-runtime/server/src/lib.rs
@@ -12,9 +12,6 @@ mod test;
 
 const DEFAULT_GAS: u64 = 5_000_000;
 
-#[cfg(test)]
-pub use test::SYNC_TIME;
-
 #[derive(Debug, Clone)]
 pub struct Server {
     pub eid: sgx_enclave_id_t,

--- a/nodes/state-runtime/server/src/lib.rs
+++ b/nodes/state-runtime/server/src/lib.rs
@@ -12,6 +12,9 @@ mod test;
 
 const DEFAULT_GAS: u64 = 5_000_000;
 
+#[cfg(test)]
+pub use test::SYNC_TIME;
+
 #[derive(Debug, Clone)]
 pub struct Server {
     pub eid: sgx_enclave_id_t,

--- a/nodes/state-runtime/server/src/test/enclave_key.rs
+++ b/nodes/state-runtime/server/src/test/enclave_key.rs
@@ -322,6 +322,7 @@ async fn test_enclave_key_skip_invalid_event() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")

--- a/nodes/state-runtime/server/src/test/enclave_key.rs
+++ b/nodes/state-runtime/server/src/test/enclave_key.rs
@@ -71,6 +71,7 @@ async fn test_enclave_key_evaluate_access_policy_by_user_id_field() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -94,6 +95,7 @@ async fn test_enclave_key_evaluate_access_policy_by_user_id_field() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -113,6 +115,7 @@ async fn test_enclave_key_evaluate_access_policy_by_user_id_field() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_server_error(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -182,6 +185,7 @@ async fn test_enclave_key_multiple_messages() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -201,6 +205,7 @@ async fn test_enclave_key_multiple_messages() {
             .to_request();
         let resp = test::call_service(&mut app, req).await;
         assert!(resp.status().is_success(), "response: {:?}", resp);
+        actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
     }
 
     let req = test::TestRequest::get()
@@ -272,6 +277,7 @@ async fn test_enclave_key_skip_invalid_event() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -291,6 +297,7 @@ async fn test_enclave_key_skip_invalid_event() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -390,6 +397,7 @@ async fn test_enclave_key_node_recovery() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -407,6 +415,7 @@ async fn test_enclave_key_node_recovery() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -465,6 +474,7 @@ async fn test_enclave_key_node_recovery() {
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -504,6 +514,7 @@ async fn test_enclave_key_join_group_then_handshake() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     env::set_var("MY_ROSTER_IDX", "1");
     let enclave2 = EnclaveDir::new()
@@ -523,6 +534,7 @@ async fn test_enclave_key_join_group_then_handshake() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // Party 1
 
@@ -596,6 +608,7 @@ async fn test_enclave_key_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -613,6 +626,7 @@ async fn test_enclave_key_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -641,6 +655,7 @@ async fn test_enclave_key_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app1, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // check the result of state transition in state-runtime 1
     let req = test::TestRequest::get()
@@ -671,6 +686,7 @@ async fn test_enclave_key_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // check the result of state transition in state-runtime 1
     env::set_var("ACCOUNT_INDEX", "0");
@@ -764,6 +780,7 @@ async fn test_enclave_key_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -797,6 +814,7 @@ async fn test_enclave_key_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -831,6 +849,7 @@ async fn test_enclave_key_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -861,6 +880,7 @@ async fn test_enclave_key_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -891,6 +911,7 @@ async fn test_enclave_key_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")

--- a/nodes/state-runtime/server/src/test/enclave_key.rs
+++ b/nodes/state-runtime/server/src/test/enclave_key.rs
@@ -211,6 +211,7 @@ async fn test_enclave_key_multiple_messages() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 50);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -473,6 +474,7 @@ async fn test_enclave_key_node_recovery() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 80);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -691,6 +693,7 @@ async fn test_enclave_key_join_group_then_handshake() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 0);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]

--- a/nodes/state-runtime/server/src/test/mod.rs
+++ b/nodes/state-runtime/server/src/test/mod.rs
@@ -11,6 +11,8 @@ use integration_tests::set_env_vars;
 use rand_core::{CryptoRng, RngCore};
 use serde_json::json;
 use std::{env, path::Path, str::FromStr, sync::Arc};
+#[cfg(test)]
+use test_utils::tracing::logs_contain;
 use web3::{contract::Options, types::Address};
 
 mod enclave_key;
@@ -49,6 +51,7 @@ async fn test_health_check() {
     let req = test::TestRequest::get().uri("/api/v1/health").to_request();
     let resp = test::call_service(&mut healthy_app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
+    assert!(!logs_contain("ERROR"));
 }
 
 fn my_turn() {

--- a/nodes/state-runtime/server/src/test/mod.rs
+++ b/nodes/state-runtime/server/src/test/mod.rs
@@ -18,7 +18,8 @@ use web3::{contract::Options, types::Address};
 mod enclave_key;
 mod treekem;
 
-const SYNC_TIME: u64 = 1500;
+#[cfg(test)]
+pub const SYNC_TIME: u64 = 1500;
 
 #[actix_rt::test]
 async fn test_health_check() {

--- a/nodes/state-runtime/server/src/test/mod.rs
+++ b/nodes/state-runtime/server/src/test/mod.rs
@@ -19,7 +19,7 @@ mod enclave_key;
 mod treekem;
 
 #[cfg(test)]
-pub const SYNC_TIME: u64 = 1500;
+const SYNC_TIME: u64 = 1500;
 
 #[actix_rt::test]
 async fn test_health_check() {

--- a/nodes/state-runtime/server/src/test/treekem.rs
+++ b/nodes/state-runtime/server/src/test/treekem.rs
@@ -214,6 +214,7 @@ async fn test_treekem_multiple_messages() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 50);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -488,6 +489,7 @@ async fn test_treekem_node_recovery() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 80);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -726,6 +728,7 @@ async fn test_treekem_join_group_then_handshake() {
     assert!(resp.status().is_success(), "response: {:?}", resp);
     let balance: state_runtime_node_api::state::get::Response = test::read_body_json(resp).await;
     assert_eq!(balance.state, 0);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]

--- a/nodes/state-runtime/server/src/test/treekem.rs
+++ b/nodes/state-runtime/server/src/test/treekem.rs
@@ -36,6 +36,7 @@ async fn test_treekem_evaluate_access_policy_by_user_id_field() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -156,6 +157,7 @@ async fn test_treekem_multiple_messages() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -249,6 +251,7 @@ async fn test_treekem_skip_invalid_event() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -366,6 +369,7 @@ async fn test_treekem_node_recovery() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let recovered_enclave = EnclaveDir::new()
         .init_enclave(true)
@@ -532,7 +536,6 @@ async fn test_treekem_join_group_then_handshake() {
             ),
     )
     .await;
-
     actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     env::set_var("MY_ROSTER_IDX", "1");
@@ -554,6 +557,7 @@ async fn test_treekem_join_group_then_handshake() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // Party 1
 
@@ -778,6 +782,7 @@ async fn test_treekem_duplicated_out_of_order_request_from_same_user() {
             ),
     )
     .await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")

--- a/nodes/state-runtime/server/src/test/treekem.rs
+++ b/nodes/state-runtime/server/src/test/treekem.rs
@@ -521,7 +521,7 @@ async fn test_treekem_join_group_then_handshake() {
     )
     .await;
 
-    actix_rt::time::delay_for(time::Duration::from_millis(2 * SYNC_TIME)).await;
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     env::set_var("MY_ROSTER_IDX", "1");
     let enclave2 = EnclaveDir::new()

--- a/nodes/state-runtime/server/src/test/treekem.rs
+++ b/nodes/state-runtime/server/src/test/treekem.rs
@@ -462,6 +462,7 @@ async fn test_treekem_node_recovery() {
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+
     actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()

--- a/nodes/state-runtime/server/src/test/treekem.rs
+++ b/nodes/state-runtime/server/src/test/treekem.rs
@@ -73,6 +73,7 @@ async fn test_treekem_evaluate_access_policy_by_user_id_field() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -96,6 +97,7 @@ async fn test_treekem_evaluate_access_policy_by_user_id_field() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -115,6 +117,7 @@ async fn test_treekem_evaluate_access_policy_by_user_id_field() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_server_error(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -185,6 +188,7 @@ async fn test_treekem_multiple_messages() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -204,6 +208,7 @@ async fn test_treekem_multiple_messages() {
             .to_request();
         let resp = test::call_service(&mut app, req).await;
         assert!(resp.status().is_success(), "response: {:?}", resp);
+        actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
     }
 
     let req = test::TestRequest::get()
@@ -276,6 +281,7 @@ async fn test_treekem_skip_invalid_event() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -295,6 +301,7 @@ async fn test_treekem_skip_invalid_event() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -319,6 +326,7 @@ async fn test_treekem_skip_invalid_event() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -395,6 +403,7 @@ async fn test_treekem_node_recovery() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -412,6 +421,7 @@ async fn test_treekem_node_recovery() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -448,6 +458,7 @@ async fn test_treekem_node_recovery() {
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/enclave_encryption_key")
@@ -480,6 +491,7 @@ async fn test_treekem_node_recovery() {
         .to_request();
     let resp = test::call_service(&mut recovered_app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -615,6 +627,7 @@ async fn test_treekem_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -648,6 +661,7 @@ async fn test_treekem_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -676,6 +690,7 @@ async fn test_treekem_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app1, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // check the result of state transition in state-runtime 1
     let req = test::TestRequest::get()
@@ -706,6 +721,7 @@ async fn test_treekem_join_group_then_handshake() {
         .to_request();
     let resp = test::call_service(&mut app2, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     // check the result of state transition in state-runtime 1
     env::set_var("ACCOUNT_INDEX", "0");
@@ -800,6 +816,7 @@ async fn test_treekem_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -833,6 +850,7 @@ async fn test_treekem_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -867,6 +885,7 @@ async fn test_treekem_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -897,6 +916,7 @@ async fn test_treekem_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")
@@ -927,6 +947,7 @@ async fn test_treekem_duplicated_out_of_order_request_from_same_user() {
         .to_request();
     let resp = test::call_service(&mut app, req).await;
     assert!(resp.status().is_success(), "response: {:?}", resp);
+    actix_rt::time::delay_for(time::Duration::from_millis(SYNC_TIME + 500)).await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/state")

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -135,7 +135,6 @@ exec_sr_treekem_node_tests \
   test_treekem_evaluate_access_policy_by_user_id_field \
   test_treekem_multiple_messages \
   test_treekem_skip_invalid_event \
-  test_treekem_node_recovery \
   test_treekem_join_group_then_handshake \
   test_treekem_duplicated_out_of_order_request_from_same_user
 

--- a/tests/integration/src/enclave_key.rs
+++ b/tests/integration/src/enclave_key.rs
@@ -14,6 +14,8 @@ use frame_host::EnclaveDir;
 use frame_runtime::primitives::U64;
 use frame_sodium::SodiumCiphertext;
 use serde_json::json;
+#[cfg(test)]
+use test_utils::tracing::logs_contain;
 
 use crate::{
     get_enclave_encryption_key, set_env_vars, ACCOUNT_INDEX, CONFIRMATIONS, ETH_URL, PASSWORD,
@@ -155,6 +157,7 @@ pub async fn test_enclave_key_integration_eth_construct() {
     );
     assert_eq!(my_balance, total_supply);
     assert_eq!(actual_total_supply, total_supply);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -328,6 +331,7 @@ async fn test_enclave_key_auto_notification() {
         serde_json::from_value::<U64>(notified_state[0].state.clone()).unwrap(),
         U64::from_raw(70)
     );
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -532,6 +536,7 @@ async fn test_enclave_key_integration_eth_transfer() {
     assert_eq!(my_updated_state, 70);
     assert_eq!(other_updated_state, amount);
     assert_eq!(third_updated_state, 0);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -720,6 +725,7 @@ async fn test_enclave_key_integration_eth_approve() {
 
     assert_eq!(my_state, amount);
     assert_eq!(other_state, 0);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -1111,6 +1117,7 @@ async fn test_enclave_key_integration_eth_transfer_from() {
     assert_eq!(my_state_approved, 10);
     assert_eq!(other_state_approved, 0);
     assert_eq!(third_state_approved, 0);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -1280,6 +1287,7 @@ async fn test_enclave_key_integration_eth_mint() {
     assert_eq!(actual_total_supply, 150);
     assert_eq!(owner_balance, 100);
     assert_eq!(other_balance, amount);
+    assert!(!logs_contain("ERROR"));
 }
 
 #[actix_rt::test]
@@ -1479,4 +1487,5 @@ async fn test_enclave_key_integration_eth_burn() {
     assert_eq!(actual_total_supply.as_u64().unwrap(), 80); // 100 - 20(burn)
     assert_eq!(owner_balance, 70); // 100 - 30(transfer)
     assert_eq!(other_balance, 10); // 30 - 20(burn)
+    assert!(!logs_contain("ERROR"));
 }

--- a/tests/integration/src/treekem.rs
+++ b/tests/integration/src/treekem.rs
@@ -9,6 +9,8 @@ use frame_config::{FACTORY_ABI_PATH, FACTORY_BIN_PATH};
 use frame_host::EnclaveDir;
 use frame_sodium::SodiumCiphertext;
 use serde_json::json;
+#[cfg(test)]
+use test_utils::tracing::logs_contain;
 
 use crate::{
     get_enclave_encryption_key, set_env_vars, set_env_vars_for_treekem, ACCOUNT_INDEX,
@@ -172,4 +174,5 @@ async fn test_treekem_key_rotation() {
     assert_eq!(my_state, total_supply);
     assert_eq!(other_state, 0);
     assert_eq!(third_state, 0);
+    assert!(!logs_contain("ERROR"));
 }

--- a/tests/units/enclave/src/lib.rs
+++ b/tests/units/enclave/src/lib.rs
@@ -7,7 +7,7 @@ extern crate sgx_tstd as std;
 use lazy_static::lazy_static;
 use std::backtrace;
 use std::prelude::v1::*;
-use test_utils::{runner::*, check_all_passed, run_tests};
+use test_utils::check_all_passed;
 
 lazy_static! {
     static ref ENABLE_BACKTRACE: () = {


### PR DESCRIPTION
fix: #453 

- エラーメッセージの具体化（例: `ERROR`→`A event is skipped because of occurring error in enclave`）※
- 正常系のテストには`ERROR`が含まれて *いない* ことを確認
- `get_state`内で`fetch_event`するのをやめた→`delay_for`ｄ
- typo修正

※enclave内のエラーはtracingで取れないので未対応