### PR TITLE
CIの並行化

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ stages:
 - stage: Build_and_Push_Base_Docker_Images
   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
-  - job: Build_and_Push_rust-sgx-sdk-rootless_image
+  - job: Build_and_Push_rust_sgx_sdk_rootless_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -119,7 +119,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build_and_Push_anonify-dev_image
+  - job: Build_and_Push_anonify_dev_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -144,7 +144,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build_and_Push_anonify-dev-pgx_image
+  - job: Build_and_Push_anonify_dev_pgx_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -198,7 +198,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build_and_Push_key-vault_for_erc20_image
+  - job: Build_and_Push_key_vault_for_erc20_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -224,7 +224,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build_and_Push_encrypted-sql-ops-pg_image
+  - job: Build_and_Push_encrypted_sql_ops-pg_image
     pool:
       name: 'AnonifyAgent'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,35 +5,51 @@ stages:
 - stage: Test
   condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
-    - job: CI
+    - job: Job1
       pool:
         name: 'AnonifyAgent'
       steps:
         - script: |
-            cp .env.sample .env
-            export SPID=$(SPID)
-            export SUB_KEY=$(SUB_KEY)
-
-            # TODO: Workaround for duplicate aesm service
-            # Remove here once https://github.com/occlum/occlum/pull/443 merged.
-            docker-compose up -d
-            docker-compose exec -T sgx_machine bash -c "sudo chown -R anonify-dev:anonify-dev anonify ; cd anonify && ./scripts/test.sh"
-          displayName: 'Run rust-sgx-sdk tests'
-        - script: docker-compose down
-          condition: always()
-          displayName: 'rust-sgx-sdk docker-compose down'
-
+            sleep 60
+          displayName: 'step 1-1'
         - script: |
-            cp .env.sample .env
-            export SPID=$(SPID)
-            export SUB_KEY=$(SUB_KEY)
+            sleep 60
+          displayName: 'step 1-2'
+    - job: Job2
+      pool:
+        name: 'AnonifyAgent'
+      steps:
+        - script: |
+            sleep 60
+          displayName: 'step 2-1'
+        - script: |
+            sleep 60
+          displayName: 'step 2-2'
+        # - script: |
+        #     cp .env.sample .env
+        #     export SPID=$(SPID)
+        #     export SUB_KEY=$(SUB_KEY)
 
-            docker-compose -f pgx-docker-compose.yml up -d
-            docker-compose -f pgx-docker-compose.yml exec -T sgx_machine_pgx bash -c "cd anonify && ./scripts/encrypted-sql-ops-pg-test.sh"
-          displayName: 'Run encrypted-sql-ops-pg integration tests'
-        - script: docker-compose -f pgx-docker-compose.yml down
-          condition: always()
-          displayName: 'pgx docker-compose down'
+        #     # TODO: Workaround for duplicate aesm service
+        #     # Remove here once https://github.com/occlum/occlum/pull/443 merged.
+        #     docker-compose up -d
+        #     docker-compose exec -T sgx_machine bash -c "sudo chown -R anonify-dev:anonify-dev anonify ; cd anonify && ./scripts/test.sh"
+        #   displayName: 'Run rust-sgx-sdk tests'
+        # - script: docker-compose down
+        #   condition: always()
+        #   displayName: 'rust-sgx-sdk docker-compose down'
+
+        # - script: |
+        #     cp .env.sample .env
+        #     export SPID=$(SPID)
+        #     export SUB_KEY=$(SUB_KEY)
+
+        #     docker-compose -f pgx-docker-compose.yml up -d
+        #     docker-compose -f pgx-docker-compose.yml exec -T sgx_machine_pgx bash -c "cd anonify && ./scripts/encrypted-sql-ops-pg-test.sh"
+        #   displayName: 'Run encrypted-sql-ops-pg integration tests'
+        # - script: docker-compose -f pgx-docker-compose.yml down
+        #   condition: always()
+        #   displayName: 'pgx docker-compose down'
 
         # NOTE: temporary removed: Add once occlum version bump up to 0.23.0
         # - script: |
