### PR TITLE
fix: `feature = ["sgx", "std"]` のケースで `localstd` が二重定義される問題を修正

### DIFF
--- a/frame/config/src/lib.rs
+++ b/frame/config/src/lib.rs
@@ -1,10 +1,13 @@
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
 #[cfg(feature = "sgx")]
 #[macro_use]
 extern crate sgx_tstd as localstd;
-#[cfg(feature = "std")]
+
+#[cfg(all(not(feature = "sgx"), feature = "std"))]
 use std as localstd;
-#[cfg(all(not(feature = "std"), not(feature = "sgx")))]
+
+#[cfg(all(not(feature = "sgx"), not(feature = "std")))]
 extern crate core as localstd;
 
 pub mod envs;


### PR DESCRIPTION
## Issueへのリンク

（なし）

## やったこと

VSCode の Remote Container で dev環境上のコンテナに接続し、rust-analyzer をかけていたところ、たまたまtitleの問題に気づきました。

![image](https://user-images.githubusercontent.com/498788/119216418-888fe500-bb0e-11eb-9b3d-2bdf03b2a967.png)

## やらないこと

考えられるfeatureの組み合わせで、CIでマトリクスビルドを書けておくべきだと思います。
今回はやらないですが、このPRが妥当と判断されたらまずはissue化します。

## 動作検証

rust-analyzer がエラーを吐かなくなった

## 参考

（なし）
