### PR TITLE
refactor: EnclaveEngine、runtimeに依存する版としない版のtraitを分けた & しない版の handle() において ecall_input を引数から取得できるようにした

### DIFF
--- a/example/erc20/enclave/src/ecalls.rs
+++ b/example/erc20/enclave/src/ecalls.rs
@@ -4,7 +4,7 @@ use anonify_ecall_types::cmd::*;
 use anonify_enclave::{context::AnonifyEnclaveContext, workflow::*};
 use anyhow::anyhow;
 use frame_common::crypto::NoAuth;
-use frame_enclave::{register_ecall, EnclaveEngine};
+use frame_enclave::{register_ecall, StateRuntimeEnclaveEngine};
 use std::{ptr, vec::Vec};
 
 register_ecall!(

--- a/example/key-vault/enclave/src/ecalls.rs
+++ b/example/key-vault/enclave/src/ecalls.rs
@@ -1,4 +1,5 @@
 use crate::ENCLAVE_CONTEXT;
+use anyhow::anyhow;
 use frame_enclave::{register_ecall, BasicEnclaveEngine};
 use key_vault_ecall_types::cmd::*;
 use key_vault_enclave::{context::KeyVaultEnclaveContext, workflow::*};

--- a/example/key-vault/enclave/src/ecalls.rs
+++ b/example/key-vault/enclave/src/ecalls.rs
@@ -1,5 +1,5 @@
 use crate::ENCLAVE_CONTEXT;
-use frame_enclave::{register_ecall, EnclaveEngine};
+use frame_enclave::{register_ecall, StateRuntimeEnclaveEngine};
 use key_vault_ecall_types::cmd::*;
 use key_vault_enclave::{context::KeyVaultEnclaveContext, workflow::*};
 use std::{ptr, vec::Vec};

--- a/example/key-vault/enclave/src/ecalls.rs
+++ b/example/key-vault/enclave/src/ecalls.rs
@@ -1,5 +1,5 @@
 use crate::ENCLAVE_CONTEXT;
-use frame_enclave::{register_ecall, StateRuntimeEnclaveEngine};
+use frame_enclave::{register_ecall, BasicEnclaveEngine};
 use key_vault_ecall_types::cmd::*;
 use key_vault_enclave::{context::KeyVaultEnclaveContext, workflow::*};
 use std::{ptr, vec::Vec};

--- a/frame/enclave/src/engine.rs
+++ b/frame/enclave/src/engine.rs
@@ -1,3 +1,5 @@
+mod basic_enclave_engine;
 mod state_runtime_enclave_engine;
 
+pub use basic_enclave_engine::BasicEnclaveEngine;
 pub use state_runtime_enclave_engine::StateRuntimeEnclaveEngine;

--- a/frame/enclave/src/engine.rs
+++ b/frame/enclave/src/engine.rs
@@ -1,37 +1,3 @@
-use frame_common::{state_types::StateType, EcallInput, EcallOutput};
-use frame_runtime::{ConfigGetter, ContextOps, RuntimeExecutor};
-use serde::{de::DeserializeOwned, Serialize};
+mod state_runtime_enclave_engine;
 
-pub trait EnclaveEngine: Sized + Default {
-    type EI: EcallInput + DeserializeOwned + Default;
-    type EO: EcallOutput + Serialize + Default;
-
-    fn decrypt<C>(_ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
-    where
-        C: ContextOps<S = StateType> + Clone,
-    {
-        Ok(Self::default())
-    }
-
-    /// Evaluate policies like authentication and idempotency
-    fn eval_policy(&self) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    /// If the module have a state transition runtime, use this handler.
-    fn handle<R, C>(self, _enclave_context: &C, _max_mem_size: usize) -> anyhow::Result<Self::EO>
-    where
-        R: RuntimeExecutor<C, S = StateType>,
-        C: ContextOps<S = StateType> + Clone,
-    {
-        Ok(Self::EO::default())
-    }
-
-    /// If the module doesn't have a state transition runtime, use this handler.
-    fn handle_without_runtime<C>(_enclave_context: &C) -> anyhow::Result<Self::EO>
-    where
-        C: ConfigGetter,
-    {
-        Ok(Self::EO::default())
-    }
-}
+pub use state_runtime_enclave_engine::StateRuntimeEnclaveEngine;

--- a/frame/enclave/src/engine/basic_enclave_engine.rs
+++ b/frame/enclave/src/engine/basic_enclave_engine.rs
@@ -6,7 +6,7 @@ pub trait BasicEnclaveEngine: Sized + Default {
     type EI: EcallInput + DeserializeOwned + Default;
     type EO: EcallOutput + Serialize + Default;
 
-    fn decrypt<C>(_ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(_ecall_input: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {

--- a/frame/enclave/src/engine/basic_enclave_engine.rs
+++ b/frame/enclave/src/engine/basic_enclave_engine.rs
@@ -1,5 +1,5 @@
-use frame_common::{state_types::StateType, EcallInput, EcallOutput};
-use frame_runtime::{ConfigGetter, ContextOps, RuntimeExecutor};
+use frame_common::{EcallInput, EcallOutput};
+use frame_runtime::ConfigGetter;
 use serde::{de::DeserializeOwned, Serialize};
 
 pub trait BasicEnclaveEngine: Sized + Default {
@@ -8,7 +8,7 @@ pub trait BasicEnclaveEngine: Sized + Default {
 
     fn new<C>(_ecall_input: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
     where
-        C: ContextOps<S = StateType> + Clone,
+        C: ConfigGetter,
     {
         Ok(Self::default())
     }

--- a/frame/enclave/src/engine/basic_enclave_engine.rs
+++ b/frame/enclave/src/engine/basic_enclave_engine.rs
@@ -1,0 +1,37 @@
+use frame_common::{state_types::StateType, EcallInput, EcallOutput};
+use frame_runtime::{ConfigGetter, ContextOps, RuntimeExecutor};
+use serde::{de::DeserializeOwned, Serialize};
+
+pub trait BasicEnclaveEngine: Sized + Default {
+    type EI: EcallInput + DeserializeOwned + Default;
+    type EO: EcallOutput + Serialize + Default;
+
+    fn decrypt<C>(_ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
+    where
+        C: ContextOps<S = StateType> + Clone,
+    {
+        Ok(Self::default())
+    }
+
+    /// Evaluate policies like authentication and idempotency
+    fn eval_policy(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// If the module have a state transition runtime, use this handler.
+    fn handle<R, C>(self, _enclave_context: &C, _max_mem_size: usize) -> anyhow::Result<Self::EO>
+    where
+        R: RuntimeExecutor<C, S = StateType>,
+        C: ContextOps<S = StateType> + Clone,
+    {
+        Ok(Self::EO::default())
+    }
+
+    /// If the module doesn't have a state transition runtime, use this handler.
+    fn handle_without_runtime<C>(_enclave_context: &C) -> anyhow::Result<Self::EO>
+    where
+        C: ConfigGetter,
+    {
+        Ok(Self::EO::default())
+    }
+}

--- a/frame/enclave/src/engine/basic_enclave_engine.rs
+++ b/frame/enclave/src/engine/basic_enclave_engine.rs
@@ -13,22 +13,8 @@ pub trait BasicEnclaveEngine: Sized + Default {
         Ok(Self::default())
     }
 
-    /// Evaluate policies like authentication and idempotency
-    fn eval_policy(&self) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    /// If the module have a state transition runtime, use this handler.
-    fn handle<R, C>(self, _enclave_context: &C, _max_mem_size: usize) -> anyhow::Result<Self::EO>
-    where
-        R: RuntimeExecutor<C, S = StateType>,
-        C: ContextOps<S = StateType> + Clone,
-    {
-        Ok(Self::EO::default())
-    }
-
-    /// If the module doesn't have a state transition runtime, use this handler.
-    fn handle_without_runtime<C>(_enclave_context: &C) -> anyhow::Result<Self::EO>
+    /// Handler for basic engine
+    fn handle<C>(_enclave_context: &C) -> anyhow::Result<Self::EO>
     where
         C: ConfigGetter,
     {

--- a/frame/enclave/src/engine/basic_enclave_engine.rs
+++ b/frame/enclave/src/engine/basic_enclave_engine.rs
@@ -14,7 +14,7 @@ pub trait BasicEnclaveEngine: Sized + Default {
     }
 
     /// Handler for basic engine
-    fn handle<C>(_enclave_context: &C) -> anyhow::Result<Self::EO>
+    fn handle<C>(self, _enclave_context: &C) -> anyhow::Result<Self::EO>
     where
         C: ConfigGetter,
     {

--- a/frame/enclave/src/engine/state_runtime_enclave_engine.rs
+++ b/frame/enclave/src/engine/state_runtime_enclave_engine.rs
@@ -18,19 +18,11 @@ pub trait StateRuntimeEnclaveEngine: Sized + Default {
         Ok(())
     }
 
-    /// If the module have a state transition runtime, use this handler.
+    /// Handler for state transition runtime
     fn handle<R, C>(self, _enclave_context: &C, _max_mem_size: usize) -> anyhow::Result<Self::EO>
     where
         R: RuntimeExecutor<C, S = StateType>,
         C: ContextOps<S = StateType> + Clone,
-    {
-        Ok(Self::EO::default())
-    }
-
-    /// If the module doesn't have a state transition runtime, use this handler.
-    fn handle_without_runtime<C>(_enclave_context: &C) -> anyhow::Result<Self::EO>
-    where
-        C: ConfigGetter,
     {
         Ok(Self::EO::default())
     }

--- a/frame/enclave/src/engine/state_runtime_enclave_engine.rs
+++ b/frame/enclave/src/engine/state_runtime_enclave_engine.rs
@@ -1,0 +1,37 @@
+use frame_common::{state_types::StateType, EcallInput, EcallOutput};
+use frame_runtime::{ConfigGetter, ContextOps, RuntimeExecutor};
+use serde::{de::DeserializeOwned, Serialize};
+
+pub trait StateRuntimeEnclaveEngine: Sized + Default {
+    type EI: EcallInput + DeserializeOwned + Default;
+    type EO: EcallOutput + Serialize + Default;
+
+    fn decrypt<C>(_ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
+    where
+        C: ContextOps<S = StateType> + Clone,
+    {
+        Ok(Self::default())
+    }
+
+    /// Evaluate policies like authentication and idempotency
+    fn eval_policy(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// If the module have a state transition runtime, use this handler.
+    fn handle<R, C>(self, _enclave_context: &C, _max_mem_size: usize) -> anyhow::Result<Self::EO>
+    where
+        R: RuntimeExecutor<C, S = StateType>,
+        C: ContextOps<S = StateType> + Clone,
+    {
+        Ok(Self::EO::default())
+    }
+
+    /// If the module doesn't have a state transition runtime, use this handler.
+    fn handle_without_runtime<C>(_enclave_context: &C) -> anyhow::Result<Self::EO>
+    where
+        C: ConfigGetter,
+    {
+        Ok(Self::EO::default())
+    }
+}

--- a/frame/enclave/src/engine/state_runtime_enclave_engine.rs
+++ b/frame/enclave/src/engine/state_runtime_enclave_engine.rs
@@ -1,5 +1,5 @@
 use frame_common::{state_types::StateType, EcallInput, EcallOutput};
-use frame_runtime::{ConfigGetter, ContextOps, RuntimeExecutor};
+use frame_runtime::{ContextOps, RuntimeExecutor};
 use serde::{de::DeserializeOwned, Serialize};
 
 pub trait StateRuntimeEnclaveEngine: Sized + Default {

--- a/frame/enclave/src/engine/state_runtime_enclave_engine.rs
+++ b/frame/enclave/src/engine/state_runtime_enclave_engine.rs
@@ -6,7 +6,7 @@ pub trait StateRuntimeEnclaveEngine: Sized + Default {
     type EI: EcallInput + DeserializeOwned + Default;
     type EO: EcallOutput + Serialize + Default;
 
-    fn decrypt<C>(_ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(_ecall_input: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {

--- a/modules/anonify-enclave/src/backup.rs
+++ b/modules/anonify-enclave/src/backup.rs
@@ -3,7 +3,7 @@
 use anonify_ecall_types::*;
 use anyhow::Result;
 use frame_common::state_types::StateType;
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 use frame_mra_tls::key_vault::request::{
     BackupAllPathSecretsRequestBody, BackupPathSecretRequestBody, RecoverAllPathSecretsRequestbody,
 };
@@ -15,7 +15,7 @@ use std::vec::Vec;
 #[derive(Debug, Clone, Default)]
 pub struct PathSecretBackupper;
 
-impl EnclaveEngine for PathSecretBackupper {
+impl StateRuntimeEnclaveEngine for PathSecretBackupper {
     type EI = input::Empty;
     type EO = output::Empty;
 
@@ -55,7 +55,7 @@ impl EnclaveEngine for PathSecretBackupper {
 #[derive(Debug, Clone, Default)]
 pub struct PathSecretRecoverer;
 
-impl EnclaveEngine for PathSecretRecoverer {
+impl StateRuntimeEnclaveEngine for PathSecretRecoverer {
     type EI = input::Empty;
     type EO = output::Empty;
 

--- a/modules/anonify-enclave/src/commands/enclave_key.rs
+++ b/modules/anonify-enclave/src/commands/enclave_key.rs
@@ -7,7 +7,7 @@ use frame_common::{
     state_types::StateType,
     AccessPolicy,
 };
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 use frame_runtime::traits::*;
 use frame_sodium::{rng::SgxRng, SodiumCiphertext};
 use serde::{Deserialize, Serialize};
@@ -20,7 +20,7 @@ pub struct CommandByEnclaveKeySender<AP: AccessPolicy> {
     user_id: Option<AccountId>,
 }
 
-impl<AP> EnclaveEngine for CommandByEnclaveKeySender<AP>
+impl<AP> StateRuntimeEnclaveEngine for CommandByEnclaveKeySender<AP>
 where
     AP: AccessPolicy,
 {
@@ -92,7 +92,7 @@ pub struct CommandByEnclaveKeyReceiver<AP> {
     ap: PhantomData<AP>,
 }
 
-impl<AP> EnclaveEngine for CommandByEnclaveKeyReceiver<AP>
+impl<AP> StateRuntimeEnclaveEngine for CommandByEnclaveKeyReceiver<AP>
 where
     AP: AccessPolicy,
 {

--- a/modules/anonify-enclave/src/commands/enclave_key.rs
+++ b/modules/anonify-enclave/src/commands/enclave_key.rs
@@ -27,7 +27,7 @@ where
     type EI = input::Command;
     type EO = output::Command;
 
-    fn decrypt<C>(ecall_input: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(ecall_input: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
@@ -99,12 +99,12 @@ where
     type EI = input::InsertCiphertext;
     type EO = output::ReturnNotifyState;
 
-    fn decrypt<C>(ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(ecall_input: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
         Ok(Self {
-            ecall_input: ciphertext,
+            ecall_input,
             ap: PhantomData,
         })
     }

--- a/modules/anonify-enclave/src/commands/treekem.rs
+++ b/modules/anonify-enclave/src/commands/treekem.rs
@@ -26,7 +26,7 @@ where
     type EI = input::Command;
     type EO = output::Command;
 
-    fn decrypt<C>(ecall_input: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(ecall_input: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
@@ -103,12 +103,12 @@ where
     type EI = input::InsertCiphertext;
     type EO = output::ReturnNotifyState;
 
-    fn decrypt<C>(ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(ecall_input: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
         Ok(Self {
-            ecall_input: ciphertext,
+            ecall_input,
             ap: PhantomData,
         })
     }

--- a/modules/anonify-enclave/src/commands/treekem.rs
+++ b/modules/anonify-enclave/src/commands/treekem.rs
@@ -7,7 +7,7 @@ use frame_common::{
     state_types::StateType,
     AccessPolicy,
 };
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 use frame_runtime::traits::*;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
@@ -19,7 +19,7 @@ pub struct CommandByTreeKemSender<AP: AccessPolicy> {
     user_id: Option<AccountId>,
 }
 
-impl<AP> EnclaveEngine for CommandByTreeKemSender<AP>
+impl<AP> StateRuntimeEnclaveEngine for CommandByTreeKemSender<AP>
 where
     AP: AccessPolicy,
 {
@@ -96,7 +96,7 @@ pub struct CommandByTreeKemReceiver<AP> {
     ap: PhantomData<AP>,
 }
 
-impl<AP> EnclaveEngine for CommandByTreeKemReceiver<AP>
+impl<AP> StateRuntimeEnclaveEngine for CommandByTreeKemReceiver<AP>
 where
     AP: AccessPolicy,
 {

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -445,11 +445,11 @@ impl<AP: AccessPolicy> StateRuntimeEnclaveEngine for GetState<AP> {
     type EI = SodiumCiphertext;
     type EO = output::ReturnState;
 
-    fn decrypt<C>(ciphertext: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(ecall_input: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        let buf = enclave_context.decrypt(&ciphertext)?;
+        let buf = enclave_context.decrypt(&ecall_input)?;
         let ecall_input = serde_json::from_slice(&buf[..])?;
 
         Ok(Self { ecall_input })
@@ -489,11 +489,11 @@ impl<AP: AccessPolicy> StateRuntimeEnclaveEngine for GetUserCounter<AP> {
     type EI = SodiumCiphertext;
     type EO = output::ReturnUserCounter;
 
-    fn decrypt<C>(ciphertext: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(ecall_input: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        let buf = enclave_context.decrypt(&ciphertext)?;
+        let buf = enclave_context.decrypt(&ecall_input)?;
         let ecall_input = serde_json::from_slice(&buf[..])?;
 
         Ok(Self { ecall_input })

--- a/modules/anonify-enclave/src/context.rs
+++ b/modules/anonify-enclave/src/context.rs
@@ -17,7 +17,7 @@ use frame_common::{
 #[cfg(feature = "backup-enable")]
 use frame_config::KEY_VAULT_ENCLAVE_MEASUREMENT;
 use frame_config::{ANONIFY_PARAMS_DIR, CMD_DEC_SECRET_DIR, IAS_ROOT_CERT};
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 #[cfg(feature = "backup-enable")]
 use frame_mra_tls::{
     key_vault::{
@@ -441,7 +441,7 @@ pub struct GetState<AP: AccessPolicy> {
     ecall_input: input::GetState<AP>,
 }
 
-impl<AP: AccessPolicy> EnclaveEngine for GetState<AP> {
+impl<AP: AccessPolicy> StateRuntimeEnclaveEngine for GetState<AP> {
     type EI = SodiumCiphertext;
     type EO = output::ReturnState;
 
@@ -485,7 +485,7 @@ pub struct GetUserCounter<AP: AccessPolicy> {
     ecall_input: input::GetUserCounter<AP>,
 }
 
-impl<AP: AccessPolicy> EnclaveEngine for GetUserCounter<AP> {
+impl<AP: AccessPolicy> StateRuntimeEnclaveEngine for GetUserCounter<AP> {
     type EI = SodiumCiphertext;
     type EO = output::ReturnUserCounter;
 
@@ -519,7 +519,7 @@ impl<AP: AccessPolicy> EnclaveEngine for GetUserCounter<AP> {
 #[derive(Debug, Clone, Default)]
 pub struct ReportRegistration;
 
-impl EnclaveEngine for ReportRegistration {
+impl StateRuntimeEnclaveEngine for ReportRegistration {
     type EI = input::Empty;
     type EO = output::ReturnRegisterReport;
 

--- a/modules/anonify-enclave/src/enclave_key.rs
+++ b/modules/anonify-enclave/src/enclave_key.rs
@@ -4,7 +4,7 @@ use crate::error::{EnclaveError, Result};
 use anonify_ecall_types::*;
 use anyhow::anyhow;
 use frame_common::{crypto::rand_assign, state_types::StateType, traits::Keccak256};
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 #[cfg(feature = "backup-enable")]
 use frame_mra_tls::{
     key_vault::request::{
@@ -34,7 +34,7 @@ const DEC_KEY_FILE_NAME: &str = "sr_enclave_decryption_key";
 #[derive(Debug, Clone, Default)]
 pub struct EncryptionKeyGetter;
 
-impl EnclaveEngine for EncryptionKeyGetter {
+impl StateRuntimeEnclaveEngine for EncryptionKeyGetter {
     type EI = input::Empty;
     type EO = output::ReturnEncryptionKey;
 

--- a/modules/anonify-enclave/src/handshake.rs
+++ b/modules/anonify-enclave/src/handshake.rs
@@ -69,12 +69,12 @@ impl StateRuntimeEnclaveEngine for HandshakeReceiver {
     type EI = input::InsertHandshake;
     type EO = output::Empty;
 
-    fn decrypt<C>(ciphertext: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(ecall_input: Self::EI, _enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
         Ok(Self {
-            ecall_input: ciphertext,
+            ecall_input,
         })
     }
 

--- a/modules/anonify-enclave/src/handshake.rs
+++ b/modules/anonify-enclave/src/handshake.rs
@@ -73,9 +73,7 @@ impl StateRuntimeEnclaveEngine for HandshakeReceiver {
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        Ok(Self {
-            ecall_input,
-        })
+        Ok(Self { ecall_input })
     }
 
     fn handle<R, C>(self, enclave_context: &C, _max_mem_size: usize) -> Result<Self::EO>

--- a/modules/anonify-enclave/src/handshake.rs
+++ b/modules/anonify-enclave/src/handshake.rs
@@ -1,7 +1,7 @@
 use anonify_ecall_types::*;
 use anyhow::{anyhow, Result};
 use frame_common::{crypto::Sha256, state_types::StateType};
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 #[cfg(feature = "backup-enable")]
 use frame_mra_tls::key_vault::request::BackupPathSecretRequestBody;
 use frame_runtime::traits::*;
@@ -11,7 +11,7 @@ use frame_treekem::handshake::HandshakeParams;
 #[derive(Debug, Clone, Default)]
 pub struct HandshakeSender;
 
-impl EnclaveEngine for HandshakeSender {
+impl StateRuntimeEnclaveEngine for HandshakeSender {
     type EI = input::Empty;
     type EO = output::ReturnHandshake;
 
@@ -65,7 +65,7 @@ pub struct HandshakeReceiver {
     ecall_input: input::InsertHandshake,
 }
 
-impl EnclaveEngine for HandshakeReceiver {
+impl StateRuntimeEnclaveEngine for HandshakeReceiver {
     type EI = input::InsertHandshake;
     type EO = output::Empty;
 

--- a/modules/anonify-enclave/src/join_group/enclave_key.rs
+++ b/modules/anonify-enclave/src/join_group/enclave_key.rs
@@ -1,14 +1,14 @@
 use anonify_ecall_types::*;
 use anyhow::Result;
 use frame_common::state_types::StateType;
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 use frame_runtime::traits::*;
 
 /// A add handshake Sender
 #[derive(Debug, Clone, Default)]
 pub struct JoinGroupWithEnclaveKey;
 
-impl EnclaveEngine for JoinGroupWithEnclaveKey {
+impl StateRuntimeEnclaveEngine for JoinGroupWithEnclaveKey {
     type EI = input::Empty;
     type EO = output::ReturnJoinGroup;
 

--- a/modules/anonify-enclave/src/join_group/treekem.rs
+++ b/modules/anonify-enclave/src/join_group/treekem.rs
@@ -1,7 +1,7 @@
 use anonify_ecall_types::*;
 use anyhow::Result;
 use frame_common::state_types::StateType;
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 #[cfg(feature = "backup-enable")]
 use frame_mra_tls::key_vault::request::BackupPathSecretRequestBody;
 use frame_runtime::traits::*;
@@ -10,7 +10,7 @@ use frame_runtime::traits::*;
 #[derive(Debug, Clone, Default)]
 pub struct JoinGroupWithTreeKem;
 
-impl EnclaveEngine for JoinGroupWithTreeKem {
+impl StateRuntimeEnclaveEngine for JoinGroupWithTreeKem {
     type EI = input::Empty;
     type EO = output::ReturnJoinGroup;
 

--- a/modules/anonify-enclave/src/notify.rs
+++ b/modules/anonify-enclave/src/notify.rs
@@ -1,6 +1,6 @@
 use anonify_ecall_types::*;
 use frame_common::{crypto::AccountId, state_types::StateType, AccessPolicy};
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 use frame_runtime::traits::*;
 use frame_sodium::SodiumCiphertext;
 use std::{
@@ -36,7 +36,7 @@ pub struct RegisterNotification<AP: AccessPolicy> {
     ecall_input: input::RegisterNotification<AP>,
 }
 
-impl<AP: AccessPolicy> EnclaveEngine for RegisterNotification<AP> {
+impl<AP: AccessPolicy> StateRuntimeEnclaveEngine for RegisterNotification<AP> {
     type EI = SodiumCiphertext;
     type EO = output::Empty;
 

--- a/modules/anonify-enclave/src/notify.rs
+++ b/modules/anonify-enclave/src/notify.rs
@@ -40,11 +40,11 @@ impl<AP: AccessPolicy> StateRuntimeEnclaveEngine for RegisterNotification<AP> {
     type EI = SodiumCiphertext;
     type EO = output::Empty;
 
-    fn decrypt<C>(ciphertext: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
+    fn new<C>(ecall_input: Self::EI, enclave_context: &C) -> anyhow::Result<Self>
     where
         C: ContextOps<S = StateType> + Clone,
     {
-        let buf = enclave_context.decrypt(&ciphertext)?;
+        let buf = enclave_context.decrypt(&ecall_input)?;
         let ecall_input = serde_json::from_slice(&buf[..])?;
         Ok(Self { ecall_input })
     }

--- a/modules/key-vault-enclave/src/server.rs
+++ b/modules/key-vault-enclave/src/server.rs
@@ -15,7 +15,7 @@ impl BasicEnclaveEngine for ServerStarter {
     type EI = input::CallServerStarter;
     type EO = output::Empty;
 
-    fn handle_without_runtime<C>(enclave_context: &C) -> anyhow::Result<Self::EO>
+    fn handle<C>(enclave_context: &C) -> anyhow::Result<Self::EO>
     where
         C: ConfigGetter,
     {

--- a/modules/key-vault-enclave/src/server.rs
+++ b/modules/key-vault-enclave/src/server.rs
@@ -1,7 +1,7 @@
 use crate::handlers::KeyVaultHandler;
 use frame_common::state_types::StateType;
 use frame_config::{ANONIFY_ENCLAVE_MEASUREMENT, IAS_ROOT_CERT};
-use frame_enclave::EnclaveEngine;
+use frame_enclave::StateRuntimeEnclaveEngine;
 use frame_mra_tls::{AttestedTlsConfig, Server, ServerConfig};
 use frame_runtime::traits::*;
 use key_vault_ecall_types::*;
@@ -11,7 +11,7 @@ use std::env;
 #[derive(Debug, Clone, Default)]
 pub struct ServerStarter;
 
-impl EnclaveEngine for ServerStarter {
+impl StateRuntimeEnclaveEngine for ServerStarter {
     type EI = input::CallServerStarter;
     type EO = output::Empty;
 
@@ -45,7 +45,7 @@ impl EnclaveEngine for ServerStarter {
 #[derive(Debug, Clone, Default)]
 pub struct ServerStopper;
 
-impl EnclaveEngine for ServerStopper {
+impl StateRuntimeEnclaveEngine for ServerStopper {
     type EI = input::CallServerStopper;
     type EO = output::Empty;
 

--- a/modules/key-vault-enclave/src/server.rs
+++ b/modules/key-vault-enclave/src/server.rs
@@ -1,5 +1,4 @@
 use crate::handlers::KeyVaultHandler;
-use frame_common::state_types::StateType;
 use frame_config::{ANONIFY_ENCLAVE_MEASUREMENT, IAS_ROOT_CERT};
 use frame_enclave::BasicEnclaveEngine;
 use frame_mra_tls::{AttestedTlsConfig, Server, ServerConfig};

--- a/modules/key-vault-enclave/src/server.rs
+++ b/modules/key-vault-enclave/src/server.rs
@@ -49,10 +49,9 @@ impl BasicEnclaveEngine for ServerStopper {
     type EI = input::CallServerStopper;
     type EO = output::Empty;
 
-    fn handle<R, C>(self, _enclave_context: &C, _max_mem_size: usize) -> anyhow::Result<Self::EO>
+    fn handle<C>(self, _enclave_context: &C) -> anyhow::Result<Self::EO>
     where
-        R: RuntimeExecutor<C, S = StateType>,
-        C: ContextOps<S = StateType> + Clone,
+        C: ConfigGetter,
     {
         Ok(output::Empty::default())
     }

--- a/modules/key-vault-enclave/src/server.rs
+++ b/modules/key-vault-enclave/src/server.rs
@@ -1,7 +1,7 @@
 use crate::handlers::KeyVaultHandler;
 use frame_common::state_types::StateType;
 use frame_config::{ANONIFY_ENCLAVE_MEASUREMENT, IAS_ROOT_CERT};
-use frame_enclave::StateRuntimeEnclaveEngine;
+use frame_enclave::BasicEnclaveEngine;
 use frame_mra_tls::{AttestedTlsConfig, Server, ServerConfig};
 use frame_runtime::traits::*;
 use key_vault_ecall_types::*;
@@ -11,7 +11,7 @@ use std::env;
 #[derive(Debug, Clone, Default)]
 pub struct ServerStarter;
 
-impl StateRuntimeEnclaveEngine for ServerStarter {
+impl BasicEnclaveEngine for ServerStarter {
     type EI = input::CallServerStarter;
     type EO = output::Empty;
 
@@ -45,7 +45,7 @@ impl StateRuntimeEnclaveEngine for ServerStarter {
 #[derive(Debug, Clone, Default)]
 pub struct ServerStopper;
 
-impl StateRuntimeEnclaveEngine for ServerStopper {
+impl BasicEnclaveEngine for ServerStopper {
     type EI = input::CallServerStopper;
     type EO = output::Empty;
 

--- a/modules/key-vault-enclave/src/server.rs
+++ b/modules/key-vault-enclave/src/server.rs
@@ -15,7 +15,7 @@ impl BasicEnclaveEngine for ServerStarter {
     type EI = input::CallServerStarter;
     type EO = output::Empty;
 
-    fn handle<C>(enclave_context: &C) -> anyhow::Result<Self::EO>
+    fn handle<C>(self, enclave_context: &C) -> anyhow::Result<Self::EO>
     where
         C: ConfigGetter,
     {


### PR DESCRIPTION
## Issueへのリンク

（なし）

## やったこと

- EnclaveEngine、runtimeに依存する版（StateRuntimeEnclaveEngine）としない版（BasicEnclaveEngine）にtraitを分けた
  - 元々 `handle()` と `handle_without_runtime()` が混ざった、使い方に注意が必要なtraitであった
- `BasicEnclaveEngine::handle` は self 引数を取り、 ecall_input が取得できるようにした
- `EnclaveEngine::decrypt` は実際には復号していないコンストラクタなので、 `new` と改名

## やらないこと

（なし）

## 動作検証

コンパイル・テスト通ればOK

## 参考

これから暗号DBを作るに当たり、enclave_inputを取る & runtimeに依存しないEnclaveEngineが必要だったので、先に作りました。