@@ -54,177 +70,177 @@ stages:
         #   condition: always()
         #   displayName: 'occlum docker-compose down'
 
-- stage:
-  condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
-  jobs:
-  - job: E2E
-    pool:
-      name: 'AnonifyAgent'
-    steps:
-      - task: Docker@2
-        displayName: Build erc20 image
-        inputs:
-          command: build
-          containerRegistry: anonify-ci-cd-acr
-          repository: erc20-state-runtime
-          tags: latest
-          dockerfile: ./docker/example-erc20.Dockerfile
-          buildContext: .
-          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-      - task: Docker@2
-        displayName: Build key-vault for erc20 image
-        inputs:
-          command: build
-          containerRegistry: anonify-ci-cd-acr
-          repository: key-vault-for-erc20
-          tags: latest
-          dockerfile: ./docker/example-keyvault.Dockerfile
-          buildContext: .
-          arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-      - script: |
-          export SPID=$(SPID)
-          export SUB_KEY=$(SUB_KEY)
-          ./scripts/e2e-test.sh
-        displayName: 'Run E2E tests'
-      - script: docker image prune -f
-        displayName: Remove dangling images
-      - script: docker-compose -f e2e-docker-compose.yml down
-        condition: always()
-        displayName: 'Shutdown'
+# - stage:
+#   condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
+#   jobs:
+#   - job: E2E
+#     pool:
+#       name: 'AnonifyAgent'
+#     steps:
+#       - task: Docker@2
+#         displayName: Build erc20 image
+#         inputs:
+#           command: build
+#           containerRegistry: anonify-ci-cd-acr
+#           repository: erc20-state-runtime
+#           tags: latest
+#           dockerfile: ./docker/example-erc20.Dockerfile
+#           buildContext: .
+#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#       - task: Docker@2
+#         displayName: Build key-vault for erc20 image
+#         inputs:
+#           command: build
+#           containerRegistry: anonify-ci-cd-acr
+#           repository: key-vault-for-erc20
+#           tags: latest
+#           dockerfile: ./docker/example-keyvault.Dockerfile
+#           buildContext: .
+#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#       - script: |
+#           export SPID=$(SPID)
+#           export SUB_KEY=$(SUB_KEY)
+#           ./scripts/e2e-test.sh
+#         displayName: 'Run E2E tests'
+#       - script: docker image prune -f
+#         displayName: Remove dangling images
+#       - script: docker-compose -f e2e-docker-compose.yml down
+#         condition: always()
+#         displayName: 'Shutdown'
 
-- stage: Build_and_Push_Base_Docker_Images
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-  jobs:
-  - job: Docker
-    pool:
-      name: 'AnonifyAgent'
-    steps:
-    - task: Docker@2
-      displayName: Build rust-sgx-sdk-rootless image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: rust-sgx-sdk-rootless
-        tags: latest
-        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push rust-sgx-sdk-rootless image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: rust-sgx-sdk-rootless
-        tags: latest
-        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-        buildContext: .
+# - stage: Build_and_Push_Base_Docker_Images
+#   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+#   jobs:
+#   - job: Docker
+#     pool:
+#       name: 'AnonifyAgent'
+#     steps:
+#     - task: Docker@2
+#       displayName: Build rust-sgx-sdk-rootless image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: rust-sgx-sdk-rootless
+#         tags: latest
+#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push rust-sgx-sdk-rootless image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: rust-sgx-sdk-rootless
+#         tags: latest
+#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+#         buildContext: .
 
-    - task: Docker@2
-      displayName: Build anonify-dev image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push anonify-dev image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev.Dockerfile
-        buildContext: .
+#     - task: Docker@2
+#       displayName: Build anonify-dev image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push anonify-dev image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev.Dockerfile
+#         buildContext: .
 
