### PR TITLE
feat: fixuidの遅さ・使い勝手改善

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -55,8 +55,8 @@ CMD_DEC_SECRET_DIR=.anonify/cmd-dec-secret
 # Set `disable`, if you don't want to connect to the key_vault node
 BACKUP=
 PJ_ROOT_DIR=/home/anonify-dev/anonify
-# fixuid is used to fix volume-mounted files' ownership in Docker Linux. Set `1` in macOS.
-DISABLE_FIXUID=0
+# fixuid is used to fix volume-mounted files' ownership in Docker Linux. Set `skip` in macOS. `quiet` and `verbose` are also available.
+FIXUID_MODE=skip
 
 
 

--- a/docker/base-rust-sgx-sdk-rootless.Dockerfile
+++ b/docker/base-rust-sgx-sdk-rootless.Dockerfile
@@ -25,7 +25,7 @@ RUN USER=${user_name} && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/$USER\n  - /home/$USER/anonify" > /etc/fixuid/config.yml
 
 # Switch to the non-root
 USER ${user_name}

--- a/docker/entrypoint/fixuid.bash
+++ b/docker/entrypoint/fixuid.bash
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-if [ "$DISABLE_FIXUID" = 1 ]; then
+FIXUID_MODE=${FIXUID_MODE:-quiet}
+
+if [ "$FIXUID_MODE" = "skip" ]; then
   echo 'skip fixuid'
-else
+elif [ "$FIXUID_MODE" = "quiet" ]; then
   echo 'Running fixuid. Wait a while...'
   fixuid -q
+elif [ "$FIXUID_MODE" = "verbose" ]; then
+  fixuid
+else
+  echo "\$FIXUID_MODE='$FIXUID_MODE', which should be one of: 'skip', 'verbose', and 'quiet' (default)."
 fi
 
 bash


### PR DESCRIPTION
## Issueへのリンク

（なし）

## やったこと

fixuid が遅すぎること（[20分たっても完了しなかった例](https://dev.azure.com/osukesudo/Anonify/_build/results?buildId=1901&view=logs&j=c3a[…]-53c8-4801-c97d6d711cc0&t=5a7e4c1e-bc5c-5f38-dfcb-a0ac47d5b0f3)）に端を発し、

- `/home/anonify-dev/` 以下のみを chown 対象にすることで若干の高速化（とはいえこれだけではまだまだ遅いこと把握してる）
- `FIXUID_MODE=verbose` を新設し、遅くてもせめて「何のchownが進行しているか」がわかるようにした

## やらないこと

本当に必要なレベルの高速化。もしかしたら chown する機能は fixuid に頼らず `chown -R ~/` とかするようにしたほうがいいのかもしれないと考えてる 🤔 

## 動作検証

```bash
docker build -t anonify.azurecr.io/rust-sgx-sdk-rootless:latest --file docker/base-rust-sgx-sdk-rootless.Dockerfile .

# (.envファイルの `FIXUID_MODE` を色々書き換え)

docker run  --env-file .env -u `id -u`:`id -g` -v `pwd`:/home/anonify-dev/anonify --rm -it anonify.azurecr.io/rust-sgx-sdk-rootless:latest
```

これで `skip`, `quiet`, `verbose` のモードが期待通りに動くことと、 `skippp` のような無効なパラメータを渡すと警告が出ること確認。

## 参考

（なし）
