### PR TITLE
fix: ENTRYPOINT においてインタラクティブシェルを立ち上げていたので、`docker run` の最終引数のコマンドや、 `docker-compose exec` の際のyamlの `command:` が実行されていなかった

### DIFF
--- a/docker/base-anonify-dev.Dockerfile
+++ b/docker/base-anonify-dev.Dockerfile
@@ -11,3 +11,5 @@ RUN set -x && \
     sudo chmod 755 /usr/bin/solc
 
 RUN git clone --depth 1 -b v1.1.3 https://github.com/baidu/rust-sgx-sdk.git sgx
+
+CMD ["bash"]

--- a/docker/base-rust-sgx-sdk-rootless.Dockerfile
+++ b/docker/base-rust-sgx-sdk-rootless.Dockerfile
@@ -48,3 +48,4 @@ RUN rustup component add rust-src rls rust-analysis clippy rustfmt && \
 
 COPY ./docker/entrypoint/fixuid.bash ./
 ENTRYPOINT ["./fixuid.bash"]
+CMD ["bash"]

--- a/docker/entrypoint/fixuid.bash
+++ b/docker/entrypoint/fixuid.bash
@@ -13,4 +13,4 @@ else
   echo "\$FIXUID_MODE='$FIXUID_MODE', which should be one of: 'skip', 'verbose', and 'quiet' (default)."
 fi
 
-bash
+exec "$@"


### PR DESCRIPTION
## Issueへのリンク

（なし）

## やったこと

```bash
docker run -it anonify.azurecr.io/rust-sgx-sdk-rootless:latest bash -c 'echo hi'
```

など実行しても、 ( `-it` パラメータありなら）インタラクティブシェルログインされるだけで、echoの実行がされない問題があった。

デフォルトでbashなインタラクティブシェルログインされる挙動は残しつつ、コマンドを自由に上書きできるように修正。

## やらないこと

（なし）

## 動作検証

上述のコマンドなど

## 参考

https://docs.docker.jp/engine/reference/builder.html#exec-entrypoint このへんでも紹介されてるテクです。

![image](https://user-images.githubusercontent.com/498788/120624588-ce986180-c49b-11eb-93c7-fed3f0ad8920.png)