-    - task: Docker@2
-      displayName: Build anonify-dev-pgx image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev-pgx
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-        buildContext: .
-    - task: Docker@2
-      displayName: Push anonify-dev-pgx image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: anonify-dev-pgx
-        tags: latest
-        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-        buildContext: .
+#     - task: Docker@2
+#       displayName: Build anonify-dev-pgx image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev-pgx
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+#         buildContext: .
+#     - task: Docker@2
+#       displayName: Push anonify-dev-pgx image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: anonify-dev-pgx
+#         tags: latest
+#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+#         buildContext: .
 
-    - script: docker image prune -f
-      displayName: Remove dangling images
+#     - script: docker image prune -f
+#       displayName: Remove dangling images
 
-- stage: Build_and_Push_Example_Docker
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-  jobs:
-  - job: Docker
-    pool:
-      name: 'AnonifyAgent'
-    steps:
-    - task: Docker@2
-      displayName: Build erc20 image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: erc20-state-runtime
-        tags: latest
-        dockerfile: ./docker/example-erc20.Dockerfile
-        buildContext: .
-        arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-    - task: Docker@2
-      displayName: Push erc20 image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: erc20-state-runtime
-        tags: latest
-        dockerfile: ./docker/example-erc20.Dockerfile
-        buildContext: .
+# - stage: Build_and_Push_Example_Docker
+#   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+#   jobs:
+#   - job: Docker
+#     pool:
+#       name: 'AnonifyAgent'
+#     steps:
+#     - task: Docker@2
+#       displayName: Build erc20 image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: erc20-state-runtime
+#         tags: latest
+#         dockerfile: ./docker/example-erc20.Dockerfile
+#         buildContext: .
+#         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#     - task: Docker@2
+#       displayName: Push erc20 image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: erc20-state-runtime
+#         tags: latest
+#         dockerfile: ./docker/example-erc20.Dockerfile
+#         buildContext: .
 
-    - task: Docker@2
-      displayName: Build key-vault for erc20 image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: key-vault-for-erc20
-        tags: latest
-        dockerfile: ./docker/example-keyvault.Dockerfile
-        buildContext: .
-        arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-    - task: Docker@2
-      displayName: Push key-vault for erc20 image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: key-vault-for-erc20
-        tags: latest
-        dockerfile: ./docker/example-keyvault.Dockerfile
-        buildContext: .
+#     - task: Docker@2
+#       displayName: Build key-vault for erc20 image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: key-vault-for-erc20
+#         tags: latest
+#         dockerfile: ./docker/example-keyvault.Dockerfile
+#         buildContext: .
+#         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#     - task: Docker@2
+#       displayName: Push key-vault for erc20 image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: key-vault-for-erc20
+#         tags: latest
+#         dockerfile: ./docker/example-keyvault.Dockerfile
+#         buildContext: .
 
-    - task: Docker@2
-      displayName: Build encrypted-sql-ops-pg image
-      inputs:
-        command: build
-        containerRegistry: anonify-ci-cd-acr
-        repository: encrypted-sql-ops-pg
-        tags: latest
-        dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
-        buildContext: .
-        arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-    - task: Docker@2
-      displayName: Push encrypted-sql-ops-pg image
-      inputs:
-        command: push
-        containerRegistry: anonify-ci-cd-acr
-        repository: encrypted-sql-ops-pg
-        tags: latest
-        dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
-        buildContext: .
+#     - task: Docker@2
+#       displayName: Build encrypted-sql-ops-pg image
+#       inputs:
+#         command: build
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: encrypted-sql-ops-pg
+#         tags: latest
+#         dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
+#         buildContext: .
+#         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+#     - task: Docker@2
+#       displayName: Push encrypted-sql-ops-pg image
+#       inputs:
+#         command: push
+#         containerRegistry: anonify-ci-cd-acr
+#         repository: encrypted-sql-ops-pg
+#         tags: latest
+#         dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
+#         buildContext: .
 
