### PR TITLE
ci: E2Eテストが壊れていたので修正

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,113 +54,113 @@ stages:
 #         #   condition: always()
 #         #   displayName: 'occlum docker-compose down'
 
-- stage:
-  condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
-  jobs:
-  - job: E2E
-    pool:
-      name: 'AnonifyAgent'
-    steps:
-      - task: Docker@2
-        displayName: Build erc20 image
-        inputs:
-          command: build
-          containerRegistry: anonify-ci-cd-acr
-          repository: erc20-state-runtime
-          tags: latest
-          dockerfile: ./docker/example-erc20.Dockerfile
-          buildContext: .
-          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-      - task: Docker@2
-        displayName: Build key-vault for erc20 image
-        inputs:
-          command: build
-          containerRegistry: anonify-ci-cd-acr
-          repository: key-vault-for-erc20
-          tags: latest
-          dockerfile: ./docker/example-keyvault.Dockerfile
-          buildContext: .
-          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-      - script: |
-          export SPID=$(SPID)
-          export SUB_KEY=$(SUB_KEY)
-          ./scripts/e2e-test.sh
-        displayName: 'Run E2E tests'
-      - script: docker image prune -f
-        displayName: Remove dangling images
-      - script: docker-compose -f e2e-docker-compose.yml down
-        condition: always()
-        displayName: 'Shutdown'
+# - stage:
+#   condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
+#   jobs:
+#   - job: E2E
+#     pool:
+#       name: 'AnonifyAgent'
+#     steps:
+#       - task: Docker@2
+#         displayName: Build erc20 image
+#         inputs:
+#           command: build
+#           containerRegistry: anonify-ci-cd-acr
+#           repository: erc20-state-runtime
+#           tags: latest
+#           dockerfile: ./docker/example-erc20.Dockerfile
+#           buildContext: .
+#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#       - task: Docker@2
+#         displayName: Build key-vault for erc20 image
+#         inputs:
+#           command: build
+#           containerRegistry: anonify-ci-cd-acr
+#           repository: key-vault-for-erc20
+#           tags: latest
+#           dockerfile: ./docker/example-keyvault.Dockerfile
+#           buildContext: .
+#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#       - script: |
+#           export SPID=$(SPID)
+#           export SUB_KEY=$(SUB_KEY)
+#           ./scripts/e2e-test.sh
+#         displayName: 'Run E2E tests'
+#       - script: docker image prune -f
+#         displayName: Remove dangling images
+#       - script: docker-compose -f e2e-docker-compose.yml down
+#         condition: always()
+#         displayName: 'Shutdown'
 
-- stage: Build_and_Push_Base_Docker_Images
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-  jobs:
-  - job: Docker
-    pool:
-      name: 'AnonifyAgent'
-    steps:
-    - task: Docker@2
-      displayName: Build rust-sgx-sdk-rootless image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: rust-sgx-sdk-rootless
-        tags: latest
-        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push rust-sgx-sdk-rootless image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: rust-sgx-sdk-rootless
-        tags: latest
-        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-        buildContext: .
+# - stage: Build_and_Push_Base_Docker_Images
+#   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+#   jobs:
+#   - job: Docker
+#     pool:
+#       name: 'AnonifyAgent'
+#     steps:
+#     - task: Docker@2
+#       displayName: Build rust-sgx-sdk-rootless image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: rust-sgx-sdk-rootless
+#         tags: latest
+#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push rust-sgx-sdk-rootless image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: rust-sgx-sdk-rootless
+#         tags: latest
+#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+#         buildContext: .
 
-    - task: Docker@2
-      displayName: Build anonify-dev image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push anonify-dev image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev.Dockerfile
-        buildContext: .
+#     - task: Docker@2
+#       displayName: Build anonify-dev image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push anonify-dev image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev.Dockerfile
+#         buildContext: .
 
-    - task: Docker@2
-      displayName: Build anonify-dev-pgx image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev-pgx
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push anonify-dev-pgx image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev-pgx
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-        buildContext: .
+#     - task: Docker@2
+#       displayName: Build anonify-dev-pgx image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev-pgx
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push anonify-dev-pgx image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev-pgx
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+#         buildContext: .
 
-    - script: docker image prune -f
-      displayName: Remove dangling images
+#     - script: docker image prune -f
+#       displayName: Remove dangling images
 
 - stage: Build_and_Push_Example_Docker
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
   - job: Docker
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,43 +54,43 @@ stages:
 #         #   condition: always()
 #         #   displayName: 'occlum docker-compose down'
 
