### PR TITLE
chore: ignore `.vscode/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ anonify-types.h
 .anonify
 /anonify-contracts
 Enclave.prd.config.xml
+/.vscode/**


### PR DESCRIPTION
## Issueへのリンク

（なし）

## やったこと

.gitignore 追記。

開発環境のdocker containerにVSCodeのRemote Container機能を使って接続して開発しているため、
コンテナの中にはいつも自分が使っている `~/.gitignore` がなく、

```json
{
    "cSpell.words": [
        "Ecall",
        "Encinteger"
    ]
}
```

のような中身の `.vscode/settings.json` が毎回git操作で出てきて邪魔になるので。

## やらないこと

（なし）

## 動作検証

コンテナ内の操作で
>  `.vscode/settings.json` が毎回git操作で出てきて

が解消。

## 参考

（なし）