-    - script: docker image prune -f
-      displayName: Remove dangling images
+#     - script: docker image prune -f
+#       displayName: Remove dangling images

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,53 +5,73 @@ stages:
 - stage: Test
   condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
-    - job: Job1
+    - job: CI
       pool:
         name: 'AnonifyAgent'
       steps:
         - script: |
-            sleep 60
-          displayName: 'step 1-1'
+            cp .env.sample .env
+            export SPID=$(SPID)
+            export SUB_KEY=$(SUB_KEY)
+
+            # TODO: Workaround for duplicate aesm service
+            # Remove here once https://github.com/occlum/occlum/pull/443 merged.
+            docker-compose up -d
+            docker-compose exec -T sgx_machine bash -c "sudo chown -R anonify-dev:anonify-dev anonify ; cd anonify && ./scripts/test.sh"
+          displayName: 'Run rust-sgx-sdk tests'
+        - script: docker-compose down
+          condition: always()
+          displayName: 'rust-sgx-sdk docker-compose down'
+
         - script: |
-            sleep 60
-          displayName: 'step 1-2'
-    - job: Job2
+            cp .env.sample .env
+            export SPID=$(SPID)
+            export SUB_KEY=$(SUB_KEY)
+
+            docker-compose -f pgx-docker-compose.yml up -d
+            docker-compose -f pgx-docker-compose.yml exec -T sgx_machine_pgx bash -c "cd anonify && ./scripts/encrypted-sql-ops-pg-test.sh"
+          displayName: 'Run encrypted-sql-ops-pg integration tests'
+        - script: docker-compose -f pgx-docker-compose.yml down
+          condition: always()
+          displayName: 'pgx docker-compose down'
+
+    - job: E2E CI
       pool:
         name: 'AnonifyAgent'
       steps:
+        - task: Docker@2
+          displayName: Build erc20 image
+          inputs:
+            command: build
+            containerRegistry: anonify-ci-cd-acr
+            repository: erc20-state-runtime
+            tags: latest
+            dockerfile: ./docker/example-erc20.Dockerfile
+            buildContext: .
+            arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+        - task: Docker@2
+          displayName: Build key-vault for erc20 image
+          inputs:
+            command: build
+            containerRegistry: anonify-ci-cd-acr
+            repository: key-vault-for-erc20
+            tags: latest
+            dockerfile: ./docker/example-keyvault.Dockerfile
+            buildContext: .
+            arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
         - script: |
-            sleep 60
-          displayName: 'step 2-1'
-        - script: |
-            sleep 60
-          displayName: 'step 2-2'
-        # - script: |
-        #     cp .env.sample .env
-        #     export SPID=$(SPID)
-        #     export SUB_KEY=$(SUB_KEY)
+            export SPID=$(SPID)
+            export SUB_KEY=$(SUB_KEY)
+            ./scripts/e2e-test.sh
+          displayName: 'Run E2E tests'
+        - script: docker image prune -f
+          displayName: Remove dangling images
+        - script: docker-compose -f e2e-docker-compose.yml down
+          condition: always()
+          displayName: 'Shutdown'
 
-        #     # TODO: Workaround for duplicate aesm service
-        #     # Remove here once https://github.com/occlum/occlum/pull/443 merged.
-        #     docker-compose up -d
-        #     docker-compose exec -T sgx_machine bash -c "sudo chown -R anonify-dev:anonify-dev anonify ; cd anonify && ./scripts/test.sh"
-        #   displayName: 'Run rust-sgx-sdk tests'
-        # - script: docker-compose down
-        #   condition: always()
-        #   displayName: 'rust-sgx-sdk docker-compose down'
-
-        # - script: |
-        #     cp .env.sample .env
-        #     export SPID=$(SPID)
-        #     export SUB_KEY=$(SUB_KEY)
-
-        #     docker-compose -f pgx-docker-compose.yml up -d
-        #     docker-compose -f pgx-docker-compose.yml exec -T sgx_machine_pgx bash -c "cd anonify && ./scripts/encrypted-sql-ops-pg-test.sh"
-        #   displayName: 'Run encrypted-sql-ops-pg integration tests'
-        # - script: docker-compose -f pgx-docker-compose.yml down
-        #   condition: always()
-        #   displayName: 'pgx docker-compose down'
-
-        # NOTE: temporary removed: Add once occlum version bump up to 0.23.0
+    # NOTE: temporary removed: Add once occlum version bump up to 0.23.0
+    # - job: occlum
         # - script: |
         #     cp .env.sample .env
         #     export SPID=$(SPID)
