### PR TITLE
fix Makefile

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -135,6 +135,7 @@ $(ANONIFY_BUILD_DIR)/$(T_O_FILE): $(Enclave_EDL_Files)
 	@$(CC) $(RustEnclave_Compile_Flags) -c $(ANONIFY_BUILD_DIR)/$(T_C_FILE) -o $(ANONIFY_BUILD_DIR)/$(T_O_FILE)
 	@echo "CC   <=  $(ANONIFY_BUILD_DIR)/$(T_C_FILE) with $(ANONIFY_BUILD_DIR)/$(T_O_FILE)"
 
+# cargo build also generates frame-types.h
 $(Lib_Enclave): $(Rust_Enclave_Files)
 	@echo "Lib_Enclave <= $(PWD)"
 	@cd $(ANONIFY_ROOT_DIR)/$(ENCLAVE_DIR) && RUST_LOG=debug cargo build $(CARGO_FLAGS) $(RustEnclave_Feature_Flags)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,10 +1,6 @@
 SGX_SDK_RUST ?= $(HOME)/sgx
 ANONIFY_ROOT_DIR := ..
-ANONIFY_CORE_ROOT := $(ANONIFY_ROOT_DIR)/core
-FRAME_ROOT := $(ANONIFY_ROOT_DIR)/frame
 CONFIG_DIR := $(ANONIFY_ROOT_DIR)/config
-ANONIFY_ENCLAVE_DIR := $(ANONIFY_CORE_ROOT)/enclave
-ANONIFY_HOST_DIR := $(ANONIFY_CORE_ROOT)/host
 ANONIFY_BIN_DIR := $(ANONIFY_ROOT_DIR)/.anonify
 ANONIFY_EDL_DIR := $(ANONIFY_ROOT_DIR)/edl
 ANONIFY_BUILD_DIR := $(ANONIFY_ROOT_DIR)/build
@@ -84,7 +80,7 @@ CUSTOM_COMMON_PATH := $(SGX_SDK_RUST)/common
 
 ######## EDL Settings ########
 
-Enclave_EDL_Files := $(ANONIFY_ENCLAVE_DIR)/$(T_C_FILE) $(ANONIFY_ENCLAVE_DIR)/$(T_H_FILE) $(ANONIFY_HOST_DIR)/$(U_C_FILE) $(ANONIFY_HOST_DIR)/$(U_H_FILE)
+Enclave_EDL_Files := $(ANONIFY_BUILD_DIR)/$(T_C_FILE) $(ANONIFY_BUILD_DIR)/$(T_H_FILE) $(ANONIFY_BUILD_DIR)/$(U_C_FILE) $(ANONIFY_BUILD_DIR)/$(U_H_FILE)
 
 ######## Enclave Settings ########
 
@@ -107,8 +103,7 @@ else
 	RustEnclave_Feature_Flags := $(FEATURE_FLAGS)
 endif
 
-
-RustEnclave_Include_Paths := -I$(CUSTOM_COMMON_PATH)/inc -I$(CUSTOM_EDL_PATH) -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/stlport -I$(SGX_SDK)/include/epid -I $(ANONIFY_ENCLAVE_DIR) -I./include
+RustEnclave_Include_Paths := -I$(CUSTOM_COMMON_PATH)/inc -I$(CUSTOM_EDL_PATH) -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/stlport -I$(SGX_SDK)/include/epid -I./include
 RustEnclave_Link_Libs := -L$(CUSTOM_LIBRARY_PATH) -l$(Rust_Enclave_Lib_Name)
 RustEnclave_Compile_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fstack-protector $(RustEnclave_Include_Paths)
 RustEnclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_LIBRARY_PATH) \
@@ -132,13 +127,13 @@ $(Enclave_EDL_Files): $(SGX_EDGER8R) $(ANONIFY_EDL_DIR)/$(EDL_FILE)
 	@mkdir -p $(ANONIFY_BUILD_DIR)
 	@$(SGX_EDGER8R) --trusted $(ANONIFY_EDL_DIR)/$(EDL_FILE) --search-path $(SGX_SDK)/include --search-path $(CUSTOM_EDL_PATH) --trusted-dir $(ANONIFY_BUILD_DIR)
 	@$(SGX_EDGER8R) --untrusted $(ANONIFY_EDL_DIR)/$(EDL_FILE) --search-path $(SGX_SDK)/include --search-path $(CUSTOM_EDL_PATH) --untrusted-dir $(ANONIFY_BUILD_DIR)