-# - stage:
-#   condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
-#   jobs:
-#   - job: E2E
-#     pool:
-#       name: 'AnonifyAgent'
-#     steps:
-#       - task: Docker@2
-#         displayName: Build erc20 image
-#         inputs:
-#           command: build
-#           containerRegistry: anonify-ci-cd-acr
-#           repository: erc20-state-runtime
-#           tags: latest
-#           dockerfile: ./docker/example-erc20.Dockerfile
-#           buildContext: .
-#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#       - task: Docker@2
-#         displayName: Build key-vault for erc20 image
-#         inputs:
-#           command: build
-#           containerRegistry: anonify-ci-cd-acr
-#           repository: key-vault-for-erc20
-#           tags: latest
-#           dockerfile: ./docker/example-keyvault.Dockerfile
-#           buildContext: .
-#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#       - script: |
-#           export SPID=$(SPID)
-#           export SUB_KEY=$(SUB_KEY)
-#           ./scripts/e2e-test.sh
-#         displayName: 'Run E2E tests'
-#       - script: docker image prune -f
-#         displayName: Remove dangling images
-#       - script: docker-compose -f e2e-docker-compose.yml down
-#         condition: always()
-#         displayName: 'Shutdown'
+- stage:
+  condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
+  jobs:
+  - job: E2E
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+      - task: Docker@2
+        displayName: Build erc20 image
+        inputs:
+          command: build
+          containerRegistry: anonify-ci-cd-acr
+          repository: erc20-state-runtime
+          tags: latest
+          dockerfile: ./docker/example-erc20.Dockerfile
+          buildContext: .
+          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+      - task: Docker@2
+        displayName: Build key-vault for erc20 image
+        inputs:
+          command: build
+          containerRegistry: anonify-ci-cd-acr
+          repository: key-vault-for-erc20
+          tags: latest
+          dockerfile: ./docker/example-keyvault.Dockerfile
+          buildContext: .
+          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+      - script: |
+          export SPID=$(SPID)
+          export SUB_KEY=$(SUB_KEY)
+          ./scripts/e2e-test.sh
+        displayName: 'Run E2E tests'
+      - script: docker image prune -f
+        displayName: Remove dangling images
+      - script: docker-compose -f e2e-docker-compose.yml down
+        condition: always()
+        displayName: 'Shutdown'
 
 # - stage: Build_and_Push_Base_Docker_Images
 #   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,57 +2,57 @@ trigger:
 - main
 
 stages:
-# - stage: Test
-#   condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
-#   jobs:
-#     - job: CI
-#       pool:
-#         name: 'AnonifyAgent'
-#       steps:
-#         - script: |
-#             cp .env.sample .env
-#             export SPID=$(SPID)
-#             export SUB_KEY=$(SUB_KEY)
+- stage: Test
+  condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+  jobs:
+    - job: CI
+      pool:
+        name: 'AnonifyAgent'
+      steps:
+        - script: |
+            cp .env.sample .env
+            export SPID=$(SPID)
+            export SUB_KEY=$(SUB_KEY)
 
-#             # TODO: Workaround for duplicate aesm service
-#             # Remove here once https://github.com/occlum/occlum/pull/443 merged.
-#             docker-compose up -d
-#             docker-compose exec -T sgx_machine bash -c "sudo chown -R anonify-dev:anonify-dev anonify ; cd anonify && ./scripts/test.sh"
-#           displayName: 'Run rust-sgx-sdk tests'
-#         - script: docker-compose down
-#           condition: always()
-#           displayName: 'rust-sgx-sdk docker-compose down'
+            # TODO: Workaround for duplicate aesm service
+            # Remove here once https://github.com/occlum/occlum/pull/443 merged.
+            docker-compose up -d
+            docker-compose exec -T sgx_machine bash -c "sudo chown -R anonify-dev:anonify-dev anonify ; cd anonify && ./scripts/test.sh"
+          displayName: 'Run rust-sgx-sdk tests'
+        - script: docker-compose down
+          condition: always()
+          displayName: 'rust-sgx-sdk docker-compose down'
 
-#         - script: |
-#             cp .env.sample .env
-#             export SPID=$(SPID)
-#             export SUB_KEY=$(SUB_KEY)
+        - script: |
+            cp .env.sample .env
+            export SPID=$(SPID)
+            export SUB_KEY=$(SUB_KEY)
 
-#             docker-compose -f pgx-docker-compose.yml up -d
-#             docker-compose -f pgx-docker-compose.yml exec -T sgx_machine_pgx bash -c "cd anonify && ./scripts/encrypted-sql-ops-pg-test.sh"
-#           displayName: 'Run encrypted-sql-ops-pg integration tests'
-#         - script: docker-compose -f pgx-docker-compose.yml down
-#           condition: always()
-#           displayName: 'pgx docker-compose down'
+            docker-compose -f pgx-docker-compose.yml up -d
+            docker-compose -f pgx-docker-compose.yml exec -T sgx_machine_pgx bash -c "cd anonify && ./scripts/encrypted-sql-ops-pg-test.sh"
+          displayName: 'Run encrypted-sql-ops-pg integration tests'
+        - script: docker-compose -f pgx-docker-compose.yml down
+          condition: always()
+          displayName: 'pgx docker-compose down'
 
-#         # NOTE: temporary removed: Add once occlum version bump up to 0.23.0
-#         # - script: |
-#         #     cp .env.sample .env
-#         #     export SPID=$(SPID)
-#         #     export SUB_KEY=$(SUB_KEY)
-#         #     docker-compose -f occlum-docker-compose.yml up -d
+        # NOTE: temporary removed: Add once occlum version bump up to 0.23.0
+        # - script: |
+        #     cp .env.sample .env
+        #     export SPID=$(SPID)
+        #     export SUB_KEY=$(SUB_KEY)
+        #     docker-compose -f occlum-docker-compose.yml up -d
 
