### PR TITLE
ecall時の最大バイト数を`bincode`で制限することでエラーハンドリング

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -6030,7 +6030,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]

--- a/example/erc20/enclave/src/ecalls.rs
+++ b/example/erc20/enclave/src/ecalls.rs
@@ -5,6 +5,7 @@ use anonify_enclave::{context::AnonifyEnclaveContext, workflow::*};
 use anyhow::anyhow;
 use frame_common::crypto::NoAuth;
 use frame_enclave::{register_ecall, StateRuntimeEnclaveEngine};
+use log::error;
 use std::{ptr, vec::Vec};
 
 register_ecall!(

--- a/example/erc20/enclave/src/ecalls.rs
+++ b/example/erc20/enclave/src/ecalls.rs
@@ -3,6 +3,7 @@ use crate::ENCLAVE_CONTEXT;
 use anonify_ecall_types::cmd::*;
 use anonify_enclave::{context::AnonifyEnclaveContext, workflow::*};
 use anyhow::anyhow;
+use bincode::Options;
 use frame_common::crypto::NoAuth;
 use frame_enclave::{register_ecall, StateRuntimeEnclaveEngine};
 use log::error;

--- a/example/key-vault/enclave/src/ecalls.rs
+++ b/example/key-vault/enclave/src/ecalls.rs
@@ -1,5 +1,6 @@
 use crate::ENCLAVE_CONTEXT;
 use anyhow::anyhow;
+use bincode::Options;
 use frame_enclave::{register_ecall, BasicEnclaveEngine};
 use key_vault_ecall_types::cmd::*;
 use key_vault_enclave::{context::KeyVaultEnclaveContext, workflow::*};

--- a/example/key-vault/enclave/src/ecalls.rs
+++ b/example/key-vault/enclave/src/ecalls.rs
@@ -3,6 +3,7 @@ use anyhow::anyhow;
 use frame_enclave::{register_ecall, BasicEnclaveEngine};
 use key_vault_ecall_types::cmd::*;
 use key_vault_enclave::{context::KeyVaultEnclaveContext, workflow::*};
+use log::error;
 use std::{ptr, vec::Vec};
 
 #[allow(dead_code)]

--- a/frame/common/src/state_types.rs
+++ b/frame/common/src/state_types.rs
@@ -41,7 +41,7 @@ impl StateType {
 
 impl From<AccountId> for StateType {
     fn from(account_id: AccountId) -> Self {
-        Self(bincode::serialize(&account_id).unwrap())
+        Self(bincode::serialize(&account_id).unwrap()) // must not fail
     }
 }
 

--- a/frame/enclave/src/register.rs
+++ b/frame/enclave/src/register.rs
@@ -7,7 +7,7 @@ macro_rules! register_ecall {
         $(  $(#[$feature: meta])*
             ($cmd: path, $handler: ty),
         )*
-    ) => {
+    ) => {        
         fn ecall_handler(cmd: u32, input: &mut [u8]) -> anyhow::Result<Vec<u8>> {
             match cmd {
                 $(
@@ -63,7 +63,7 @@ macro_rules! register_ecall {
                 match ecall_handler(command, input) {
                     Ok(out) => out,
                     Err(e) => {
-                        println!("Error in enclave (ecall_entry_point): command: {:?}, error: {:?}", command, e);
+                        error!("Error in enclave (ecall_entry_point): command: {:?}, error: {:?}", command, e);
                         return frame_types::EnclaveStatus::error();
                     }
                 }
@@ -73,7 +73,7 @@ macro_rules! register_ecall {
             *output_len = res_len;
 
             if res_len > output_max_len {
-                println!("Result buffer length is over output_max: output_max={}, res_len={}", output_max_len, res_len);
+                error!("Result buffer length is over output_max: output_max={}, res_len={}", output_max_len, res_len);
                 return frame_types::EnclaveStatus::error();
             }
             unsafe {

--- a/frame/enclave/src/register.rs
+++ b/frame/enclave/src/register.rs
@@ -7,7 +7,7 @@ macro_rules! register_ecall {
         $(  $(#[$feature: meta])*
             ($cmd: path, $handler: ty),
         )*
-    ) => {        
+    ) => {
         fn ecall_handler(cmd: u32, input: &mut [u8]) -> anyhow::Result<Vec<u8>> {
             match cmd {
                 $(

--- a/frame/enclave/src/register.rs
+++ b/frame/enclave/src/register.rs
@@ -8,24 +8,27 @@ macro_rules! register_ecall {
             ($cmd: path, $handler: ty),
         )*
     ) => {
-        fn ecall_handler(cmd: u32, input: &mut [u8]) -> anyhow::Result<Vec<u8>> {
+        fn ecall_handler(cmd: u32, input: &mut [u8], ecall_max_size: usize) -> anyhow::Result<Vec<u8>> {
             match cmd {
                 $(
                     $(#[$feature])*
-                    $cmd => inner_ecall_handler::<$handler>(input),
+                    $cmd => inner_ecall_handler::<$handler>(input, ecall_max_size),
                 )*
                 _ => anyhow::bail!("Not registered the ecall command"),
             }
         }
 
         #[cfg(feature = "runtime_enabled")]
-        fn inner_ecall_handler<EE>(input_payload: &[u8]) -> anyhow::Result<Vec<u8>>
+        fn inner_ecall_handler<EE>(input_payload: &[u8], ecall_max_size: usize) -> anyhow::Result<Vec<u8>>
         where
             EE: StateRuntimeEnclaveEngine,
         {
             let res = {
-                let ecall_input = bincode::deserialize(&input_payload[..])
+                let ecall_input = bincode::DefaultOptions::new()
+                    .with_limit(ecall_max_size as u64)
+                    .deserialize(&input_payload[..])
                     .map_err(|e| anyhow!("{:?}", e))?;
+
                 let slf = EE::new::<$ctx_ops>(ecall_input, $ctx)?;
                 EE::eval_policy(&slf)?;
                 EE::handle::<$runtime_exec, $ctx_ops>(slf, $ctx, $max_mem)?
@@ -35,13 +38,16 @@ macro_rules! register_ecall {
         }
 
         #[cfg(not(feature = "runtime_enabled"))]
-        fn inner_ecall_handler<EE>(input_payload: &[u8]) -> anyhow::Result<Vec<u8>>
+        fn inner_ecall_handler<EE>(input_payload: &[u8], ecall_max_size: usize) -> anyhow::Result<Vec<u8>>
         where
             EE: BasicEnclaveEngine,
         {
             let res = {
-                let ecall_input = bincode::deserialize(&input_payload[..])
+                let ecall_input = bincode::DefaultOptions::new()
+                    .with_limit(ecall_max_size as u64)
+                    .deserialize(&input_payload[..])
                     .map_err(|e| anyhow!("{:?}", e))?;
+
                 let slf = EE::new::<$ctx_ops>(ecall_input, $ctx)?;
                 EE::handle::<$ctx_ops>(slf, $ctx)?
             };
@@ -55,12 +61,12 @@ macro_rules! register_ecall {
             input_buf: *mut u8,
             input_len: usize,
             output_buf: *mut u8,
-            output_max_len: usize,
+            ecall_max_size: usize,
             output_len: &mut usize,
         ) -> frame_types::EnclaveStatus {
             let input = unsafe { std::slice::from_raw_parts_mut(input_buf, input_len) };
             let res = unsafe {
-                match ecall_handler(command, input) {
+                match ecall_handler(command, input, ecall_max_size) {
                     Ok(out) => out,
                     Err(e) => {
                         error!("Error in enclave (ecall_entry_point): command: {:?}, error: {:?}", command, e);
@@ -72,8 +78,8 @@ macro_rules! register_ecall {
             let res_len = res.len();
             *output_len = res_len;
 
-            if res_len > output_max_len {
-                error!("Result buffer length is over output_max: output_max={}, res_len={}", output_max_len, res_len);
+            if res_len > ecall_max_size {
+                error!("Result buffer length is over ecall_max_size: ecall_max_size={}, res_len={}", ecall_max_size, res_len);
                 return frame_types::EnclaveStatus::error();
             }
             unsafe {

--- a/frame/host/src/ecalls.rs
+++ b/frame/host/src/ecalls.rs
@@ -5,7 +5,6 @@ use frame_types::EnclaveStatus;
 use serde::{de::DeserializeOwned, Serialize};
 use sgx_types::{sgx_enclave_id_t, sgx_status_t};
 
-
 extern "C" {
     fn ecall_entry_point(
         eid: sgx_enclave_id_t,

--- a/frame/host/src/ecalls.rs
+++ b/frame/host/src/ecalls.rs
@@ -46,9 +46,9 @@ impl EnclaveConnector {
     fn inner_invoke_ecall(&self, cmd: u32, mut input: Vec<u8>) -> Result<Vec<u8>> {
         let input_ptr = input.as_mut_ptr();
         let input_len = input.len();
-        let output_max = self.ecall_max_size;
-        let mut output_len = output_max;
-        let mut output_buf = Vec::with_capacity(output_max);
+        let ecall_max_size = self.ecall_max_size;
+        let mut output_len = ecall_max_size;
+        let mut output_buf = Vec::with_capacity(ecall_max_size);
         let output_ptr = output_buf.as_mut_ptr();
 
         let mut ret = EnclaveStatus::default();
@@ -61,7 +61,7 @@ impl EnclaveConnector {
                 input_ptr,
                 input_len,
                 output_ptr,
-                output_max,
+                ecall_max_size,
                 &mut output_len,
             )
         };
@@ -80,7 +80,7 @@ impl EnclaveConnector {
                 cmd,
             });
         }
-        assert!(output_len < output_max);
+        assert!(output_len < ecall_max_size);
 
         unsafe {
             output_buf.set_len(output_len);

--- a/frame/host/src/engine.rs
+++ b/frame/host/src/engine.rs
@@ -9,12 +9,12 @@ pub trait HostEngine {
     type EI: EcallInput + Serialize;
     type EO: EcallOutput + DeserializeOwned;
     type HO: HostOutput<EcallOutput = Self::EO>;
-    const OUTPUT_MAX_LEN: usize;
+    const ECALL_MAX_SIZE: usize;
 
     fn exec(input: Self::HI, eid: sgx_enclave_id_t) -> anyhow::Result<Self::HO> {
         let ecall_cmd = input.ecall_cmd();
         let (ecall_input, host_output) = input.apply()?;
-        let ecall_output = EnclaveConnector::new(eid, Self::OUTPUT_MAX_LEN)
+        let ecall_output = EnclaveConnector::new(eid, Self::ECALL_MAX_SIZE)
             .invoke_ecall::<Self::EI, Self::EO>(ecall_cmd, ecall_input)?;
 
         host_output.set_ecall_output(ecall_output)

--- a/modules/anonify-eth-driver/src/workflow.rs
+++ b/modules/anonify-eth-driver/src/workflow.rs
@@ -7,7 +7,7 @@ use frame_host::engine::*;
 use frame_sodium::SodiumCiphertext;
 use web3::types::Address;
 
-pub const OUTPUT_MAX_LEN: usize = 2048;
+pub const ECALL_MAX_SIZE: usize = 2048;
 
 pub struct CommandWorkflow;
 
@@ -16,7 +16,7 @@ impl HostEngine for CommandWorkflow {
     type EI = input::Command;
     type EO = output::Command;
     type HO = host_output::Command;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct JoinGroupWorkflow;
@@ -26,7 +26,7 @@ impl HostEngine for JoinGroupWorkflow {
     type EI = input::Empty;
     type EO = output::ReturnJoinGroup;
     type HO = host_output::JoinGroup;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct RegisterReportWorkflow;
@@ -36,7 +36,7 @@ impl HostEngine for RegisterReportWorkflow {
     type EI = input::Empty;
     type EO = output::ReturnRegisterReport;
     type HO = host_output::RegisterReport;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct HandshakeWorkflow;
@@ -46,7 +46,7 @@ impl HostEngine for HandshakeWorkflow {
     type EI = input::Empty;
     type EO = output::ReturnHandshake;
     type HO = host_output::Handshake;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct RegisterNotificationWorkflow;
@@ -56,7 +56,7 @@ impl HostEngine for RegisterNotificationWorkflow {
     type EI = SodiumCiphertext;
     type EO = output::Empty;
     type HO = host_output::RegisterNotification;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct GetStateWorkflow;
@@ -66,7 +66,7 @@ impl HostEngine for GetStateWorkflow {
     type EI = SodiumCiphertext;
     type EO = output::ReturnState;
     type HO = host_output::GetState;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct InsertCiphertextWorkflow;
@@ -76,7 +76,7 @@ impl HostEngine for InsertCiphertextWorkflow {
     type EI = input::InsertCiphertext;
     type EO = output::ReturnNotifyState;
     type HO = host_output::InsertCiphertext;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct InsertHandshakeWorkflow;
@@ -86,7 +86,7 @@ impl HostEngine for InsertHandshakeWorkflow {
     type EI = input::InsertHandshake;
     type EO = output::Empty;
     type HO = host_output::InsertHandshake;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct GetEncryptionKeyWorkflow;
@@ -96,7 +96,7 @@ impl HostEngine for GetEncryptionKeyWorkflow {
     type EI = input::Empty;
     type EO = output::ReturnEncryptionKey;
     type HO = host_output::ReturnEncryptionKey;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct BackupPathSecretAllWorkflow;
@@ -106,7 +106,7 @@ impl HostEngine for BackupPathSecretAllWorkflow {
     type EI = input::Empty;
     type EO = output::Empty;
     type HO = host_output::BackupPathSecretAll;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct RecoverPathSecretAllWorkflow;
@@ -116,7 +116,7 @@ impl HostEngine for RecoverPathSecretAllWorkflow {
     type EI = input::Empty;
     type EO = output::Empty;
     type HO = host_output::RecoverPathSecretAll;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct GetUserCounterWorkflow;
@@ -126,7 +126,7 @@ impl HostEngine for GetUserCounterWorkflow {
     type EI = SodiumCiphertext;
     type EO = output::ReturnUserCounter;
     type HO = host_output::GetUserCounter;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub mod host_input {

--- a/modules/key-vault-host/src/workflow.rs
+++ b/modules/key-vault-host/src/workflow.rs
@@ -1,7 +1,7 @@
 use frame_host::engine::*;
 use key_vault_ecall_types::*;
 
-pub const ECALL_MAX_SIZE: usize = 1_048_576;
+pub const ECALL_MAX_SIZE: usize = 2048;
 
 pub struct StartServerWorkflow;
 

--- a/modules/key-vault-host/src/workflow.rs
+++ b/modules/key-vault-host/src/workflow.rs
@@ -1,7 +1,7 @@
 use frame_host::engine::*;
 use key_vault_ecall_types::*;
 
-pub const ECALL_MAX_SIZE: usize = 2048;
+pub const ECALL_MAX_SIZE: usize = 1_048_576;
 
 pub struct StartServerWorkflow;
 

--- a/modules/key-vault-host/src/workflow.rs
+++ b/modules/key-vault-host/src/workflow.rs
@@ -1,7 +1,7 @@
 use frame_host::engine::*;
 use key_vault_ecall_types::*;
 
-pub const OUTPUT_MAX_LEN: usize = 2048;
+pub const ECALL_MAX_SIZE: usize = 2048;
 
 pub struct StartServerWorkflow;
 
@@ -10,7 +10,7 @@ impl HostEngine for StartServerWorkflow {
     type EI = input::CallServerStarter;
     type EO = output::Empty;
     type HO = host_output::StartServer;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub struct StopServerWorkflow;
@@ -20,7 +20,7 @@ impl HostEngine for StopServerWorkflow {
     type EI = input::CallServerStopper;
     type EO = output::Empty;
     type HO = host_output::StopServer;
-    const OUTPUT_MAX_LEN: usize = OUTPUT_MAX_LEN;
+    const ECALL_MAX_SIZE: usize = ECALL_MAX_SIZE;
 }
 
 pub mod host_input {


### PR DESCRIPTION
## Issueへのリンク

* https://github.com/LayerXcom/anonify/issues/463

## やったこと

ホストから任意長のデータサイズをecallのバッファに許可してしまうとプロセスが落ちる。 serialize時にバイト数を制限し、エラーハンドリングを実施。

```rust
let input_payload = bincode::DefaultOptions::new()
            .with_limit(self.ecall_max_size as u64)
            .serialize(&input)?;
```

## やらないこと


## 動作検証

## 参考