-	@echo "GEN  =>  $(Enclave_EDL_Files)"
+	@echo "GEN  =>  $@"
 
 ######## Enclave Objects ########
 
 $(ANONIFY_BUILD_DIR)/$(T_O_FILE): $(Enclave_EDL_Files)
 	@$(CC) $(RustEnclave_Compile_Flags) -c $(ANONIFY_BUILD_DIR)/$(T_C_FILE) -o $(ANONIFY_BUILD_DIR)/$(T_O_FILE)
-	@echo "CC   <=  $<"
+	@echo "CC   <=  $(ANONIFY_BUILD_DIR)/$(T_C_FILE) with $(ANONIFY_BUILD_DIR)/$(T_O_FILE)"
 
 $(Rust_Enclave_Name): $(Rust_Enclave_Files)
 	@echo "Rust_Enclave_Name <= $(PWD)"

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -93,8 +93,8 @@ else
 endif
 Crypto_Library_Name := sgx_tcrypto
 
-RustEnclave_Name := $(ANONIFY_BUILD_DIR)/$(ENCLAVE_PKG_NAME).enclave.so
-Signed_RustEnclave_Name := $(ANONIFY_BIN_DIR)/$(ENCLAVE_PKG_NAME).signed.so
+Enclave_SO := $(ANONIFY_BUILD_DIR)/$(ENCLAVE_PKG_NAME).enclave.so
+Signed_Enclave_SO := $(ANONIFY_BIN_DIR)/$(ENCLAVE_PKG_NAME).signed.so
 Measurement_File_Name := $(ENCLAVE_PKG_NAME)_measurement.txt
 Rust_Enclave_Lib_Name := $(ENCLAVE_PKG_NAME)enclave
 ifdef FEATURE_FLAGS