-#         #     # TODO: Remove the dettached mode flag once the enclave runs as the embedded mode.
-#         #     docker-compose -f occlum-docker-compose.yml exec -d -T enclave bash -c "./anonify/scripts/occlum-enclave-test.sh"
-#         #     docker-compose -f occlum-docker-compose.yml exec -T host bash -c "./anonify/scripts/occlum-host-test.sh"
-#         #   displayName: 'Run occlum tests'
-#         # - script: |
-#         #     sudo systemctl restart aesmd
-#         #     LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service
+        #     # TODO: Remove the dettached mode flag once the enclave runs as the embedded mode.
+        #     docker-compose -f occlum-docker-compose.yml exec -d -T enclave bash -c "./anonify/scripts/occlum-enclave-test.sh"
+        #     docker-compose -f occlum-docker-compose.yml exec -T host bash -c "./anonify/scripts/occlum-host-test.sh"
+        #   displayName: 'Run occlum tests'
+        # - script: |
+        #     sudo systemctl restart aesmd
+        #     LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service
 
-#         #     docker-compose -f occlum-docker-compose.yml down
-#         #   condition: always()
-#         #   displayName: 'occlum docker-compose down'
+        #     docker-compose -f occlum-docker-compose.yml down
+        #   condition: always()
+        #   displayName: 'occlum docker-compose down'
 
 - stage:
   condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
@@ -92,75 +92,75 @@ stages:
         condition: always()
         displayName: 'Shutdown'
 
-# - stage: Build_and_Push_Base_Docker_Images
-#   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-#   jobs:
-#   - job: Docker
-#     pool:
-#       name: 'AnonifyAgent'
-#     steps:
-#     - task: Docker@2
-#       displayName: Build rust-sgx-sdk-rootless image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: rust-sgx-sdk-rootless
-#         tags: latest
-#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push rust-sgx-sdk-rootless image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: rust-sgx-sdk-rootless
-#         tags: latest
-#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-#         buildContext: .
+- stage: Build_and_Push_Base_Docker_Images
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  jobs:
+  - job: Docker
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+    - task: Docker@2
+      displayName: Build rust-sgx-sdk-rootless image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: rust-sgx-sdk-rootless
+        tags: latest
+        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push rust-sgx-sdk-rootless image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: rust-sgx-sdk-rootless
+        tags: latest
+        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+        buildContext: .
 
-#     - task: Docker@2
-#       displayName: Build anonify-dev image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push anonify-dev image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev.Dockerfile
-#         buildContext: .
+    - task: Docker@2
+      displayName: Build anonify-dev image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push anonify-dev image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev.Dockerfile
+        buildContext: .
 
-#     - task: Docker@2
-#       displayName: Build anonify-dev-pgx image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev-pgx
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push anonify-dev-pgx image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev-pgx
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-#         buildContext: .
+    - task: Docker@2
+      displayName: Build anonify-dev-pgx image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev-pgx
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push anonify-dev-pgx image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev-pgx
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+        buildContext: .
 
-#     - script: docker image prune -f
-#       displayName: Remove dangling images
+    - script: docker image prune -f
+      displayName: Remove dangling images
 
 - stage: Build_and_Push_Example_Docker
-  # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
   - job: Docker
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,113 +54,113 @@ stages:
 #         #   condition: always()
 #         #   displayName: 'occlum docker-compose down'
 
-# - stage:
-#   condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
-#   jobs:
-#   - job: E2E
-#     pool:
-#       name: 'AnonifyAgent'
-#     steps:
-#       - task: Docker@2
-#         displayName: Build erc20 image
-#         inputs:
-#           command: build
-#           containerRegistry: anonify-ci-cd-acr
-#           repository: erc20-state-runtime
-#           tags: latest
-#           dockerfile: ./docker/example-erc20.Dockerfile
-#           buildContext: .
-#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#       - task: Docker@2
-#         displayName: Build key-vault for erc20 image
-#         inputs:
-#           command: build
-#           containerRegistry: anonify-ci-cd-acr
-#           repository: key-vault-for-erc20
-#           tags: latest
-#           dockerfile: ./docker/example-keyvault.Dockerfile
-#           buildContext: .
-#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#       - script: |
-#           export SPID=$(SPID)
-#           export SUB_KEY=$(SUB_KEY)
-#           ./scripts/e2e-test.sh
-#         displayName: 'Run E2E tests'
-#       - script: docker image prune -f
-#         displayName: Remove dangling images
-#       - script: docker-compose -f e2e-docker-compose.yml down
-#         condition: always()
-#         displayName: 'Shutdown'
+- stage:
+  condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
+  jobs:
+  - job: E2E
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+      - task: Docker@2
+        displayName: Build erc20 image
+        inputs:
+          command: build
+          containerRegistry: anonify-ci-cd-acr
+          repository: erc20-state-runtime
+          tags: latest
+          dockerfile: ./docker/example-erc20.Dockerfile
+          buildContext: .
+          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+      - task: Docker@2
+        displayName: Build key-vault for erc20 image
+        inputs:
+          command: build
+          containerRegistry: anonify-ci-cd-acr
+          repository: key-vault-for-erc20
+          tags: latest
+          dockerfile: ./docker/example-keyvault.Dockerfile
+          buildContext: .
+          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+      - script: |
+          export SPID=$(SPID)
+          export SUB_KEY=$(SUB_KEY)
+          ./scripts/e2e-test.sh
+        displayName: 'Run E2E tests'
+      - script: docker image prune -f
+        displayName: Remove dangling images
+      - script: docker-compose -f e2e-docker-compose.yml down
+        condition: always()
+        displayName: 'Shutdown'
 