@@ -70,177 +90,163 @@ stages:
         #   condition: always()
         #   displayName: 'occlum docker-compose down'
 
-# - stage:
-#   condition: contains(variables['System.PullRequest.SourceBranch'], 'e2e')
-#   jobs:
-#   - job: E2E
-#     pool:
-#       name: 'AnonifyAgent'
-#     steps:
-#       - task: Docker@2
-#         displayName: Build erc20 image
-#         inputs:
-#           command: build
-#           containerRegistry: anonify-ci-cd-acr
-#           repository: erc20-state-runtime
-#           tags: latest
-#           dockerfile: ./docker/example-erc20.Dockerfile
-#           buildContext: .
-#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#       - task: Docker@2
-#         displayName: Build key-vault for erc20 image
-#         inputs:
-#           command: build
-#           containerRegistry: anonify-ci-cd-acr
-#           repository: key-vault-for-erc20
-#           tags: latest
-#           dockerfile: ./docker/example-keyvault.Dockerfile
-#           buildContext: .
-#           arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#       - script: |
-#           export SPID=$(SPID)
-#           export SUB_KEY=$(SUB_KEY)
-#           ./scripts/e2e-test.sh
-#         displayName: 'Run E2E tests'
-#       - script: docker image prune -f
-#         displayName: Remove dangling images
-#       - script: docker-compose -f e2e-docker-compose.yml down
-#         condition: always()
-#         displayName: 'Shutdown'
 
-# - stage: Build_and_Push_Base_Docker_Images
-#   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-#   jobs:
-#   - job: Docker
-#     pool:
-#       name: 'AnonifyAgent'
-#     steps:
-#     - task: Docker@2
-#       displayName: Build rust-sgx-sdk-rootless image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: rust-sgx-sdk-rootless
-#         tags: latest
-#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push rust-sgx-sdk-rootless image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: rust-sgx-sdk-rootless
-#         tags: latest
-#         dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
-#         buildContext: .
+- stage: Build_and_Push_Base_Docker_Images
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  jobs:
+  - job: Build and Push rust-sgx-sdk-rootless image
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+    - task: Docker@2
+      displayName: Build rust-sgx-sdk-rootless image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: rust-sgx-sdk-rootless
+        tags: latest
+        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push rust-sgx-sdk-rootless image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: rust-sgx-sdk-rootless
+        tags: latest
+        dockerfile: ./docker/base-rust-sgx-sdk-rootless.Dockerfile
+        buildContext: .
+    - script: docker image prune -f
+      displayName: Remove dangling images
 
-#     - task: Docker@2
-#       displayName: Build anonify-dev image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push anonify-dev image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev.Dockerfile
-#         buildContext: .
+  - job: Build and Push anonify-dev image
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+    - task: Docker@2
+      displayName: Build anonify-dev image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push anonify-dev image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev.Dockerfile
+        buildContext: .
+    - script: docker image prune -f
+      displayName: Remove dangling images
 