@@ -119,7 +119,7 @@ Rust_Enclave_Name := lib$(Rust_Enclave_Lib_Name).a
 Rust_Enclave_Files := $(wildcard src/*.rs)
 
 .PHONY: all
-all: $(Signed_RustEnclave_Name)
+all: $(Signed_Enclave_SO)
 
 ######## EDL Objects ########
 
@@ -127,7 +127,7 @@ $(Enclave_EDL_Files): $(SGX_EDGER8R) $(ANONIFY_EDL_DIR)/$(EDL_FILE)
 	@mkdir -p $(ANONIFY_BUILD_DIR)
 	@$(SGX_EDGER8R) --trusted $(ANONIFY_EDL_DIR)/$(EDL_FILE) --search-path $(SGX_SDK)/include --search-path $(CUSTOM_EDL_PATH) --trusted-dir $(ANONIFY_BUILD_DIR)
 	@$(SGX_EDGER8R) --untrusted $(ANONIFY_EDL_DIR)/$(EDL_FILE) --search-path $(SGX_SDK)/include --search-path $(CUSTOM_EDL_PATH) --untrusted-dir $(ANONIFY_BUILD_DIR)
-	@echo "GEN  =>  $@"
+	@echo "GEN  =>  $(Enclave_EDL_Files)"
 
 ######## Enclave Objects ########
 
@@ -141,24 +141,24 @@ $(Rust_Enclave_Name): $(Rust_Enclave_Files)
 	@mkdir -p $(CUSTOM_LIBRARY_PATH)
 	@cp $(ANONIFY_ROOT_DIR)/target/$(Rust_target_dir)/libanonifyenclave.a $(CUSTOM_LIBRARY_PATH)/lib$(Rust_Enclave_Lib_Name).a
 
-$(RustEnclave_Name): $(ANONIFY_BUILD_DIR)/$(T_O_FILE) $(Rust_Enclave_Name)
+$(Enclave_SO): $(ANONIFY_BUILD_DIR)/$(T_O_FILE) $(Rust_Enclave_Name)
 	@$(CXX) $(ANONIFY_BUILD_DIR)/$(T_O_FILE) -o $@ $(RustEnclave_Link_Flags)
 	@echo "LINK =>  $@"
 
-$(Signed_RustEnclave_Name): $(RustEnclave_Name)
+$(Signed_Enclave_SO): $(Enclave_SO)
 	@mkdir -p $(ANONIFY_BIN_DIR)
-	@$(SGX_ENCLAVE_SIGNER) sign -key $(CONFIG_DIR)/test_enclave_signing.pem -enclave $(RustEnclave_Name) -out $@ -config $(CONFIG_DIR)/$(Enclave_Config_File_Name) -dumpfile $(ANONIFY_BIN_DIR)/$(Measurement_File_Name)
+	@$(SGX_ENCLAVE_SIGNER) sign -key $(CONFIG_DIR)/test_enclave_signing.pem -enclave $(Enclave_SO) -out $@ -config $(CONFIG_DIR)/$(Enclave_Config_File_Name) -dumpfile $(ANONIFY_BIN_DIR)/$(Measurement_File_Name)
 	@echo "SIGN =>  $@"
 
 # Based on the 2-step signing process
-prd-signed.so: $(RustEnclave_Name)
+prd-signed.so: $(Enclave_SO)
 	@mkdir -p $(ANONIFY_BIN_DIR)
-	@$(SGX_ENCLAVE_SIGNER) gendata -enclave $(RustEnclave_Name) -config $(CONFIG_DIR)/$(Enclave_Config_File_Name) -out $(ANONIFY_BIN_DIR)/$(ENCLAVE_PKG_NAME).dat
+	@$(SGX_ENCLAVE_SIGNER) gendata -enclave $(Enclave_SO) -config $(CONFIG_DIR)/$(Enclave_Config_File_Name) -out $(ANONIFY_BIN_DIR)/$(ENCLAVE_PKG_NAME).dat
 	@python3 $(ANONIFY_ROOT_DIR)/scripts/req_sign_to_azkv.py $(ENCLAVE_PKG_NAME)
 	@$(SGX_ENCLAVE_SIGNER) catsig \
-		-enclave $(RustEnclave_Name) \
+		-enclave $(Enclave_SO) \
 		-config $(CONFIG_DIR)/$(Enclave_Config_File_Name) \
-		-out $(Signed_RustEnclave_Name) \
+		-out $(Signed_Enclave_SO) \
 		-key $(CONFIG_DIR)/enclave_pub.pem \
 		-sig $(ANONIFY_BIN_DIR)/$(ENCLAVE_PKG_NAME)_signed.dat \
 		-unsigned $(ANONIFY_BIN_DIR)/$(ENCLAVE_PKG_NAME).dat \

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -96,7 +96,7 @@ Crypto_Library_Name := sgx_tcrypto
 Enclave_SO := $(ANONIFY_BUILD_DIR)/$(ENCLAVE_PKG_NAME).enclave.so
 Signed_Enclave_SO := $(ANONIFY_BIN_DIR)/$(ENCLAVE_PKG_NAME).signed.so
 Measurement_File_Name := $(ENCLAVE_PKG_NAME)_measurement.txt
-Rust_Enclave_Lib_Name := $(ENCLAVE_PKG_NAME)enclave
+Lib_Enclave_Name := $(ENCLAVE_PKG_NAME)enclave
 ifdef FEATURE_FLAGS
 	RustEnclave_Feature_Flags := --no-default-features --features $(FEATURE_FLAGS)
 else
@@ -104,7 +104,7 @@ else
 endif
 
 RustEnclave_Include_Paths := -I$(CUSTOM_COMMON_PATH)/inc -I$(CUSTOM_EDL_PATH) -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/stlport -I$(SGX_SDK)/include/epid -I./include
-RustEnclave_Link_Libs := -L$(CUSTOM_LIBRARY_PATH) -l$(Rust_Enclave_Lib_Name)
+RustEnclave_Link_Libs := -L$(CUSTOM_LIBRARY_PATH) -l$(Lib_Enclave_Name)
 RustEnclave_Compile_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fstack-protector $(RustEnclave_Include_Paths)
 RustEnclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_LIBRARY_PATH) \
 	-Wl,--whole-archive -l$(Trts_Library_Name) -Wl,--no-whole-archive \
@@ -114,7 +114,7 @@ RustEnclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nod
 	-Wl,--defsym,__ImageBase=0 \
 	-Wl,--gc-sections \
 	-Wl,--version-script=$(CONFIG_DIR)/Enclave.lds
-Rust_Enclave_Name := lib$(Rust_Enclave_Lib_Name).a
+Lib_Enclave := lib$(Lib_Enclave_Name).a
 
 Rust_Enclave_Files := $(wildcard src/*.rs)
 
@@ -135,13 +135,13 @@ $(ANONIFY_BUILD_DIR)/$(T_O_FILE): $(Enclave_EDL_Files)
 	@$(CC) $(RustEnclave_Compile_Flags) -c $(ANONIFY_BUILD_DIR)/$(T_C_FILE) -o $(ANONIFY_BUILD_DIR)/$(T_O_FILE)
 	@echo "CC   <=  $(ANONIFY_BUILD_DIR)/$(T_C_FILE) with $(ANONIFY_BUILD_DIR)/$(T_O_FILE)"
 
-$(Rust_Enclave_Name): $(Rust_Enclave_Files)
-	@echo "Rust_Enclave_Name <= $(PWD)"
+$(Lib_Enclave): $(Rust_Enclave_Files)
+	@echo "Lib_Enclave <= $(PWD)"
 	@cd $(ANONIFY_ROOT_DIR)/$(ENCLAVE_DIR) && RUST_LOG=debug cargo build $(CARGO_FLAGS) $(RustEnclave_Feature_Flags)
 	@mkdir -p $(CUSTOM_LIBRARY_PATH)
-	@cp $(ANONIFY_ROOT_DIR)/target/$(Rust_target_dir)/libanonifyenclave.a $(CUSTOM_LIBRARY_PATH)/lib$(Rust_Enclave_Lib_Name).a
+	@cp $(ANONIFY_ROOT_DIR)/target/$(Rust_target_dir)/libanonifyenclave.a $(CUSTOM_LIBRARY_PATH)/lib$(Lib_Enclave_Name).a
 
-$(Enclave_SO): $(ANONIFY_BUILD_DIR)/$(T_O_FILE) $(Rust_Enclave_Name)
+$(Enclave_SO): $(ANONIFY_BUILD_DIR)/$(T_O_FILE) $(Lib_Enclave)
 	@$(CXX) $(ANONIFY_BUILD_DIR)/$(T_O_FILE) -o $@ $(RustEnclave_Link_Flags)
 	@echo "LINK =>  $@"
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -131,7 +131,7 @@ $(Enclave_EDL_Files): $(SGX_EDGER8R) $(ANONIFY_EDL_DIR)/$(EDL_FILE)
 
 ######## Enclave Objects ########
 
-$(ANONIFY_BUILD_DIR)/$(T_O_FILE): $(Enclave_EDL_Files)
+$(ANONIFY_BUILD_DIR)/$(T_O_FILE): $(Lib_Enclave) $(Enclave_EDL_Files)
 	@$(CC) $(RustEnclave_Compile_Flags) -c $(ANONIFY_BUILD_DIR)/$(T_C_FILE) -o $(ANONIFY_BUILD_DIR)/$(T_O_FILE)
 	@echo "CC   <=  $(ANONIFY_BUILD_DIR)/$(T_C_FILE) with $(ANONIFY_BUILD_DIR)/$(T_O_FILE)"
 
@@ -142,7 +142,7 @@ $(Lib_Enclave): $(Rust_Enclave_Files)
 	@mkdir -p $(CUSTOM_LIBRARY_PATH)
 	@cp $(ANONIFY_ROOT_DIR)/target/$(Rust_target_dir)/libanonifyenclave.a $(CUSTOM_LIBRARY_PATH)/lib$(Lib_Enclave_Name).a
 
-$(Enclave_SO): $(ANONIFY_BUILD_DIR)/$(T_O_FILE) $(Lib_Enclave)
+$(Enclave_SO): $(ANONIFY_BUILD_DIR)/$(T_O_FILE)
 	@$(CXX) $(ANONIFY_BUILD_DIR)/$(T_O_FILE) -o $@ $(RustEnclave_Link_Flags)
 	@echo "LINK =>  $@"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -37,15 +37,11 @@ solc -o contract-build --bin --abi --optimize --overwrite \
 cd ${ANONIFY_ROOT}/anonify-contracts/deployer
 export FACTORY_CONTRACT_ADDRESS=$(cargo run factory)
 
-cd ${ANONIFY_ROOT}/frame/types
-cargo build
-
 # Generate key-vault's signed.so and measurement.txt
 echo "Integration testing..."
 cd ${ANONIFY_ROOT}/scripts
 export ENCLAVE_PKG_NAME=key_vault
 make DEBUG=1 ENCLAVE_DIR=example/key-vault/enclave
-
 
 #
 # Lints checks


### PR DESCRIPTION
## Issueへのリンク

* なし

## やったこと

* unused variablesの削除
* targetとする生成物が、変数名からわかるようにrename
* 標準出力と生成ファイルが一致するよう修正
* 依存関係の整理

## やらないこと

* なし

## 動作検証

* CI
* `prd-signed.so`を含んだ検証として`example-erc20.Dockerfile`がdocker buildできることを手動で確認

## 参考

依存関係の整理について補足です。
処理の中で必要なものが`:`の右に来るようにしています。
例外は`T_O_FILE`の生成で、処理で明示される`T_C_FILE`が`Enclave_EDL_Files`の最初の値というのがトリッキーです。
これは標準出力と生成ファイルが一致するようにする方針を優先して例外としています。