-# - stage: Build_and_Push_Base_Docker_Images
-#   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-#   jobs:
-#   - job: Docker
-#     pool:
-#       name: 'AnonifyAgent'
-#     steps:
-#     - task: Docker@2
-#       displayName: Build rust-sgx-sdk-rootless image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: rust-sgx-sdk-rootless
-#         tags: latest
-#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push rust-sgx-sdk-rootless image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: rust-sgx-sdk-rootless
-#         tags: latest
-#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-#         buildContext: .
+- stage: Build_and_Push_Base_Docker_Images
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  jobs:
+  - job: Docker
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+    - task: Docker@2
+      displayName: Build rust-sgx-sdk-rootless image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: rust-sgx-sdk-rootless
+        tags: latest
+        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push rust-sgx-sdk-rootless image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: rust-sgx-sdk-rootless
+        tags: latest
+        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+        buildContext: .
 
-#     - task: Docker@2
-#       displayName: Build anonify-dev image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push anonify-dev image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev.Dockerfile
-#         buildContext: .
+    - task: Docker@2
+      displayName: Build anonify-dev image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push anonify-dev image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev.Dockerfile
+        buildContext: .
 
-#     - task: Docker@2
-#       displayName: Build anonify-dev-pgx image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev-pgx
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push anonify-dev-pgx image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev-pgx
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-#         buildContext: .
+    - task: Docker@2
+      displayName: Build anonify-dev-pgx image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev-pgx
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push anonify-dev-pgx image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev-pgx
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+        buildContext: .
 
-#     - script: docker image prune -f
-#       displayName: Remove dangling images
+    - script: docker image prune -f
+      displayName: Remove dangling images
 
 - stage: Build_and_Push_Example_Docker
-  # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
   - job: Docker
     pool:
@@ -172,7 +172,7 @@ stages:
         command: build
         containerRegistry: anonify-ci-cd-acr
         repository: erc20-state-runtime
-        tags: latest-test
+        tags: latest
         dockerfile: ./docker/example-erc20.Dockerfile
         buildContext: .
         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
@@ -182,7 +182,7 @@ stages:
         command: push
         containerRegistry: anonify-ci-cd-acr
         repository: erc20-state-runtime
-        tags: latest-test
+        tags: latest
         dockerfile: ./docker/example-erc20.Dockerfile
         buildContext: .
 
@@ -192,7 +192,7 @@ stages:
         command: build
         containerRegistry: anonify-ci-cd-acr
         repository: key-vault-for-erc20
-        tags: latest-test
+        tags: latest
         dockerfile: ./docker/example-keyvault.Dockerfile
         buildContext: .
         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
@@ -202,7 +202,7 @@ stages:
         command: push
         containerRegistry: anonify-ci-cd-acr
         repository: key-vault-for-erc20
-        tags: latest-test
+        tags: latest
         dockerfile: ./docker/example-keyvault.Dockerfile
         buildContext: .
 
@@ -212,7 +212,7 @@ stages:
         command: build
         containerRegistry: anonify-ci-cd-acr
         repository: encrypted-sql-ops-pg
-        tags: latest-test
+        tags: latest
         dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
         buildContext: .
         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
@@ -222,7 +222,7 @@ stages:
         command: push
         containerRegistry: anonify-ci-cd-acr
         repository: encrypted-sql-ops-pg
-        tags: latest-test
+        tags: latest
         dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
         buildContext: .
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,165 +2,165 @@ trigger:
 - main
 
 stages:
-- stage: Test
-  condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
-  jobs:
-    - job: CI
-      pool:
-        name: 'AnonifyAgent'
-      steps:
-        - script: |
-            cp .env.sample .env
-            export SPID=$(SPID)
-            export SUB_KEY=$(SUB_KEY)
+# - stage: Test
+#   condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+#   jobs:
+#     - job: CI
+#       pool:
+#         name: 'AnonifyAgent'
+#       steps:
+#         - script: |
+#             cp .env.sample .env
+#             export SPID=$(SPID)
+#             export SUB_KEY=$(SUB_KEY)
 
-            # TODO: Workaround for duplicate aesm service
-            # Remove here once https://github.com/occlum/occlum/pull/443 merged.
-            docker-compose up -d
-            docker-compose exec -T sgx_machine bash -c "sudo chown -R anonify-dev:anonify-dev anonify ; cd anonify && ./scripts/test.sh"
-          displayName: 'Run rust-sgx-sdk tests'
-        - script: docker-compose down
-          condition: always()
-          displayName: 'rust-sgx-sdk docker-compose down'
+#             # TODO: Workaround for duplicate aesm service
+#             # Remove here once https://github.com/occlum/occlum/pull/443 merged.
+#             docker-compose up -d
+#             docker-compose exec -T sgx_machine bash -c "sudo chown -R anonify-dev:anonify-dev anonify ; cd anonify && ./scripts/test.sh"
+#           displayName: 'Run rust-sgx-sdk tests'
+#         - script: docker-compose down
+#           condition: always()
+#           displayName: 'rust-sgx-sdk docker-compose down'
 
-        - script: |
-            cp .env.sample .env
-            export SPID=$(SPID)
-            export SUB_KEY=$(SUB_KEY)
+#         - script: |
+#             cp .env.sample .env
+#             export SPID=$(SPID)
+#             export SUB_KEY=$(SUB_KEY)
 