-#     - task: Docker@2
-#       displayName: Build anonify-dev-pgx image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev-pgx
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-#         buildContext: .
-#     - task: Docker@2
-#       displayName: Push anonify-dev-pgx image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: anonify-dev-pgx
-#         tags: latest
-#         dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
-#         buildContext: .
+  - job: Build and Push anonify-dev-pgx image
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+    - task: Docker@2
+      displayName: Build anonify-dev-pgx image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev-pgx
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+        buildContext: .
+    - task: Docker@2
+      displayName: Push anonify-dev-pgx image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: anonify-dev-pgx
+        tags: latest
+        dockerfile: ./docker/base-anonify-dev-pgx.Dockerfile
+        buildContext: .
+    - script: docker image prune -f
+      displayName: Remove dangling images
 
-#     - script: docker image prune -f
-#       displayName: Remove dangling images
+- stage: Build_and_Push_Example_Docker
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  jobs:
+  - job: Build and Push erc20 image
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+    - task: Docker@2
+      displayName: Build erc20 image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: erc20-state-runtime
+        tags: latest
+        dockerfile: ./docker/example-erc20.Dockerfile
+        buildContext: .
+        arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+    - task: Docker@2
+      displayName: Push erc20 image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: erc20-state-runtime
+        tags: latest
+        dockerfile: ./docker/example-erc20.Dockerfile
+        buildContext: .
+    - script: docker image prune -f
+      displayName: Remove dangling images
 
-# - stage: Build_and_Push_Example_Docker
-#   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-#   jobs:
-#   - job: Docker
-#     pool:
-#       name: 'AnonifyAgent'
-#     steps:
-#     - task: Docker@2
-#       displayName: Build erc20 image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: erc20-state-runtime
-#         tags: latest
-#         dockerfile: ./docker/example-erc20.Dockerfile
-#         buildContext: .
-#         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#     - task: Docker@2
-#       displayName: Push erc20 image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: erc20-state-runtime
-#         tags: latest
-#         dockerfile: ./docker/example-erc20.Dockerfile
-#         buildContext: .
+  - job: Build and Push key-vault for erc20 image
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+    - task: Docker@2
+      displayName: Build key-vault for erc20 image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: key-vault-for-erc20
+        tags: latest
+        dockerfile: ./docker/example-keyvault.Dockerfile
+        buildContext: .
+        arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+    - task: Docker@2
+      displayName: Push key-vault for erc20 image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: key-vault-for-erc20
+        tags: latest
+        dockerfile: ./docker/example-keyvault.Dockerfile
+        buildContext: .
+    - script: docker image prune -f
+      displayName: Remove dangling images
 
-#     - task: Docker@2
-#       displayName: Build key-vault for erc20 image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: key-vault-for-erc20
-#         tags: latest
-#         dockerfile: ./docker/example-keyvault.Dockerfile
-#         buildContext: .
-#         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#     - task: Docker@2
-#       displayName: Push key-vault for erc20 image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: key-vault-for-erc20
-#         tags: latest
-#         dockerfile: ./docker/example-keyvault.Dockerfile
-#         buildContext: .
+  - job: Build and Push encrypted-sql-ops-pg image
+    pool:
+      name: 'AnonifyAgent'
+    steps:
+    - task: Docker@2
+      displayName: Build encrypted-sql-ops-pg image
+      inputs:
+        command: build
+        containerRegistry: anonify-ci-cd-acr
+        repository: encrypted-sql-ops-pg
+        tags: latest
+        dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
+        buildContext: .
+        arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
+    - task: Docker@2
+      displayName: Push encrypted-sql-ops-pg image
+      inputs:
+        command: push
+        containerRegistry: anonify-ci-cd-acr
+        repository: encrypted-sql-ops-pg
+        tags: latest
+        dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
+        buildContext: .
 
