### PR TITLE
features指定でMRENCLAVEの一致検証を行うように修正

### DIFF
--- a/config/Enclave.config.xml
+++ b/config/Enclave.config.xml
@@ -3,7 +3,7 @@
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
-  <HeapMaxSize>0x100000</HeapMaxSize>
+  <HeapMaxSize>0x8000000</HeapMaxSize>
   <TCSNum>2</TCSNum>
   <TCSPolicy>1</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/frame/mra-tls/Cargo.toml
+++ b/frame/mra-tls/Cargo.toml
@@ -30,3 +30,7 @@ test-utils = { path = "../../tests/utils", default-features = false, features = 
 pem = { version = "0.8.2", git = "https://github.com/mesalock-linux/pem-rs-sgx" }
 tracing = { version = "0.1", default-features = false }
 log = { git = "https://github.com/mesalock-linux/log-sgx" }
+
+[features]
+default = ["verify-mr-enclave-enable"]
+verify-mr-enclave-enable = []

--- a/frame/mra-tls/src/verifier.rs
+++ b/frame/mra-tls/src/verifier.rs
@@ -48,7 +48,11 @@ impl AttestedReportVerifier {
         quote.read_exact(&mut report_data)?;
 
         Self::verify_pubkey_eq(pubkey, report_data)?;
-        self.verify_measurement(mr_enclave, mr_signer)?;
+
+        #[cfg(feature = "verify-mr-enclave-enable")]
+        self.verify_mr_enclave(mr_enclave)?;
+
+        self.verify_mr_signer(mr_signer)?;
 
         Ok(())
     }
@@ -65,7 +69,8 @@ impl AttestedReportVerifier {
         Ok(())
     }
 
-    fn verify_measurement(&self, mr_enclave: [u8; 32], mr_signer: [u8; 32]) -> Result<()> {
+    #[cfg(feature = "verify-mr-enclave-enable")]
+    fn verify_mr_enclave(&self, mr_enclave: [u8; 32]) -> Result<()> {
         if self.measurement.mr_enclave() != mr_enclave {
             return Err(MraTLSError::Error(anyhow!(
                 "Invalid mr_enclave: local mr_enclave: {:?}, received mr_enclave: {:?}",
@@ -73,6 +78,11 @@ impl AttestedReportVerifier {
                 mr_enclave
             )));
         }
+
+        Ok(())
+    }
+
+    fn verify_mr_signer(&self, mr_signer: [u8; 32]) -> Result<()> {
         if self.measurement.mr_signer() != mr_signer {
             return Err(MraTLSError::Error(anyhow!(
                 "Invalid mr_signer: local mr_signer: {:?}, received mr_signer: {:?}",

--- a/frame/mra-tls/src/verifier.rs
+++ b/frame/mra-tls/src/verifier.rs
@@ -71,7 +71,6 @@ impl AttestedReportVerifier {
 
     #[cfg(feature = "verify-mr-enclave-enable")]
     fn verify_mr_enclave(&self, mr_enclave: [u8; 32]) -> Result<()> {
-        println!("##### verify_mr_enclave");
         if self.measurement.mr_enclave() != mr_enclave {
             return Err(MraTLSError::Error(anyhow!(
                 "Invalid mr_enclave: local mr_enclave: {:?}, received mr_enclave: {:?}",

--- a/frame/mra-tls/src/verifier.rs
+++ b/frame/mra-tls/src/verifier.rs
@@ -71,6 +71,7 @@ impl AttestedReportVerifier {
 
     #[cfg(feature = "verify-mr-enclave-enable")]
     fn verify_mr_enclave(&self, mr_enclave: [u8; 32]) -> Result<()> {
+        println!("##### verify_mr_enclave");
         if self.measurement.mr_enclave() != mr_enclave {
             return Err(MraTLSError::Error(anyhow!(
                 "Invalid mr_enclave: local mr_enclave: {:?}, received mr_enclave: {:?}",

--- a/frame/runtime/Cargo.toml
+++ b/frame/runtime/Cargo.toml
@@ -24,7 +24,7 @@ serde_bytes_std = { package = "serde_bytes", version = "0.11", optional = true }
 serde_bytes_sgx = { package = "serde_bytes", git = "https://github.com/mesalock-linux/serde-bytes-sgx", optional = true }
 
 [features]
-default = ["std", "backup-enable"]
+default = ["std", "backup-enable", "verify-mr-enclave-enable"]
 std = [
     "frame-common/std",
     "anyhow-std",
@@ -48,3 +48,4 @@ sgx = [
     "serde_bytes_sgx",
 ]
 backup-enable = []
+verify-mr-enclave-enable = []

--- a/frame/treekem/Cargo.toml
+++ b/frame/treekem/Cargo.toml
@@ -26,5 +26,6 @@ serde_bytes = { git = "https://github.com/mesalock-linux/serde-bytes-sgx" }
 base64 = { rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/rust-base64-sgx" }
 
 [features]
-default = ["backup-enable"]
+default = ["backup-enable", "verify-mr-enclave-enable"]
 backup-enable = []
+verify-mr-enclave-enable = []

--- a/modules/anonify-enclave/Cargo.toml
+++ b/modules/anonify-enclave/Cargo.toml
@@ -29,8 +29,9 @@ sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.g
 sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 [features]
-default = ["backup-enable"]
+default = ["backup-enable", "verify-mr-enclave-enable"]
 backup-enable = [
     "frame-runtime/backup-enable",
     "frame-treekem/backup-enable",
 ]
+verify-mr-enclave-enable = []

--- a/modules/anonify-enclave/Cargo.toml
+++ b/modules/anonify-enclave/Cargo.toml
@@ -12,7 +12,7 @@ frame-runtime = { path = "../../frame/runtime", default-features = false, featur
 frame-treekem = { path = "../../frame/treekem", default-features = false }
 frame-sodium = { path = "../../frame/sodium", default-features = false, features = ["sgx"] }
 frame-common = { path = "../../frame/common", default-features = false, features = ["sgx"] }
-frame-mra-tls = { path = "../../frame/mra-tls" }
+frame-mra-tls = { path = "../../frame/mra-tls", default-features = false }
 remote-attestation = { path = "../../frame/remote-attestation", default-features = false, features = ["sgx"]}
 anonify-ecall-types = { path = "../anonify-ecall-types", default-features = false, features = ["sgx"] }
 test-utils = { path = "../../tests/utils", default-features = false, features = ["sgx"] }
@@ -34,4 +34,6 @@ backup-enable = [
     "frame-runtime/backup-enable",
     "frame-treekem/backup-enable",
 ]
-verify-mr-enclave-enable = []
+verify-mr-enclave-enable = [
+    "frame-mra-tls/verify-mr-enclave-enable",
+]


### PR DESCRIPTION
## Issueへのリンク

* なし

## やったこと

* `verify-mr-enclave-enable`フィーチャーフラグを追加し、有効な場合のみMRENCLAVEの一致検証を行うように修正
* `verify_measurement`メソッドを`verify_mr_enclave`と`verify_mr_signer`に分割
* `verify-mr-enclave-enable`はデフォで有効になっている

## やらないこと

* 特になし

## 動作検証

* test.shで動作確認

## 参考

* 特になし