-            docker-compose -f pgx-docker-compose.yml up -d
-            docker-compose -f pgx-docker-compose.yml exec -T sgx_machine_pgx bash -c "cd anonify && ./scripts/encrypted-sql-ops-pg-test.sh"
-          displayName: 'Run encrypted-sql-ops-pg integration tests'
-        - script: docker-compose -f pgx-docker-compose.yml down
-          condition: always()
-          displayName: 'pgx docker-compose down'
+#             docker-compose -f pgx-docker-compose.yml up -d
+#             docker-compose -f pgx-docker-compose.yml exec -T sgx_machine_pgx bash -c "cd anonify && ./scripts/encrypted-sql-ops-pg-test.sh"
+#           displayName: 'Run encrypted-sql-ops-pg integration tests'
+#         - script: docker-compose -f pgx-docker-compose.yml down
+#           condition: always()
+#           displayName: 'pgx docker-compose down'
 
-        # NOTE: temporary removed: Add once occlum version bump up to 0.23.0
-        # - script: |
-        #     cp .env.sample .env
-        #     export SPID=$(SPID)
-        #     export SUB_KEY=$(SUB_KEY)
-        #     docker-compose -f occlum-docker-compose.yml up -d
+#         # NOTE: temporary removed: Add once occlum version bump up to 0.23.0
+#         # - script: |
+#         #     cp .env.sample .env
+#         #     export SPID=$(SPID)
+#         #     export SUB_KEY=$(SUB_KEY)
+#         #     docker-compose -f occlum-docker-compose.yml up -d
 
-        #     # TODO: Remove the dettached mode flag once the enclave runs as the embedded mode.
-        #     docker-compose -f occlum-docker-compose.yml exec -d -T enclave bash -c "./anonify/scripts/occlum-enclave-test.sh"
-        #     docker-compose -f occlum-docker-compose.yml exec -T host bash -c "./anonify/scripts/occlum-host-test.sh"
-        #   displayName: 'Run occlum tests'
-        # - script: |
-        #     sudo systemctl restart aesmd
-        #     LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service
+#         #     # TODO: Remove the dettached mode flag once the enclave runs as the embedded mode.
+#         #     docker-compose -f occlum-docker-compose.yml exec -d -T enclave bash -c "./anonify/scripts/occlum-enclave-test.sh"
+#         #     docker-compose -f occlum-docker-compose.yml exec -T host bash -c "./anonify/scripts/occlum-host-test.sh"
+#         #   displayName: 'Run occlum tests'
+#         # - script: |
+#         #     sudo systemctl restart aesmd
+#         #     LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm /opt/intel/sgx-aesm-service/aesm/aesm_service
 
-        #     docker-compose -f occlum-docker-compose.yml down
-        #   condition: always()
-        #   displayName: 'occlum docker-compose down'
+#         #     docker-compose -f occlum-docker-compose.yml down
+#         #   condition: always()
+#         #   displayName: 'occlum docker-compose down'
 
-- stage:
-  condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
-  jobs:
-  - job: E2E
-    pool:
-      name: 'AnonifyAgent'
-    steps:
-      - task: Docker@2
-        displayName: Build erc20 image
-        inputs:
-          command: build
-          containerRegistry: anonify-ci-cd-acr
-          repository: erc20-state-runtime
-          tags: latest
-          dockerfile: ./docker/example-erc20.Dockerfile
-          buildContext: .
-          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-      - task: Docker@2
-        displayName: Build key-vault for erc20 image
-        inputs:
-          command: build
-          containerRegistry: anonify-ci-cd-acr
-          repository: key-vault-for-erc20
-          tags: latest
-          dockerfile: ./docker/example-keyvault.Dockerfile
-          buildContext: .
-          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-      - script: |
-          export SPID=$(SPID)
-          export SUB_KEY=$(SUB_KEY)
-          ./scripts/e2e-test.sh
-        displayName: 'Run E2E tests'
-      - script: docker image prune -f
-        displayName: Remove dangling images
-      - script: docker-compose -f e2e-docker-compose.yml down
-        condition: always()
-        displayName: 'Shutdown'
+# - stage:
+#   condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
+#   jobs:
+#   - job: E2E
+#     pool:
+#       name: 'AnonifyAgent'
+#     steps:
+#       - task: Docker@2
+#         displayName: Build erc20 image
+#         inputs:
+#           command: build
+#           containerRegistry: anonify-ci-cd-acr
+#           repository: erc20-state-runtime
+#           tags: latest
+#           dockerfile: ./docker/example-erc20.Dockerfile
+#           buildContext: .
+#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#       - task: Docker@2
+#         displayName: Build key-vault for erc20 image
+#         inputs:
+#           command: build
+#           containerRegistry: anonify-ci-cd-acr
+#           repository: key-vault-for-erc20
+#           tags: latest
+#           dockerfile: ./docker/example-keyvault.Dockerfile
+#           buildContext: .
+#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#       - script: |
+#           export SPID=$(SPID)
+#           export SUB_KEY=$(SUB_KEY)
+#           ./scripts/e2e-test.sh
+#         displayName: 'Run E2E tests'
+#       - script: docker image prune -f
+#         displayName: Remove dangling images
+#       - script: docker-compose -f e2e-docker-compose.yml down
+#         condition: always()
+#         displayName: 'Shutdown'
 
