### PR TITLE
ci: Run CI jobs not on branch creation but on PR open / sync

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 stages:
 - stage: Test
-  condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+  condition: and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'skiptest-')))
   jobs:
     - job: CI
       pool:


### PR DESCRIPTION
## Motivation

- 自分の手元で書いた作業中のコードをバックアップの気持ちでpushしたい時がある
- CI Runner のコスト・遅さなどを鑑みると、pushのたびに毎回テストを走らせるのはやりたいことではない
  - PR作成時にはテストを走らせたいが、remote branch作成時には走らせたくない

## やること

（今pushしてる内容と変えます）

- CIを走らせるhookをブランチpushではなくPR open, PR更新に変更
  - 既にそうなってる説もある。確認