-#     - task: Docker@2
-#       displayName: Build encrypted-sql-ops-pg image
-#       inputs:
-#         command: build
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: encrypted-sql-ops-pg
-#         tags: latest
-#         dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
-#         buildContext: .
-#         arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
-#     - task: Docker@2
-#       displayName: Push encrypted-sql-ops-pg image
-#       inputs:
-#         command: push
-#         containerRegistry: anonify-ci-cd-acr
-#         repository: encrypted-sql-ops-pg
-#         tags: latest
-#         dockerfile: ./docker/example-encrypted-sql-ops-pg.Dockerfile
-#         buildContext: .
-
-#     - script: docker image prune -f
-#       displayName: Remove dangling images
+    - script: docker image prune -f
+      displayName: Remove dangling images

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,7 @@ stages:
             buildContext: .
             arguments: '--build-arg AZ_KV_ENDPOINT=$(AZ_KV_ENDPOINT) --build-arg AZURE_CLIENT_ID=$(AZURE_CLIENT_ID) --build-arg AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) --build-arg AZURE_TENANT_ID=$(AZURE_TENANT_ID) --build-arg PROD_ID=$(PROD_ID) --build-arg ISVSVN=$(ISVSVN)'
         - script: |
+            cp .env.sample .env
             export SPID=$(SPID)
             export SUB_KEY=$(SUB_KEY)
             ./scripts/e2e-test.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build_and_Push_encrypted_sql_ops-pg_image
+  - job: Build_and_Push_encrypted_sql_ops_pg_image
     pool:
       name: 'AnonifyAgent'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ stages:
           condition: always()
           displayName: 'pgx docker-compose down'
 
-    - job: E2E CI
+    - job: E2E_CI
       pool:
         name: 'AnonifyAgent'
       steps:
@@ -94,7 +94,7 @@ stages:
 - stage: Build_and_Push_Base_Docker_Images
   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
-  - job: Build and Push rust-sgx-sdk-rootless image
+  - job: Build_and_Push_rust-sgx-sdk-rootless_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -119,7 +119,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build and Push anonify-dev image
+  - job: Build_and_Push_anonify-dev_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -144,7 +144,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build and Push anonify-dev-pgx image
+  - job: Build_and_Push_anonify-dev-pgx_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -172,7 +172,7 @@ stages:
 - stage: Build_and_Push_Example_Docker
   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   jobs:
-  - job: Build and Push erc20 image
+  - job: Build_and_Push_erc20_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -198,7 +198,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build and Push key-vault for erc20 image
+  - job: Build_and_Push_key-vault_for_erc20_image
     pool:
       name: 'AnonifyAgent'
     steps:
@@ -224,7 +224,7 @@ stages:
     - script: docker image prune -f
       displayName: Remove dangling images
 
-  - job: Build and Push encrypted-sql-ops-pg image
+  - job: Build_and_Push_encrypted-sql-ops-pg_image
     pool:
       name: 'AnonifyAgent'
     steps:

--- a/scripts/client.js
+++ b/scripts/client.js
@@ -98,7 +98,7 @@ const generate_balance_of_request = () => {
             .then((result) => {
                 const balance = JSON.parse(result).state;
                 if (balance !== 100) {
-                    console.log('go unexpected balance');
+                    console.log('got unexpected balance: ' + balance);
                     process.exit(1);
                 }
             })


### PR DESCRIPTION
## Issueへのリンク

* fix: #634 

## やったこと

* E2EをPRごとにテストする（通常CIと並行実行）
* mainマージ時のdocker buildの並列化（imageごとにbuild&push が 1 setでそれぞれのimageは並行で実行できる）
* jsのエラー文言がdebugしやすいよう追記

## やらないこと

* base-*をbuildする条件は別PR（レビューのわかりやすさ優先）
* E2Eのerc20とkvのimage並行化（pushしないので、同一agent内でbuildする必要があるため）
* mainマージ時の通常CI、e2e CI追加は別PR

## 動作検証

* CI

## 参考

* [scrapbox](https://scrapbox.io/layerx/azure_pipeline%E3%81%AE%E3%82%B9%E3%82%AD%E3%83%BC%E3%83%9E) にメモ残しました
* 並行と言っているが、Agentが動いているVMは1台なので実質並列（HT-enabled vCPU 2 coresなので）