-- stage: Build_and_Push_Base_Docker_Images
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-  jobs:
-  - job: Docker
-    pool:
-      name: 'AnonifyAgent'
-    steps:
-    - task: Docker@2
-      displayName: Build rust-sgx-sdk-rootless image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: rust-sgx-sdk-rootless
-        tags: latest
-        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push rust-sgx-sdk-rootless image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: rust-sgx-sdk-rootless
-        tags: latest
-        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-        buildContext: .
+# - stage: Build_and_Push_Base_Docker_Images
+#   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+#   jobs:
+#   - job: Docker
+#     pool:
+#       name: 'AnonifyAgent'
+#     steps:
+#     - task: Docker@2
+#       displayName: Build rust-sgx-sdk-rootless image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: rust-sgx-sdk-rootless
+#         tags: latest
+#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push rust-sgx-sdk-rootless image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: rust-sgx-sdk-rootless
+#         tags: latest
+#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+#         buildContext: .
 
-    - task: Docker@2
-      displayName: Build anonify-dev image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push anonify-dev image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev.Dockerfile
-        buildContext: .
+#     - task: Docker@2
+#       displayName: Build anonify-dev image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push anonify-dev image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev.Dockerfile
+#         buildContext: .
 
-    - task: Docker@2
-      displayName: Build anonify-dev-pgx image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev-pgx
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push anonify-dev-pgx image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev-pgx
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-        buildContext: .
+#     - task: Docker@2
+#       displayName: Build anonify-dev-pgx image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev-pgx
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push anonify-dev-pgx image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev-pgx
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+#         buildContext: .
 
-    - script: docker image prune -f
-      displayName: Remove dangling images
+#     - script: docker image prune -f
+#       displayName: Remove dangling images
 
 - stage: Build_and_Push_Example_Docker
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
   - job: Docker
     pool:
@@ -172,7 +172,7 @@ stages:
         command: build
         containerRegistry: anonify-ci-cd-acr
         repository: erc20-state-runtime
-        tags: latest
+        tags: latest-test
         dockerfile: ./docker/example-erc20.Dockerfile
         buildContext: .
         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
@@ -182,7 +182,7 @@ stages:
         command: push
         containerRegistry: anonify-ci-cd-acr
         repository: erc20-state-runtime
-        tags: latest
+        tags: latest-test
         dockerfile: ./docker/example-erc20.Dockerfile
         buildContext: .
 
@@ -192,7 +192,7 @@ stages:
         command: build
         containerRegistry: anonify-ci-cd-acr
         repository: key-vault-for-erc20
-        tags: latest
+        tags: latest-test
         dockerfile: ./docker/example-keyvault.Dockerfile
         buildContext: .
         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
@@ -202,7 +202,7 @@ stages:
         command: push
         containerRegistry: anonify-ci-cd-acr
         repository: key-vault-for-erc20
-        tags: latest
+        tags: latest-test
         dockerfile: ./docker/example-keyvault.Dockerfile
         buildContext: .
 
@@ -212,7 +212,7 @@ stages:
         command: build
         containerRegistry: anonify-ci-cd-acr
         repository: encrypted-sql-ops-pg
-        tags: latest
+        tags: latest-test
         dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
         buildContext: .
         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
@@ -222,7 +222,7 @@ stages:
         command: push
         containerRegistry: anonify-ci-cd-acr
         repository: encrypted-sql-ops-pg
-        tags: latest
+        tags: latest-test
         dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
         buildContext: .
 

--- a/docker/example-encrypted-sql-ops-pg.Dockerfile
+++ b/docker/example-encrypted-sql-ops-pg.Dockerfile
@@ -1,3 +1,6 @@
+ARG user_name=anonify-dev
+ARG group_name=anonify-dev
+
 FROM anonify.azurecr.io/anonify-dev:latest as builder
 
 SHELL ["/bin/bash", "-c"]
