### PR TITLE
fix range for BlobClient's get method

### DIFF
--- a/frame/azure-client/src/blob.rs
+++ b/frame/azure-client/src/blob.rs
@@ -61,7 +61,7 @@ impl BlobClient {
 
         let response = blob_client
             .get()
-            .range(Range::new(0, 1024)) // TODO: Fix range nums
+            .range(Range::new(0, 2048)) // TODO: Fix range nums
             .execute()
             .await
             .map_err(|err| anyhow!(err))?;


### PR DESCRIPTION
## Issueへのリンク

* なし

## やったこと

* blobデータを取得する際、途中までしか取得できないため、取得処理のrangeを1024から2048に変更

## やらないこと

* なし

## 動作検証

* 別のリポジトリにて動作確認済

## 参考

* なし