@@ -10,8 +13,8 @@ RUN set -x && \
     sudo python3 -m pip install --upgrade pip --target /usr/lib64/az/lib/python3.6/site-packages/ && \
     sudo rm -rf /var/lib/apt/lists/*
 
-ARG user_name=anonify-dev
-ARG group_name=anonify-dev
+ARG user_name
+ARG group_name
 COPY --chown=${user_name}:${group_name} . ${HOME}/anonify
 WORKDIR ${HOME}/anonify
 
@@ -42,5 +45,8 @@ RUN set -x && \
 FROM anonify.azurecr.io/anonify-dev-pgx:latest
 
 WORKDIR ${HOME}
+
+ARG user_name
+ARG group_name
 
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify ${HOME}/anonify

--- a/docker/example-encrypted-sql-ops-pg.Dockerfile
+++ b/docker/example-encrypted-sql-ops-pg.Dockerfile
@@ -43,4 +43,4 @@ FROM anonify.azurecr.io/anonify-dev-pgx:latest
 
 WORKDIR ${HOME}
 
-COPY --from=builder ${HOME}/anonify ${HOME}/anonify
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify ${HOME}/anonify

--- a/docker/example-erc20.Dockerfile
+++ b/docker/example-erc20.Dockerfile
@@ -60,9 +60,7 @@ ARG user_name
 ARG group_name
 
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
-COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20.signed.so ./.anonify/erc20.signed.so
-COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20_measurement.txt ./.anonify/erc20_measurement.txt
-COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault_measurement.txt ./.anonify/key_vault_measurement.txt
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify ./.anonify
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/target/release/erc20-server ./target/release/
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/AnonifyWithEnclaveKey.abi ./contract-build/
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/AnonifyWithEnclaveKey.bin ./contract-build/

--- a/docker/example-erc20.Dockerfile
+++ b/docker/example-erc20.Dockerfile
@@ -1,3 +1,6 @@
+ARG user_name=anonify-dev
+ARG group_name=anonify-dev
+
 FROM anonify.azurecr.io/anonify-dev:latest as builder
 LABEL maintainer="osuke.sudo@layerx.co.jp"
 
@@ -11,8 +14,8 @@ RUN set -x && \
     sudo python3 -m pip install --upgrade pip --target /usr/lib64/az/lib/python3.6/site-packages/ && \
     sudo rm -rf /var/lib/apt/lists/*
 
-ARG user_name=anonify-dev
-ARG group_name=anonify-dev
+ARG user_name
+ARG group_name
 COPY --chown=${user_name}:${group_name} . ${HOME}/anonify
 WORKDIR ${HOME}/anonify
 
@@ -52,6 +55,9 @@ FROM anonify.azurecr.io/anonify-dev:latest
 LABEL maintainer="osuke.sudo@layerx.co.jp"
 
 WORKDIR ${HOME}/anonify
+
+ARG user_name
+ARG group_name
 
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20.signed.so ./.anonify/erc20.signed.so

--- a/docker/example-erc20.Dockerfile
+++ b/docker/example-erc20.Dockerfile
@@ -60,7 +60,9 @@ ARG user_name
 ARG group_name
 
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
-COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify ./.anonify
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20.signed.so ./.anonify/erc20.signed.so
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20_measurement.txt ./.anonify/erc20_measurement.txt
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault_measurement.txt ./.anonify/key_vault_measurement.txt
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/target/release/erc20-server ./target/release/
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/AnonifyWithEnclaveKey.abi ./contract-build/
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/AnonifyWithEnclaveKey.bin ./contract-build/
@@ -69,5 +71,7 @@ COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/DeployAnonify.abi ./contract-build/
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/DeployAnonify.bin ./contract-build/
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/fixuid.bash ./
+
+RUN sudo chown ${user_name}:${group_name} .
 
 CMD ["./target/release/erc20-server"]

--- a/docker/example-erc20.Dockerfile
+++ b/docker/example-erc20.Dockerfile
@@ -53,17 +53,17 @@ LABEL maintainer="osuke.sudo@layerx.co.jp"
 
 WORKDIR ${HOME}/anonify
 
-COPY --from=builder ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
-COPY --from=builder ${HOME}/anonify/.anonify/erc20.signed.so ./.anonify/erc20.signed.so
-COPY --from=builder ${HOME}/anonify/.anonify/erc20_measurement.txt ./.anonify/erc20_measurement.txt
-COPY --from=builder ${HOME}/anonify/.anonify/key_vault_measurement.txt ./.anonify/key_vault_measurement.txt
-COPY --from=builder ${HOME}/anonify/target/release/erc20-server ./target/release/
-COPY --from=builder ${HOME}/anonify/contract-build/AnonifyWithEnclaveKey.abi ./contract-build/
-COPY --from=builder ${HOME}/anonify/contract-build/AnonifyWithEnclaveKey.bin ./contract-build/
-COPY --from=builder ${HOME}/anonify/contract-build/AnonifyWithTreeKem.abi ./contract-build/
-COPY --from=builder ${HOME}/anonify/contract-build/AnonifyWithTreeKem.bin ./contract-build/
-COPY --from=builder ${HOME}/anonify/contract-build/DeployAnonify.abi ./contract-build/
-COPY --from=builder ${HOME}/anonify/contract-build/DeployAnonify.bin ./contract-build/
-COPY --from=builder ${HOME}/fixuid.bash ./
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20.signed.so ./.anonify/erc20.signed.so
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20_measurement.txt ./.anonify/erc20_measurement.txt
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault_measurement.txt ./.anonify/key_vault_measurement.txt
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/target/release/erc20-server ./target/release/
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/AnonifyWithEnclaveKey.abi ./contract-build/
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/AnonifyWithEnclaveKey.bin ./contract-build/
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/AnonifyWithTreeKem.abi ./contract-build/
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/AnonifyWithTreeKem.bin ./contract-build/
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/DeployAnonify.abi ./contract-build/
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/contract-build/DeployAnonify.bin ./contract-build/
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/fixuid.bash ./
 
 CMD ["./target/release/erc20-server"]

--- a/docker/example-keyvault.Dockerfile
+++ b/docker/example-keyvault.Dockerfile
@@ -55,8 +55,12 @@ ARG user_name
 ARG group_name
 
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
-COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify ./.anonify
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault.signed.so ./.anonify/key_vault.signed.so
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20_measurement.txt ./.anonify/erc20_measurement.txt
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault_measurement.txt ./.anonify/key_vault_measurement.txt
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/target/release/key-vault-server ./target/release/
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/fixuid.bash ./
+
+RUN sudo chown ${user_name}:${group_name} .
 
 CMD ["./target/release/key-vault-server"]

--- a/docker/example-keyvault.Dockerfile
+++ b/docker/example-keyvault.Dockerfile
@@ -1,3 +1,6 @@
+ARG user_name=anonify-dev
+ARG group_name=anonify-dev
+
 FROM anonify.azurecr.io/anonify-dev:latest as builder
 LABEL maintainer="osuke.sudo@layerx.co.jp"
 
@@ -11,8 +14,8 @@ RUN set -x && \
     sudo python3 -m pip install --upgrade pip --target /usr/lib64/az/lib/python3.6/site-packages/ && \
     sudo rm -rf /var/lib/apt/lists/*
 
-ARG user_name=anonify-dev
-ARG group_name=anonify-dev
+ARG user_name
+ARG group_name
 COPY --chown=${user_name}:${group_name} . ${HOME}/anonify
 WORKDIR ${HOME}/anonify
 
@@ -47,6 +50,9 @@ FROM anonify.azurecr.io/anonify-dev:latest
 LABEL maintainer="osuke.sudo@layerx.co.jp"
 
 WORKDIR ${HOME}/anonify
+
+ARG user_name
+ARG group_name
 
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault.signed.so ./.anonify/key_vault.signed.so

--- a/docker/example-keyvault.Dockerfile
+++ b/docker/example-keyvault.Dockerfile
@@ -48,11 +48,11 @@ LABEL maintainer="osuke.sudo@layerx.co.jp"
 
 WORKDIR ${HOME}/anonify
 
-COPY --from=builder ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
-COPY --from=builder ${HOME}/anonify/.anonify/key_vault.signed.so ./.anonify/key_vault.signed.so
-COPY --from=builder ${HOME}/anonify/.anonify/erc20_measurement.txt ./.anonify/erc20_measurement.txt
-COPY --from=builder ${HOME}/anonify/.anonify/key_vault_measurement.txt ./.anonify/key_vault_measurement.txt
-COPY --from=builder ${HOME}/anonify/target/release/key-vault-server ./target/release/
-COPY --from=builder ${HOME}/fixuid.bash ./
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault.signed.so ./.anonify/key_vault.signed.so
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20_measurement.txt ./.anonify/erc20_measurement.txt
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault_measurement.txt ./.anonify/key_vault_measurement.txt
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/target/release/key-vault-server ./target/release/
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/fixuid.bash ./
 
 CMD ["./target/release/key-vault-server"]

--- a/docker/example-keyvault.Dockerfile
+++ b/docker/example-keyvault.Dockerfile
@@ -55,9 +55,7 @@ ARG user_name
 ARG group_name
 
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/config/ias_root_cert.pem ./config/ias_root_cert.pem
-COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault.signed.so ./.anonify/key_vault.signed.so
-COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/erc20_measurement.txt ./.anonify/erc20_measurement.txt
-COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify/key_vault_measurement.txt ./.anonify/key_vault_measurement.txt
+COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/.anonify ./.anonify
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/anonify/target/release/key-vault-server ./target/release/
 COPY --from=builder --chown=${user_name}:${group_name} ${HOME}/fixuid.bash ./
 

--- a/e2e-docker-compose.yml
+++ b/e2e-docker-compose.yml
@@ -39,6 +39,7 @@ services:
       UNLOCK_DURATION: "60"
       PJ_ROOT_DIR: "/home-anonify-dev/anonify"
       IS_DEBUG: "false"
+      FIXUID_MODE: "skip" # bacause it's too slow. Nothing matters even if UID of host & guest differs.
     # Add an lookup from the IP Adress to FQDN because of the following limition of rustls
     # https://github.com/ctz/rustls/issues/184
     # https://github.com/briansmith/webpki/issues/54
@@ -77,6 +78,7 @@ services:
       IAS_ROOT_CERT_PATH: "config/ias_root_cert.pem"
       PJ_ROOT_DIR: "/home/anonify-dev/anonify"
       IS_DEBUG: "false"
+      FIXUID_MODE: "skip" # bacause it's too slow. Nothing matters even if UID of host & guest differs.
     # Add an lookup from the IP Address to FQDN because of the following limitation of rustls
     # https://github.com/ctz/rustls/issues/184
     # https://github.com/briansmith/webpki/issues/54

--- a/e2e-docker-compose.yml
+++ b/e2e-docker-compose.yml
@@ -37,7 +37,7 @@ services:
       IAS_ROOT_CERT_PATH: "config/ias_root_cert.pem"
       EVENT_LIMIT: "100"
       UNLOCK_DURATION: "60"
-      PJ_ROOT_DIR: "/home-anonify-dev/anonify"
+      PJ_ROOT_DIR: "/home/anonify-dev/anonify"
       IS_DEBUG: "false"
       FIXUID_MODE: "skip" # bacause it's too slow. Nothing matters even if UID of host & guest differs.
     # Add an lookup from the IP Adress to FQDN because of the following limition of rustls

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -30,7 +30,7 @@ sleep 10
 
 cd "$CI_ROOT_DIR"
 
-pubkey=$(curl "$STATE_RUNTIME_URL"/api/v1/enclave_encryption_key -s -f -k -X GET -H "Content-Type: application/json" -d '')
+pubkey=$(curl -v "$STATE_RUNTIME_URL"/api/v1/enclave_encryption_key -s -f -k -X GET -H "Content-Type: application/json" -d '')
 if [[ $pubkey == *"enclave_encryption_key"* ]]; then
   echo $pubkey
 else


### PR DESCRIPTION
## Issueへのリンク

（なし）

## やったこと

Dockerイメージのrootlessなど諸々やっていた結果、E2Eテストが動かなくなっていたので修正。

- `/home-anonify-dev/anonify` という嘘pathの修正
- docker build で作られる各種ファイルの owner が anonify-dev になるよう調整

あたりが本質的な差分です。

## やらないこと

（なし）

## 動作検証

E2EのstepがCI上成功していることは確認しています。
**念の為、CIのログを見てE2Eが正常動作していることを確認してほしい** です。

## 参考

（なし）